### PR TITLE
fix(ci): lint.yml.template invalid for every consumer (job-level hashFiles) + actionlint guard

### DIFF
--- a/.github/workflows/lint.yml.template
+++ b/.github/workflows/lint.yml.template
@@ -15,26 +15,47 @@ permissions:
 
 jobs:
   python:
-    if: hashFiles('ruff.toml', 'pyproject.toml') != ''
+    # Detection runs as a step (after checkout), NOT a job-level `if:`.
+    # `hashFiles()` is only valid once a runner is assigned and the repo is
+    # checked out — using it in a job-level `if:` makes GitHub reject the
+    # WHOLE workflow as invalid, silently disabling every job including
+    # guardrails. The job always starts; its tool steps no-op when the
+    # configs are absent (frontend-only repos see a green, empty python job).
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+      - id: detect
+        run: |
+          if [ -f ruff.toml ] || [ -f pyproject.toml ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          fi
+      - if: steps.detect.outputs.present == 'true'
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: "3.12"
-      - run: pip install ruff
-      - run: ruff check .
+      - if: steps.detect.outputs.present == 'true'
+        run: pip install ruff
+      - if: steps.detect.outputs.present == 'true'
+        run: ruff check .
 
   frontend:
-    if: hashFiles('eslint.config.js', 'package.json') != ''
+    # Same pattern as `python` — detect in a step, not a job-level `if:`.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
+      - id: detect
+        run: |
+          if [ -f eslint.config.js ] || [ -f package.json ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          fi
+      - if: steps.detect.outputs.present == 'true'
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: "20"
-      - run: npm ci || npm install
-      - run: npx eslint .
+      - if: steps.detect.outputs.present == 'true'
+        run: npm ci || npm install
+      - if: steps.detect.outputs.present == 'true'
+        run: npx eslint .
 
   guardrails:
     # File size, forbidden patterns, blocked filenames, secret scan —

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,5 +25,14 @@ jobs:
         with:
           python-version: "3.12"
       - run: pip install ruff
+      - name: Install actionlint
+        # Validates the rendered lint.yml is a parseable GitHub Actions
+        # workflow — guards against the job-level `if: hashFiles(...)` class
+        # of error that silently disables every job. Version + download
+        # script both pinned for reproducibility.
+        run: |
+          mkdir -p "$RUNNER_TEMP/bin"
+          bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/v1.7.12/scripts/download-actionlint.bash) 1.7.12 "$RUNNER_TEMP/bin"
+          echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
       - run: chmod +x tests/run.sh install.sh githooks/pre-commit.template
       - run: ./tests/run.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+## [v0.5.1] — 2026-05-25
+
 ### Fixed
 - **`lint.yml.template`: workflow was invalid for every consumer.** The
   `python` and `frontend` jobs gated execution with a **job-level**
@@ -25,6 +27,9 @@ versioning follows [SemVer](https://semver.org/).
   `actionlint` (pinned 1.7.12), so a job-level `hashFiles()` — or any
   context-availability error — can never silently disable CI for consumers
   again. `actionlint` is skipped locally when absent; CI always runs it.
+
+### Changed
+- `README.md` install pin bumped to `v0.5.1`.
 
 ## [v0.5.0] — 2026-05-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- **`lint.yml.template`: workflow was invalid for every consumer.** The
+  `python` and `frontend` jobs gated execution with a **job-level**
+  `if: hashFiles(...)`. `hashFiles()` is only available once a runner is
+  assigned and the repo is checked out, so GitHub rejected the *entire*
+  workflow file as invalid — meaning **no job ran at all**, including
+  `guardrails` (the server-side mirror of the pre-commit hook). Every push
+  reported a startup failure with no jobs and no annotations. File
+  detection now runs in a post-checkout `detect` step; the tool steps are
+  gated on `steps.detect.outputs.present`, preserving the
+  skip-when-absent behavior. A frontend-only repo now shows a green, empty
+  `python` job instead of a hard workflow error.
+
+### Added
+- **`tests/run.sh` + `test.yml`: workflow-validity regression guard.** The
+  harness now renders `lint.yml` via `install.sh` and validates it with
+  `actionlint` (pinned 1.7.12), so a job-level `hashFiles()` — or any
+  context-availability error — can never silently disable CI for consumers
+  again. `actionlint` is skipped locally when absent; CI always runs it.
+
 ## [v0.5.0] — 2026-05-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Clone the scaffold somewhere stable:
 
 ```sh
 # Recommended: pin to a tagged release for reproducibility
-git clone --branch v0.5.0 https://github.com/Sting25/ai-coding-rules-scaffold ~/src/ai-coding-rules-scaffold
+git clone --branch v0.5.1 https://github.com/Sting25/ai-coding-rules-scaffold ~/src/ai-coding-rules-scaffold
 # Or track main if you want the latest changes
 git clone https://github.com/Sting25/ai-coding-rules-scaffold ~/src/ai-coding-rules-scaffold
 ```

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -221,6 +221,27 @@ else
 fi
 reset_repo
 
+# 18. workflow validity — the rendered .github/workflows/lint.yml must be a
+#     VALID GitHub Actions workflow. A job-level `if: hashFiles(...)` (or any
+#     context-availability error) makes GitHub reject the whole file, silently
+#     disabling every job — the failure mode that shipped a no-op lint workflow
+#     to consumers for weeks. actionlint catches this class. shellcheck/pyflakes
+#     integration is disabled: this guard is about Actions semantics, not shell
+#     or Python style (those have their own checks). Skipped if actionlint is
+#     absent locally; CI installs it so the guard always runs there.
+if command -v actionlint >/dev/null 2>&1; then
+  if actionlint -shellcheck= -pyflakes= .github/workflows/lint.yml >"$HOOK_OUT" 2>&1; then
+    echo "  ✓ rendered lint.yml is a valid GitHub Actions workflow"
+    PASS=$((PASS + 1))
+  else
+    echo "  ✗ rendered lint.yml failed actionlint validation"
+    sed 's/^/      /' "$HOOK_OUT"
+    FAIL=$((FAIL + 1))
+  fi
+else
+  echo "  - skipped workflow validation (actionlint not installed)"
+fi
+
 echo ""
 echo "Result: $PASS passed, $FAIL failed"
 exit $FAIL


### PR DESCRIPTION
## The bug

`lint.yml.template` gated the `python` and `frontend` jobs with a **job-level** `if: hashFiles(...)`. `hashFiles()` is only available *after* a runner is assigned and the repo is checked out, so GitHub rejected the **entire workflow file as invalid** — meaning **no job ran at all**, including `guardrails` (the server-side mirror of the pre-commit hook).

Every push to a consumer repo reported a startup failure with **no jobs and no annotations** — the "what failed" message only renders in the browser, never in the API or the failure email. This is shipped publicly via `install.sh`, so it affected anyone using the scaffold, not just the maintainer's own projects. Confirmed broken for ≥2 weeks across multiple consuming repos.

Exact GitHub error:
```
Invalid workflow file: .github/workflows/lint.yml#L1
(Line: 12, Col: 9): Unrecognized function: 'hashFiles'.
```

## The fix

Move file detection into a post-checkout `detect` step and gate the tool steps on `steps.detect.outputs.present`. Skip-when-absent behavior is **preserved** — a frontend-only repo now shows a green, empty `python` job instead of a hard workflow error. `guardrails` was already unconditional and needed no change; it just needed the file to parse.

No change to `install.sh`, the install flow, or any other public contract.

## Regression guard (why this won't recur)

The root cause behind the root cause: the scaffold's own test harness validated the **pre-commit hook** but never validated that `lint.yml.template` was even a parseable workflow. So a broken workflow shipped to consumers undetected.

- `tests/run.sh` now renders `lint.yml` via `install.sh` into the temp repo and validates it with **actionlint** (pinned `1.7.12`, Actions-semantics only — shellcheck/pyflakes integration disabled so the guard is about workflow validity, not shell style).
- `test.yml` installs actionlint (version + download script both pinned) so CI always exercises the guard.
- Skipped gracefully when actionlint is absent locally, matching the existing ruff-skip pattern.

## Verification

- `actionlint` exits **1** on the old template — both job-level `if:`s flagged at lines 18 & 29.
- `actionlint` exits **0** on the new template.
- Full harness: **19/19 passed** (18 existing + the new workflow-validity case).

## After merge

Cut the `v0.5.1` tag on `main` (the release commit already bumps CHANGELOG + the README install pin), then re-propagate to consuming repos. **Caveat — valid ≠ green:** once the workflow parses, jobs finally *run* and surface each repo's real lint debt; that cleanup is each repo's own follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)