### PR TITLE
feat: scaffold-allow marker, hook-time linting, faster pattern scan

### DIFF
--- a/.github/workflows/lint.yml.template
+++ b/.github/workflows/lint.yml.template
@@ -45,9 +45,12 @@ jobs:
       - name: Run scaffold checks
         run: |
           chmod +x .githooks/lib/check-*
+          # core.quotepath=off so unicode filenames aren't C-quoted into
+          # bypass paths — see pre-commit.template for the same fix.
+          FILES=$(git -c core.quotepath=off ls-files)
           FAILED=0
-          git ls-files | .githooks/lib/check-size      --ci || FAILED=1
-          git ls-files | .githooks/lib/check-patterns  --ci || FAILED=1
-          git ls-files | .githooks/lib/check-filenames --ci || FAILED=1
-          git ls-files | .githooks/lib/check-secrets   --ci || FAILED=1
+          echo "$FILES" | .githooks/lib/check-size      --ci || FAILED=1
+          echo "$FILES" | .githooks/lib/check-patterns  --ci || FAILED=1
+          echo "$FILES" | .githooks/lib/check-filenames --ci || FAILED=1
+          echo "$FILES" | .githooks/lib/check-secrets   --ci || FAILED=1
           exit $FAILED

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,5 +21,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        with:
+          python-version: "3.12"
+      - run: pip install ruff
       - run: chmod +x tests/run.sh install.sh githooks/pre-commit.template
       - run: ./tests/run.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- **Per-line `scaffold-allow` marker.** Lines containing `scaffold-allow`
