### PR TITLE
fix(ci): bump pinned actions off Node 20 (deprecated June 2) — v0.5.2

### DIFF
--- a/.github/workflows/lint.yml.template
+++ b/.github/workflows/lint.yml.template
@@ -23,14 +23,14 @@ jobs:
     # configs are absent (frontend-only repos see a green, empty python job).
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - id: detect
         run: |
           if [ -f ruff.toml ] || [ -f pyproject.toml ]; then
             echo "present=true" >> "$GITHUB_OUTPUT"
           fi
       - if: steps.detect.outputs.present == 'true'
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.12"
       - if: steps.detect.outputs.present == 'true'
@@ -42,14 +42,14 @@ jobs:
     # Same pattern as `python` — detect in a step, not a job-level `if:`.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - id: detect
         run: |
           if [ -f eslint.config.js ] || [ -f package.json ]; then
             echo "present=true" >> "$GITHUB_OUTPUT"
           fi
       - if: steps.detect.outputs.present == 'true'
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: "20"
       - if: steps.detect.outputs.present == 'true'
@@ -62,7 +62,7 @@ jobs:
     # the same lib/check-* scripts the pre-commit hook calls.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Run scaffold checks
         run: |
           chmod +x .githooks/lib/check-*

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -16,5 +16,5 @@ jobs:
   shellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - run: shellcheck -S info install.sh uninstall.sh tests/run.sh githooks/pre-commit.template githooks/lib/check-size.template githooks/lib/check-patterns.template githooks/lib/check-filenames.template githooks/lib/check-secrets.template

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,8 +20,8 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.12"
       - run: pip install ruff

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+## [v0.5.2] — 2026-05-25
+
+### Fixed
+- **Pinned actions ran on Node 20, force-deprecated 2026-06-02.** GitHub
+  forces all Node-20 actions to Node 24 on 2026-06-02 and removes the
+  Node-20 runtime 2026-09-16; every consumer's workflow runs were already
+  emitting the deprecation annotation. Bumped the SHA pins across
+  `lint.yml.template`, `test.yml`, and `shellcheck.yml` to Node-24-capable
+  majors: `actions/checkout` v4.3.1 → **v6.0.2**, `actions/setup-python`
+  v5.6.0 → **v6.2.0**, `actions/setup-node` v4.4.0 → **v6.4.0**. Inputs
+  (`python-version`, `node-version`) are unchanged and compatible; verified
+  with `actionlint` + the full test harness.
+
+### Changed
+- `README.md` install pin bumped to `v0.5.2`.
+
 ## [v0.5.1] — 2026-05-25
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Clone the scaffold somewhere stable:
 
 ```sh
 # Recommended: pin to a tagged release for reproducibility
-git clone --branch v0.5.1 https://github.com/Sting25/ai-coding-rules-scaffold ~/src/ai-coding-rules-scaffold
+git clone --branch v0.5.2 https://github.com/Sting25/ai-coding-rules-scaffold ~/src/ai-coding-rules-scaffold
 # Or track main if you want the latest changes
 git clone https://github.com/Sting25/ai-coding-rules-scaffold ~/src/ai-coding-rules-scaffold
 ```


### PR DESCRIPTION
## Why

GitHub **force-deprecates Node 20 actions on 2026-06-02** (~1 week out) and removes the Node-20 runtime on 2026-09-16. The scaffold's pinned actions all run on Node 20, so every consumer's workflow runs were already emitting the deprecation annotation — it surfaced on PR #4's run logs. This affects everyone using the scaffold, not just the maintainer's projects.

## What

Bumped the SHA pins to the latest Node-24-capable majors, across **all three** workflow files (`lint.yml.template`, `test.yml`, `shellcheck.yml`):

| Action | Old (Node 20) | New (Node 24) |
|---|---|---|
| `actions/checkout` | v4.3.1 (`34e1148`) | **v6.0.2** (`de0fac2`) |
| `actions/setup-python` | v5.6.0 (`a26af69`) | **v6.2.0** (`a309ff8`) |
| `actions/setup-node` | v4.4.0 (`49933ea`) | **v6.4.0** (`48b55a0`) |

Inputs (`python-version: "3.12"`, `node-version: "20"`) are unchanged and compatible with the new majors. Pins stay SHA-locked with version comments, per repo discipline.

## Verification

- `actionlint` (Actions-semantics) clean on all three workflows.
- Full harness **19/19** with the bumped template (incl. the workflow-validity guard added in v0.5.1).
- This PR's own `test` + `shellcheck` runs now execute on Node 24 — the deprecation annotation should be gone.

## After merge

Cut the **`v0.5.2`** tag on `main` (release commit already bumps CHANGELOG + README install pin). Builds on v0.5.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)