+  (case-insensitive) are exempt from `check-patterns` and `check-secrets`
+  — an inline `# noqa`-style escape valve for legitimate `print` calls,
+  docs examples showing key prefixes, and synthetic test fixtures. Audit
+  usage with `git grep -i scaffold-allow`. `check-filenames` and
+  `check-size` ignore the marker (they're file-level rules).
+- Pre-commit hook now runs `ruff` / `eslint` against staged files when
+  their configs are present and the tool is on PATH. Cuts the
+  edit→push→CI→fix loop; CI remains the authoritative backstop.
+  Silently skipped when a tool isn't installed so the hook doesn't break
+  on fresh checkouts.
+- `actions/setup-python` + `pip install ruff` step in `tests.yml` so the
+  new ruff-integration test case actually exercises lint at hook time.
+
+### Changed
+- `check-patterns` and `check-secrets` rewritten to combine all patterns
+  into one ERE per scan and run a single `grep` per file as a fast-path
+  filter. Per-pattern attribution only runs on files that already
+  matched something. Cuts grep invocations from O(P×F) to F + matching×P
+  — meaningful on the CI path where `git ls-files` feeds in thousands of
+  files.
+
+### Fixed
+- "Clean Python file" test fixture (`tests/run.sh` case 6) gained the
+  blank line between `import logging` and the rest, which ruff I001
+  requires now that the hook lints.
+
 ## [v0.3.2] — 2026-05-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,43 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Security / hardening (audit pass)
+- **Unicode filename bypass closed.** `git diff --cached --name-only`
+  honoured `core.quotepath=on` (the default), C-quoting non-ASCII names
+  like `"caf\303\251.py"`. The downstream `[ -f "$file" ]` check then
+  failed and the file was silently skipped — every scanner bypassed.
+  Hook + `lint.yml` now run with `-c core.quotepath=off`.
+- **Stash-failure no longer silently downgrades.** If
+  `git stash --keep-index` fails (submodule conflicts, lock contention),
+  the hook now aborts with a clear error rather than falling through to
+  scan the dirty working tree (which would re-open the bypass v0.3.0
+  closed).
+- **Invalid forbidden-pattern handling.** A malformed ERE in
+  `.forbidden-patterns/*.txt` previously poisoned the combined regex
+  and silently dropped every file in the scan. Patterns are now
+  validated up-front; invalid ones are warned about and dropped, valid
+  ones continue to scan.
+- **`MAX_LINES` env var validated.** Non-numeric values used to cause a
+  cryptic `[: integer expression expected` mid-scan; now exit 2 with a
+  clear message before any file is read.
+
+### Fixed
+- `uninstall.sh` uses `git rev-parse --git-dir` (matching `install.sh`)
+  so `core.hooksPath` is correctly unset in worktrees and submodules.
+- Pre-commit header comment described the pattern format as
+  `regex|description`; corrected to TAB-separated to match v0.3.0.
+- `check-secrets` skip list extended to cover `.exe`, `.dll`, `.so`,
+  `.dylib`, `.bin`, `.class`, `.pyc`, `.pyo`, `.o`, `.a`, `.parquet`,
+  plus `go.sum` and named lockfiles (`Cargo.lock`, `Gemfile.lock`,
+  `composer.lock`, `poetry.lock`, `yarn.lock`). Cuts false positives
+  and slow scans.
+- `[a-z]+://` URL-with-credentials pattern in `secrets.txt` widened to
+  `[a-zA-Z]+://` so the regex reads correctly without depending on
+  `grep -i`.
+- Stale `[[:<:]]print` example in `forbidden-patterns/README.md`
+  updated to the POSIX-portable `(^|[^A-Za-z_])print` form actually
+  used elsewhere in the doc.
+
 ### Added
 - **Per-line `scaffold-allow` marker.** Lines containing `scaffold-allow`
   (case-insensitive) are exempt from `check-patterns` and `check-secrets`

--- a/README.md
+++ b/README.md
@@ -156,7 +156,13 @@ For parallel agent sessions, use `git worktree add ../proj-feat-x -b feat-x` so 
 
 ## What the tooling enforces
 
-Build-breaking (`ruff` / `eslint`, on every lint + in CI):
+The pre-commit hook now invokes `ruff` / `eslint` against staged files
+when their configs are present and the tool is on PATH — so most of the
+build-breaking rules below also fire at commit time, not only in CI.
+Linters are silently skipped if not installed; CI is the authoritative
+backstop.
+
+Build-breaking (`ruff` / `eslint`, on every lint + commit + in CI):
 
 | Concern | Rule |
 |---|---|
@@ -181,6 +187,16 @@ Commit + CI-breaking (pre-commit hook + `lint.yml`):
 | TODO/FIXME without ticket ref | regex (opt-in; commented in template) |
 | Secret / credential leaks (AWS keys, GitHub tokens, private keys, URLs with embedded credentials, hardcoded password=/token= assignments) | regex (case-insensitive, all files) |
 | Committed `.env` / `*.pem` / SSH private keys (`id_rsa`, `id_ed25519`, `id_ecdsa`, `id_dsa`) | filename check (`.env.example` / `.env.sample` / `.env.template` allowed) |
+
+### Per-line escape valve
+
+When a regex match is intentional — a CLI entry point that needs `print`,
+a docs example showing an AWS key prefix, a fixture with a synthetic
+credential — append `scaffold-allow` (any case, in a comment) on the
+matched line. `check-patterns` and `check-secrets` skip lines containing
+the marker; `check-filenames` and `check-size` are file-level and
+unaffected. Audit usage with `git grep -i scaffold-allow`. See
+`forbidden-patterns/README.md` for examples.
 
 ## Verify it works
 

--- a/README.md
+++ b/README.md
@@ -195,8 +195,12 @@ a docs example showing an AWS key prefix, a fixture with a synthetic
 credential — append `scaffold-allow` (any case, in a comment) on the
 matched line. `check-patterns` and `check-secrets` skip lines containing
 the marker; `check-filenames` and `check-size` are file-level and
-unaffected. Audit usage with `git grep -i scaffold-allow`. See
-`forbidden-patterns/README.md` for examples.
+unaffected. See `forbidden-patterns/README.md` for examples.
+
+**Reviewers: every PR that adds or moves a `scaffold-allow` marker is
+suppressing a guardrail.** Treat new markers like new `# noqa`s — confirm
+the suppression is justified before approving. Audit the full set with
+`git grep -i scaffold-allow`.
 
 ## Verify it works
 

--- a/forbidden-patterns/README.md
+++ b/forbidden-patterns/README.md
@@ -48,6 +48,31 @@ The text after the TAB, printed when the pattern matches alongside the
 file:line that triggered it. Keep it actionable — every consumer project
 sees this on every blocked commit.
 
+## Per-line opt-out: `scaffold-allow`
+
+A line containing the substring `scaffold-allow` (case-insensitive) is
+exempt from `check-patterns` and `check-secrets`. Use it as an inline
+escape valve when a match is intentional — a CLI entry point that needs
+`print`, a docs example showing an AWS key prefix, a test fixture with a
+synthetic credential. Mirrors the role `# noqa` plays for ruff.
+
+```python
+print("entering CLI")  # scaffold-allow — no logger configured yet
+```
+
+```ts
+console.log(banner);  // scaffold-allow — pre-init log, before logger ready
+```
+
+```md
+Example AWS key: AKIAIOSFODNN7EXAMPLE  <!-- scaffold-allow docs example -->
+```
+
+The marker only suppresses **its own line**. Other matches in the same
+file still fail the check. `check-filenames` and `check-size` ignore the
+marker — those rules are file-level, not line-level. Audit usage with
+`git grep -i scaffold-allow`.
+
 ## Adding a pattern
 
 1. Pick the right file (backend / frontend / secrets).

--- a/forbidden-patterns/README.md
+++ b/forbidden-patterns/README.md
@@ -85,7 +85,7 @@ marker — those rules are file-level, not line-level. Audit usage with
 ## Why three files
 
 Splitting by language keeps regexes precise: a pattern targeting Python
-function calls (`[[:<:]]print[[:space:]]*\(`) shouldn't run against a TS
-file containing the string `print` in a comment. The secrets file is
-language-agnostic and case-insensitive because credentials leak from
+function calls (`(^|[^A-Za-z_])print[[:space:]]*\(`) shouldn't run against
+a TS file containing the string `print` in a comment. The secrets file
+is language-agnostic and case-insensitive because credentials leak from
 config, docs, scripts, and code alike.

--- a/forbidden-patterns/secrets.txt.template
+++ b/forbidden-patterns/secrets.txt.template
@@ -19,8 +19,10 @@ sk-[A-Za-z0-9]{48,}	OpenAI / Anthropic-style API key — rotate immediately
 # Private keys of any flavor (RSA / EC / DSA / OPENSSH / bare)
 -----BEGIN [A-Z ]*PRIVATE KEY-----	Private key in source — rotate and move to a secret manager
 
-# URL with embedded credentials — e.g. protocol scheme + userinfo + host
-[a-z]+://[^[:space:]:/@]+:[^[:space:]/@]+@[^[:space:]/]+	URL with embedded credentials — use env vars
+# URL with embedded credentials — e.g. protocol scheme + userinfo + host.
+# `[a-zA-Z]+` rather than `[a-z]+` so the pattern reads correctly when copied
+# into other tooling that doesn't run grep with -i.
+[a-zA-Z]+://[^[:space:]:/@]+:[^[:space:]/@]+@[^[:space:]/]+	URL with embedded credentials — use env vars
 
 # Hardcoded credentials in assignments. Value must be 16+ chars of token-like
 # content to dodge test fixtures / short placeholders. Six per-keyword lines

--- a/githooks/lib/check-patterns.template
+++ b/githooks/lib/check-patterns.template
@@ -4,6 +4,9 @@
 # against frontend.txt. Pattern format: <regex><TAB><description>
 # (TAB is the field separator so regex can use literal `|` alternation).
 #
+# Lines containing `scaffold-allow` (case-insensitive) are exempt — an
+# explicit per-line opt-out, like `# noqa`. Use sparingly.
+#
 # Output: human-readable on tty; ::error file=...:: when --ci is passed.
 # Exit:   0 if all OK, 1 if any violation.
 
@@ -20,31 +23,58 @@ done
 scan() {
   local config=$1
   shift
+  local exts=("$@")
   [ -f "$config" ] || return 0
   [ ${#FILES[@]} -eq 0 ] && return 0
 
+  local patterns=() descriptions=()
+  local pattern description
   while IFS=$'\t' read -r pattern description; do
     [ -z "$pattern" ] && continue
     case "$pattern" in \#*) continue ;; esac
-
-    for file in "${FILES[@]}"; do
-      local matched=0
-      for ext in "$@"; do
-        case "$file" in *."$ext") matched=1; break ;; esac
-      done
-      [ "$matched" -eq 1 ] || continue
-
-      if grep -nE -- "$pattern" "$file" >/dev/null 2>&1; then
-        if [ "$CI_MODE" -eq 1 ]; then
-          echo "::error file=$file::$description"
-        else
-          echo "✗ $file: $description"
-          grep -nE -- "$pattern" "$file" | head -3 | sed 's/^/    /'
-        fi
-        FAILED=1
-      fi
-    done
+    patterns+=("$pattern")
+    descriptions+=("$description")
   done <"$config"
+
+  [ ${#patterns[@]} -eq 0 ] && return 0
+
+  # Combine all patterns into one ERE so a single grep call per file decides
+  # whether to drop into the per-pattern attribution loop. Cuts grep calls
+  # from O(P*F) to F + matching_files*P — large repos see a big speedup.
+  local combined=""
+  local p
+  for p in "${patterns[@]}"; do
+    if [ -z "$combined" ]; then
+      combined="(${p})"
+    else
+      combined="${combined}|(${p})"
+    fi
+  done
+
+  local file ext keep i pat desc m
+  for file in "${FILES[@]}"; do
+    keep=0
+    for ext in "${exts[@]}"; do
+      case "$file" in *."$ext") keep=1; break ;; esac
+    done
+    [ "$keep" -eq 1 ] || continue
+
+    grep -nE -- "$combined" "$file" >/dev/null 2>&1 || continue
+
+    for i in "${!patterns[@]}"; do
+      pat="${patterns[$i]}"
+      desc="${descriptions[$i]}"
+      m=$(grep -nE -- "$pat" "$file" 2>/dev/null | grep -iv 'scaffold-allow' || true)
+      [ -n "$m" ] || continue
+      if [ "$CI_MODE" -eq 1 ]; then
+        echo "::error file=$file::$desc"
+      else
+        echo "✗ $file: $desc"
+        printf '%s\n' "$m" | head -3 | sed 's/^/    /'
+      fi
+      FAILED=1
+    done
+  done
 }
 
 FAILED=0

--- a/githooks/lib/check-patterns.template
+++ b/githooks/lib/check-patterns.template
@@ -27,14 +27,33 @@ scan() {
   [ -f "$config" ] || return 0
   [ ${#FILES[@]} -eq 0 ] && return 0
 
-  local patterns=() descriptions=()
+  local raw_patterns=() raw_descs=()
   local pattern description
   while IFS=$'\t' read -r pattern description; do
     [ -z "$pattern" ] && continue
     case "$pattern" in \#*) continue ;; esac
-    patterns+=("$pattern")
-    descriptions+=("$description")
+    raw_patterns+=("$pattern")
+    raw_descs+=("$description")
   done <"$config"
+
+  [ ${#raw_patterns[@]} -eq 0 ] && return 0
+
+  # Validate each pattern up-front. An invalid ERE here would otherwise
+  # poison the combined regex (silently dropping every file) and produce
+  # cryptic per-file grep errors. `printf '' | grep -E p` returns 1
+  # (no match) for valid patterns and writes to stderr for invalid ones —
+  # so empty stderr means valid.
+  local patterns=() descriptions=()
+  local i p_err
+  for i in "${!raw_patterns[@]}"; do
+    p_err=$(printf '' | grep -E -- "${raw_patterns[$i]}" 2>&1 1>/dev/null || true)
+    if [ -n "$p_err" ]; then
+      echo "warning: $config: invalid pattern dropped: ${raw_patterns[$i]} — $p_err" >&2
+      continue
+    fi
+    patterns+=("${raw_patterns[$i]}")
+    descriptions+=("${raw_descs[$i]}")
+  done
 
   [ ${#patterns[@]} -eq 0 ] && return 0
 

--- a/githooks/lib/check-secrets.template
+++ b/githooks/lib/check-secrets.template
@@ -5,6 +5,9 @@
 # directory itself. Pattern format: <regex><TAB><description>
 # (TAB is the field separator so regex can use literal `|` alternation).
 #
+# Lines containing `scaffold-allow` (case-insensitive) are exempt — an
+# explicit per-line opt-out for documented test fixtures or example keys.
+#
 # Output: human-readable on tty; ::error file=...:: when --ci is passed.
 # Exit:   0 if all OK, 1 if any violation.
 
@@ -30,22 +33,42 @@ done
 
 [ ${#FILES[@]} -eq 0 ] && exit 0
 
-FAILED=0
+PATTERNS=()
+DESCRIPTIONS=()
 while IFS=$'\t' read -r pattern description; do
   [ -z "$pattern" ] && continue
   case "$pattern" in \#*) continue ;; esac
-
-  for file in "${FILES[@]}"; do
-    if grep -niE -- "$pattern" "$file" >/dev/null 2>&1; then
-      if [ "$CI_MODE" -eq 1 ]; then
-        echo "::error file=$file::$description"
-      else
-        echo "✗ $file: $description"
-        grep -niE -- "$pattern" "$file" | head -3 | sed 's/^/    /'
-      fi
-      FAILED=1
-    fi
-  done
+  PATTERNS+=("$pattern")
+  DESCRIPTIONS+=("$description")
 done <"$CONFIG"
+
+[ ${#PATTERNS[@]} -eq 0 ] && exit 0
+
+COMBINED=""
+for p in "${PATTERNS[@]}"; do
+  if [ -z "$COMBINED" ]; then
+    COMBINED="(${p})"
+  else
+    COMBINED="${COMBINED}|(${p})"
+  fi
+done
+
+FAILED=0
+for file in "${FILES[@]}"; do
+  grep -niE -- "$COMBINED" "$file" >/dev/null 2>&1 || continue
+  for i in "${!PATTERNS[@]}"; do
+    pat="${PATTERNS[$i]}"
+    desc="${DESCRIPTIONS[$i]}"
+    m=$(grep -niE -- "$pat" "$file" 2>/dev/null | grep -iv 'scaffold-allow' || true)
+    [ -n "$m" ] || continue
+    if [ "$CI_MODE" -eq 1 ]; then
+      echo "::error file=$file::$desc"
+    else
+      echo "✗ $file: $desc"
+      printf '%s\n' "$m" | head -3 | sed 's/^/    /'
+    fi
+    FAILED=1
+  done
+done
 
 exit $FAILED

--- a/githooks/lib/check-secrets.template
+++ b/githooks/lib/check-secrets.template
@@ -23,9 +23,14 @@ FILES=()
 while IFS= read -r f; do
   [ -z "$f" ] && continue
   case "$f" in
+    # Images / docs
     *.svg|*.png|*.jpg|*.jpeg|*.gif|*.ico|*.pdf) continue ;;
-    *.lock|*.zip|*.tar|*.gz|*.woff|*.woff2|*.ttf|*.mp4|*.mov) continue ;;
-    package-lock.json|pnpm-lock.yaml) continue ;;
+    # Archives / fonts / media
+    *.lock|*.zip|*.tar|*.gz|*.bz2|*.xz|*.7z|*.woff|*.woff2|*.ttf|*.otf|*.eot|*.mp4|*.mov|*.mp3|*.wav) continue ;;
+    # Compiled / binary
+    *.exe|*.dll|*.so|*.dylib|*.bin|*.class|*.pyc|*.pyo|*.o|*.a|*.parquet) continue ;;
+    # Lockfiles by name (extension catches *.lock generically)
+    package-lock.json|pnpm-lock.yaml|yarn.lock|composer.lock|Gemfile.lock|poetry.lock|go.sum|Cargo.lock) continue ;;
     .forbidden-patterns/*) continue ;;
   esac
   [ -f "$f" ] && FILES+=("$f")
@@ -33,14 +38,30 @@ done
 
 [ ${#FILES[@]} -eq 0 ] && exit 0
 
-PATTERNS=()
-DESCRIPTIONS=()
+RAW_PATTERNS=()
+RAW_DESCS=()
 while IFS=$'\t' read -r pattern description; do
   [ -z "$pattern" ] && continue
   case "$pattern" in \#*) continue ;; esac
-  PATTERNS+=("$pattern")
-  DESCRIPTIONS+=("$description")
+  RAW_PATTERNS+=("$pattern")
+  RAW_DESCS+=("$description")
 done <"$CONFIG"
+
+[ ${#RAW_PATTERNS[@]} -eq 0 ] && exit 0
+
+# Validate patterns up-front so an invalid ERE doesn't poison the combined
+# regex or produce cryptic per-file errors. See check-patterns for context.
+PATTERNS=()
+DESCRIPTIONS=()
+for i in "${!RAW_PATTERNS[@]}"; do
+  p_err=$(printf '' | grep -E -- "${RAW_PATTERNS[$i]}" 2>&1 1>/dev/null || true)
+  if [ -n "$p_err" ]; then
+    echo "warning: $CONFIG: invalid pattern dropped: ${RAW_PATTERNS[$i]} — $p_err" >&2
+    continue
+  fi
+  PATTERNS+=("${RAW_PATTERNS[$i]}")
+  DESCRIPTIONS+=("${RAW_DESCS[$i]}")
+done
 
 [ ${#PATTERNS[@]} -eq 0 ] && exit 0
 

--- a/githooks/lib/check-secrets.template
+++ b/githooks/lib/check-secrets.template
@@ -29,8 +29,8 @@ while IFS= read -r f; do
     *.lock|*.zip|*.tar|*.gz|*.bz2|*.xz|*.7z|*.woff|*.woff2|*.ttf|*.otf|*.eot|*.mp4|*.mov|*.mp3|*.wav) continue ;;
     # Compiled / binary
     *.exe|*.dll|*.so|*.dylib|*.bin|*.class|*.pyc|*.pyo|*.o|*.a|*.parquet) continue ;;
-    # Lockfiles by name (extension catches *.lock generically)
-    package-lock.json|pnpm-lock.yaml|yarn.lock|composer.lock|Gemfile.lock|poetry.lock|go.sum|Cargo.lock) continue ;;
+    # Lockfiles whose extension isn't `.lock` (those are caught above)
+    package-lock.json|pnpm-lock.yaml|go.sum) continue ;;
     .forbidden-patterns/*) continue ;;
   esac
   [ -f "$f" ] && FILES+=("$f")

--- a/githooks/lib/check-size.template
+++ b/githooks/lib/check-size.template
@@ -9,6 +9,14 @@
 set -euo pipefail
 
 MAX_LINES=${MAX_LINES:-500}
+case "$MAX_LINES" in
+  ''|*[!0-9]*)
+    echo "error: MAX_LINES must be a positive integer, got: $MAX_LINES" >&2
+    exit 2
+    ;;
+esac
+[ "$MAX_LINES" -gt 0 ] || { echo "error: MAX_LINES must be > 0" >&2; exit 2; }
+
 CI_MODE=0
 [ "${1:-}" = "--ci" ] && CI_MODE=1
 

--- a/githooks/pre-commit.template
+++ b/githooks/pre-commit.template
@@ -9,9 +9,10 @@
 #   git config core.hooksPath .githooks
 #
 # Patterns are read from:
-#   .forbidden-patterns/backend.txt   (regex|description; applied to *.py)
-#   .forbidden-patterns/frontend.txt  (regex|description; applied to *.ts,*.tsx,*.js,*.jsx)
-#   .forbidden-patterns/secrets.txt   (regex|description; applied to all text files)
+#   .forbidden-patterns/backend.txt   (regex<TAB>description; *.py)
+#   .forbidden-patterns/frontend.txt  (regex<TAB>description; *.ts,*.tsx,*.js,*.jsx)
+#   .forbidden-patterns/shell.txt     (regex<TAB>description; *.sh,*.bash)
+#   .forbidden-patterns/secrets.txt   (regex<TAB>description; all text files)
 #
 # Lines starting with # in those files are comments.
 
@@ -20,7 +21,11 @@ set -euo pipefail
 HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
 LIB="$HOOK_DIR/lib"
 
-STAGED=$(git diff --cached --name-only --diff-filter=ACMR)
+# core.quotepath=off so non-ASCII filenames are emitted verbatim, not as
+# `"caf\303\251.py"`. The C-quoted form would fail downstream `[ -f ... ]`
+# checks and silently skip the scan — a real bypass on repos with unicode
+# filenames.
+STAGED=$(git -c core.quotepath=off diff --cached --name-only --diff-filter=ACMR)
 [ -z "$STAGED" ] && exit 0
 
 # Make the working tree match the staged content for the duration of the
@@ -33,8 +38,16 @@ NEED_RESTORE=0
 GIT_DIR=$(git rev-parse --git-dir 2>/dev/null || echo .git)
 if [ ! -e "$GIT_DIR/MERGE_HEAD" ] && [ ! -e "$GIT_DIR/REBASE_HEAD" ]; then
   if ! git diff --quiet 2>/dev/null; then
+    # Fail loudly if we can't isolate staged content. The previous
+    # behaviour fell back to scanning the dirty working tree, which
+    # silently re-opens the bypass v0.3.0 closed.
     if git stash push --keep-index --quiet --message "pre-commit-hook" 2>/dev/null; then
       NEED_RESTORE=1
+    else
+      echo "error: pre-commit hook could not stash unstaged changes." >&2
+      echo "       Refusing to proceed — the scan would see the working tree," >&2
+      echo "       not the staged content. Commit or stash manually first." >&2
+      exit 1
     fi
   fi
 fi

--- a/githooks/pre-commit.template
+++ b/githooks/pre-commit.template
@@ -53,6 +53,35 @@ echo "$STAGED" | "$LIB/check-patterns"  || FAILED=1
 echo "$STAGED" | "$LIB/check-filenames" || FAILED=1
 echo "$STAGED" | "$LIB/check-secrets"   || FAILED=1
 
+# Lint staged files with ruff / eslint when configs exist and the tool is
+# installed. CI is the source of truth — running here just shortens the
+# feedback loop. Silently skipped if a tool isn't on PATH so the hook
+# stays usable on machines that haven't run `pip install ruff` yet.
+STAGED_PY=()
+STAGED_JS=()
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  case "$f" in
+    *.py)                  STAGED_PY+=("$f") ;;
+    *.ts|*.tsx|*.js|*.jsx) STAGED_JS+=("$f") ;;
+  esac
+done <<<"$STAGED"
+
+# Config detection mirrors `lint.yml`'s `hashFiles(...)` predicate so the
+# hook fires in the same projects where CI does.
+if [ ${#STAGED_PY[@]} -gt 0 ] \
+   && { [ -f ruff.toml ] || [ -f pyproject.toml ]; } \
+   && command -v ruff >/dev/null 2>&1; then
+  ruff check "${STAGED_PY[@]}" || FAILED=1
+fi
+
+if [ ${#STAGED_JS[@]} -gt 0 ] \
+   && { [ -f eslint.config.js ] || [ -f package.json ]; } \
+   && command -v npx >/dev/null 2>&1 \
+   && npx --no-install eslint --version >/dev/null 2>&1; then
+  npx --no-install eslint "${STAGED_JS[@]}" || FAILED=1
+fi
+
 if [ "$FAILED" -ne 0 ]; then
   echo ""
   echo "Pre-commit failed. Fix the issues above or use 'git commit --no-verify' to skip (don't)."

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -99,9 +99,10 @@ echo "FOO=bar" >.env
 git add -f .env
 assert_rejects ".env file blocked"
 
-# 6. clean code passes
+# 6. clean code passes — ruff-clean too (blank line after imports for I001).
 cat >app.py <<'EOF'
 import logging
+
 log = logging.getLogger(__name__)
 log.info("ok")
 EOF
@@ -127,6 +128,39 @@ echo 'pri''nt("debug")' >sneaky.py
 git add sneaky.py
 echo '# clean now' >sneaky.py
 assert_rejects "scans staged content (not working tree)"
+
+# 10. scaffold-allow marker exempts the matched line.
+echo 'pri''nt("entry")  # scaffold-allow CLI entry point' >cli.py
+git add cli.py
+assert_passes "scaffold-allow exempts marked line"
+
+# 11. scaffold-allow only exempts its own line — an unmarked offending line
+#     in the same file must still reject.
+{
+  echo 'pri''nt("ok")  # scaffold-allow'
+  echo 'pri''nt("real leak")'
+} >mixed.py
+git add mixed.py
+assert_rejects "scaffold-allow does not whitelist whole file"
+
+# 12. scaffold-allow works for the secrets check too. AKIA literal split
+#     so this test file itself doesn't trip the scan.
+echo "AKIA""IOSFODNN7EXAMPLE  # scaffold-allow docs example" >example.md
+git add example.md
+assert_passes "scaffold-allow exempts secret on docs line"
+
+# 13. ruff lint integration — the hook should run ruff on staged .py when
+#     ruff.toml is present and ruff is on PATH. Skipped otherwise.
+if command -v ruff >/dev/null 2>&1; then
+  cat >badimports.py <<'EOF'
+import sys
+import os
+EOF
+  git add badimports.py
+  assert_rejects "ruff catches unsorted imports"
+else
+  echo "  - skipped ruff test (ruff not installed)"
+fi
 
 echo ""
 echo "Result: $PASS passed, $FAIL failed"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -162,6 +162,65 @@ else
   echo "  - skipped ruff test (ruff not installed)"
 fi
 
+# 14. unicode filename — `core.quotepath=on` (git default) would emit the
+#     name as a C-quoted string, the downstream `[ -f "$file" ]` check
+#     would fail, and the file would slip past every scanner. The hook
+#     now uses `-c core.quotepath=off` so this case rejects.
+echo 'pri''nt("debug")' >café.py
+git add café.py
+assert_rejects "unicode filename does not bypass scan"
+
+# 15. MAX_LINES env override — passing 100 should cause a 200-line file
+#     to reject (default 500 would let it through).
+seq 1 200 >medium.py
+git add medium.py
+if MAX_LINES=100 .githooks/pre-commit >"$HOOK_OUT" 2>&1; then
+  echo "  ✗ MAX_LINES=100 — hook accepted, expected reject"
+  sed 's/^/      /' "$HOOK_OUT"
+  FAIL=$((FAIL + 1))
+else
+  echo "  ✓ MAX_LINES env var override"
+  PASS=$((PASS + 1))
+fi
+reset_repo
+
+# 16. MAX_LINES non-numeric — the size check should fail loudly with
+#     exit 2, not silently misbehave.
+echo 'ok = True' >tiny.py
+git add tiny.py
+if MAX_LINES=abc .githooks/pre-commit >"$HOOK_OUT" 2>&1; then
+  echo "  ✗ MAX_LINES=abc — hook accepted, expected reject"
+  FAIL=$((FAIL + 1))
+elif grep -q "MAX_LINES must be a positive integer" "$HOOK_OUT"; then
+  echo "  ✓ MAX_LINES validation rejects non-numeric"
+  PASS=$((PASS + 1))
+else
+  echo "  ✗ MAX_LINES=abc — rejected but without expected error message"
+  sed 's/^/      /' "$HOOK_OUT"
+  FAIL=$((FAIL + 1))
+fi
+reset_repo
+
+# 17. invalid pattern in backend.txt — the scan should warn and drop the
+#     bad pattern, then continue with the rest. A valid `print` pattern
+#     match must still reject.
+printf '[unclosed\tbroken regex\n' >>.forbidden-patterns/backend.txt
+echo 'pri''nt("debug")' >app.py
+git add .forbidden-patterns/backend.txt app.py
+if .githooks/pre-commit >"$HOOK_OUT" 2>&1; then
+  echo "  ✗ invalid-pattern test — hook accepted, expected reject (on print)"
+  sed 's/^/      /' "$HOOK_OUT"
+  FAIL=$((FAIL + 1))
+elif grep -q "invalid pattern dropped" "$HOOK_OUT"; then
+  echo "  ✓ invalid pattern dropped with warning, valid patterns still scan"
+  PASS=$((PASS + 1))
+else
+  echo "  ✗ invalid-pattern test — rejected but no warning emitted"
+  sed 's/^/      /' "$HOOK_OUT"
+  FAIL=$((FAIL + 1))
+fi
+reset_repo
+
 echo ""
 echo "Result: $PASS passed, $FAIL failed"
 exit $FAIL

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -89,15 +89,15 @@ for dir in .githooks/lib .githooks .github/workflows .github; do
   fi
 done
 
-# Unwire the hook
-if [ -d .git ] && git config --get core.hooksPath >/dev/null 2>&1; then
-  if [ "$(git config --get core.hooksPath)" = ".githooks" ]; then
-    if [ "$DRY_RUN" -eq 1 ]; then
-      echo "would unset:  core.hooksPath"
-    else
-      git config --unset core.hooksPath
-      echo "unset:        core.hooksPath"
-    fi
+# Unwire the hook. Use `git rev-parse --git-dir` instead of `[ -d .git ]`
+# so the unwire works in worktrees and submodules, where `.git` is a file.
+if git rev-parse --git-dir >/dev/null 2>&1 \
+   && [ "$(git config --get core.hooksPath || true)" = ".githooks" ]; then
+  if [ "$DRY_RUN" -eq 1 ]; then
+    echo "would unset:  core.hooksPath"
+  else
+    git config --unset core.hooksPath
+    echo "unset:        core.hooksPath"
   fi
 fi
 


### PR DESCRIPTION
## Summary

Three independent improvements bundled because they touch overlapping files (`check-patterns`, `check-secrets`, `pre-commit`, `tests/run.sh`):

- **Per-line `scaffold-allow` opt-out.** Lines containing `scaffold-allow` (case-insensitive) are exempt from `check-patterns` and `check-secrets` — an inline `# noqa`-style escape valve for legitimate `print()` calls, docs examples showing key prefixes, and synthetic test fixtures. File-level checks (`check-filenames`, `check-size`) are unaffected. Audit usage with `git grep -i scaffold-allow`.
- **Pre-commit hook runs `ruff` / `eslint`** against staged files when configs are present and the tool is on `PATH`. Cuts the edit→push→CI→fix loop. Silently skipped when a tool isn't installed; CI remains the authoritative backstop. Config detection mirrors `lint.yml`'s `hashFiles` predicate (`ruff.toml` OR `pyproject.toml`; `eslint.config.js` OR `package.json`) so hook and CI fire in the same projects.
- **`check-patterns` / `check-secrets` perf rewrite.** Combine all patterns into one ERE per scan and run a single `grep` per file as a fast-path filter; per-pattern attribution only runs on files that already matched. Drops grep invocations from `O(P×F)` to `F + matched×P` — meaningful on the CI path where `git ls-files` feeds in thousands of files.

## Test plan

- [x] `tests/run.sh` — 14 cases, all passing locally (was 10). Four new fixtures cover the marker (exempt-line, not-whole-file, secrets variant) and ruff lint integration.
- [x] `test.yml` now installs `ruff` so the lint case actually runs in CI on `ubuntu-latest` + `macos-latest`.
- [x] "Clean Python file" fixture gained a blank line after `import logging` to satisfy `ruff I001`, which the hook now triggers.
- [ ] Verify CI green on this PR (lint / tests matrix / shellcheck).
- [ ] Spot-check `git grep -i scaffold-allow` behaviour in a downstream project after install.

https://claude.ai/code/session_017N8zHif6ePbthnJRbY6BBg

---
_Generated by [Claude Code](https://claude.ai/code/session_017N8zHif6ePbthnJRbY6BBg)_