### PR TITLE
security: fail-closed config trust + comment-anchored scaffold-allow (Root Cause C)

### DIFF
--- a/SECURITY_AUDIT.md
+++ b/SECURITY_AUDIT.md
@@ -48,6 +48,15 @@ High-specificity, low-false-positive pattern broadening (each validated against 
 
 Deliberately **not** done here (needs a design decision, not a regex tweak): the generic **unquoted / multi-line** hardcoded-credential gaps. Every loose regex either over-matches dotted identifiers (false positives, which erode trust) or still misses — this case is better served by layering a purpose-built secret scanner (gitleaks/trufflehog), the audit's standing recommendation. Tracked under Root Cause B below.
 
+### Update 2026-06-09 — fail-closed config trust (branch `fix/audit-config-trust`, Root Cause C)
+
+- HIGH `Deleting the forbidden-patterns config in the same commit disables the scan` → the hook now refuses a staged deletion of any `.forbidden-patterns/*.txt` (checked before the empty-staged-list exit, so a delete-only commit can't slip through); `--no-verify` remains the explicit escape for a genuine uninstall.
+- HIGH (CI side) → `check-secrets --ci` now fails **closed** when `secrets.txt` is absent (it is always installed by the scaffold, so its absence server-side means the scanner was disabled).
+- HIGH `scaffold-allow is a case-insensitive substring match anywhere on the line` → the marker is now honored **only after a comment leader** (`#`, `//`, `/*`, `<!--`, `--`), so it can't be smuggled inside a string literal to whitelist a real secret.
+- MEDIUM `Config line missing a TAB is promoted to a whole-line pattern` → pattern lines without a TAB separator are now skipped with a warning.
+
+Locked in with harness fixtures #27–30 (the #30 `--ci` test also begins closing the "harness never exercises the `--ci` path" finding). Still open from Root Cause C/D: escaping `::error` annotation fields (LOW), and a strict-token escape audit. 33/33 tests pass.
+
 **Status legend:** ✅ Fixed on this branch · 🟡 Partially addressed · ⬜ Open (tracked below).
 
 ## 🔴 Critical

--- a/forbidden-patterns/README.md
+++ b/forbidden-patterns/README.md
@@ -50,11 +50,15 @@ sees this on every blocked commit.
 
 ## Per-line opt-out: `scaffold-allow`
 
-A line containing the substring `scaffold-allow` (case-insensitive) is
-exempt from `check-patterns` and `check-secrets`. Use it as an inline
-escape valve when a match is intentional — a CLI entry point that needs
-`print`, a docs example showing an AWS key prefix, a test fixture with a
-synthetic credential. Mirrors the role `# noqa` plays for ruff.
+A line is exempt from `check-patterns` and `check-secrets` when it carries a
+`scaffold-allow` marker **after a comment leader** — `#`, `//`, `/*`, `<!--`,
+or `--` (case-insensitive). The comment-leader requirement is deliberate: it
+stops the bare substring from being smuggled inside a string literal to
+whitelist a real secret (e.g. `token = "scaffold-allow..."` is **not**
+exempt). Use it as an inline escape valve when a match is intentional — a CLI
+entry point that needs `print`, a docs example showing an AWS key prefix, a
+test fixture with a synthetic credential. Mirrors the role `# noqa` plays for
+ruff.
 
 ```python
 print("entering CLI")  # scaffold-allow — no logger configured yet

--- a/githooks/lib/check-patterns.template
+++ b/githooks/lib/check-patterns.template
@@ -10,8 +10,8 @@
 # bytes, and post-stage edits cannot hide content from the scan. Every grep
 # passes -a/--text for the same reason.
 #
-# Lines containing `scaffold-allow` (case-insensitive) are exempt — an
-# explicit per-line opt-out, like `# noqa`. Use sparingly.
+# A `scaffold-allow` marker exempts a line, but ONLY after a comment leader
+# (`#`, `//`, `/*`, `<!--`, `--`) — like `# noqa`. Use sparingly.
 #
 # Output: human-readable on tty; ::error file=...:: when --ci is passed.
 # Exit:   0 if all OK, 1 if any violation.
@@ -34,12 +34,20 @@ scan() {
   [ ${#FILES[@]} -eq 0 ] && return 0
 
   local raw_patterns=() raw_descs=()
-  local pattern description
-  while IFS=$'\t' read -r pattern description; do
-    pattern=${pattern%$'\r'}
-    description=${description%$'\r'}
+  local line pattern description
+  while IFS= read -r line || [ -n "$line" ]; do
+    line=${line%$'\r'}
+    [ -z "$line" ] && continue
+    case "$line" in \#*) continue ;; esac
+    # Require a real TAB separator (see check-secrets): a line without one would
+    # become a whole-line pattern with an empty description. Skip + warn.
+    case "$line" in
+      *$'\t'*) ;;
+      *) echo "warning: $config: line has no TAB separator, skipped: $line" >&2; continue ;;
+    esac
+    pattern=${line%%$'\t'*}
+    description=${line#*$'\t'}
     [ -z "$pattern" ] && continue
-    case "$pattern" in \#*) continue ;; esac
     raw_patterns+=("$pattern")
     raw_descs+=("$description")
   done <"$config"
@@ -110,7 +118,8 @@ scan() {
     for i in "${!patterns[@]}"; do
       pat="${patterns[$i]}"
       desc="${descriptions[$i]}"
-      m=$(grep -anE -- "$pat" <<<"$content" | grep -iv 'scaffold-allow' || true)
+      # Exempt only a comment-anchored marker (see check-secrets).
+      m=$(grep -anE -- "$pat" <<<"$content" | grep -ivE '(#|//|/\*|<!--|--)[[:space:]]*scaffold-allow' || true)
       [ -n "$m" ] || continue
       if [ "$CI_MODE" -eq 1 ]; then
         echo "::error file=$file::$desc"

--- a/githooks/lib/check-secrets.template
+++ b/githooks/lib/check-secrets.template
@@ -17,8 +17,9 @@
 # Pattern format: <regex><TAB><description>
 # (TAB is the field separator so regex can use literal `|` alternation.)
 #
-# Lines containing `scaffold-allow` (case-insensitive) are exempt — an
-# explicit per-line opt-out for documented test fixtures or example keys.
+# A `scaffold-allow` marker exempts a line, but ONLY when it appears after a
+# comment leader (`#`, `//`, `/*`, `<!--`, `--`) — so the substring can't be
+# smuggled inside a string literal to whitelist a real secret.
 #
 # Output: human-readable on tty; ::error file=...:: when --ci is passed.
 # Exit:   0 if all OK, 1 if any violation.
@@ -29,7 +30,17 @@ CI_MODE=0
 [ "${1:-}" = "--ci" ] && CI_MODE=1
 
 CONFIG=".forbidden-patterns/secrets.txt"
-[ -f "$CONFIG" ] || exit 0
+if [ ! -f "$CONFIG" ]; then
+  # Fail CLOSED in CI: secrets.txt is always installed by the scaffold, so its
+  # absence server-side means the secret scanner has been disabled (e.g. the
+  # config was deleted in a merged commit). Locally (hook) stay lenient — a
+  # fresh checkout may not have run install.sh yet.
+  if [ "$CI_MODE" -eq 1 ]; then
+    echo "::error::.forbidden-patterns/secrets.txt is missing — the secret scanner is disabled. Restore it (or remove the guardrails job intentionally)."
+    exit 1
+  fi
+  exit 0
+fi
 
 FILES=()
 while IFS= read -r -d '' f; do
@@ -52,11 +63,20 @@ done
 
 RAW_PATTERNS=()
 RAW_DESCS=()
-while IFS=$'\t' read -r pattern description; do
-  pattern=${pattern%$'\r'}
-  description=${description%$'\r'}
+while IFS= read -r line || [ -n "$line" ]; do
+  line=${line%$'\r'}
+  [ -z "$line" ] && continue
+  case "$line" in \#*) continue ;; esac
+  # Require a real TAB separator. Without one the whole line would become a
+  # pattern with an empty description — over-matching and emitting blank
+  # ::error annotations. Skip + warn instead.
+  case "$line" in
+    *$'\t'*) ;;
+    *) echo "warning: $CONFIG: line has no TAB separator, skipped: $line" >&2; continue ;;
+  esac
+  pattern=${line%%$'\t'*}
+  description=${line#*$'\t'}
   [ -z "$pattern" ] && continue
-  case "$pattern" in \#*) continue ;; esac
   RAW_PATTERNS+=("$pattern")
   RAW_DESCS+=("$description")
 done <"$CONFIG"
@@ -112,7 +132,9 @@ for file in "${FILES[@]}"; do
   for i in "${!PATTERNS[@]}"; do
     pat="${PATTERNS[$i]}"
     desc="${DESCRIPTIONS[$i]}"
-    m=$(grep -aniE -- "$pat" <<<"$content" | grep -iv 'scaffold-allow' || true)
+    # Exempt only a comment-anchored marker, so `scaffold-allow` inside a string
+    # literal cannot whitelist a real secret.
+    m=$(grep -aniE -- "$pat" <<<"$content" | grep -ivE '(#|//|/\*|<!--|--)[[:space:]]*scaffold-allow' || true)
     [ -n "$m" ] || continue
     if [ "$CI_MODE" -eq 1 ]; then
       echo "::error file=$file::$desc"

--- a/githooks/pre-commit.template
+++ b/githooks/pre-commit.template
@@ -30,6 +30,19 @@ LIB="$HOOK_DIR/lib"
 # shell variable cannot hold NUL bytes, so the list goes to a temp file and each
 # check is fed from it. (core.quotepath is irrelevant under -z, which never
 # C-quotes; kept only for defence in depth.)
+# Refuse to let a commit silently disable the scanners by deleting their config.
+# A staged deletion of a .forbidden-patterns/*.txt makes the matching check find
+# no config and exit 0 — a one-commit way to land a secret AND neuter the scan.
+# Checked BEFORE the empty-staged-list exit, since a delete-only commit has an
+# empty ACMR list. Use `git commit --no-verify` if a removal is intended (uninstall).
+DELETED_CONFIG=$(git diff --cached -z --name-only --diff-filter=D | tr '\0' '\n' | grep -E '^\.forbidden-patterns/.+\.txt$' || true)
+if [ -n "$DELETED_CONFIG" ]; then
+  echo "error: this commit deletes forbidden-pattern config, disabling the scanner:" >&2
+  printf '%s\n' "$DELETED_CONFIG" | sed 's/^/       /' >&2
+  echo "       Refusing — re-add it, or use 'git commit --no-verify' if intended." >&2
+  exit 1
+fi
+
 STAGED_LIST=$(mktemp)
 git -c core.quotepath=off diff --cached -z --name-only --diff-filter=ACMR >"$STAGED_LIST"
 if [ ! -s "$STAGED_LIST" ]; then

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -314,6 +314,49 @@ echo 'Console.log("ok");' >comp.ts
 git add comp.ts
 assert_passes "case-sensitive: Console.log not flagged as console.log"
 
+# 27. Deleting the secrets config in the same commit must not silently disable
+#     the scanner — the hook refuses a staged deletion of .forbidden-patterns/*.txt.
+git rm -q .forbidden-patterns/secrets.txt
+assert_rejects "deleting forbidden-pattern config is refused" "disabling the scanner"
+
+# 28. scaffold-allow only exempts when it follows a comment leader; the bare
+#     substring inside a string literal must NOT whitelist a real secret.
+echo 'note = "scaffold-allow AKIA''IOSFODNN7EXAMPLE"' >sneaky2.txt
+git add sneaky2.txt
+assert_rejects "scaffold-allow in a string does not exempt a secret" "AWS access key"
+
+# 29. A config line with no TAB separator is skipped with a warning (not promoted
+#     to a whole-line pattern); a valid pattern on another line still scans.
+printf 'this line has no tab separator at all\n' >>.forbidden-patterns/backend.txt
+echo 'pri''nt("debug")' >hastab.py
+git add .forbidden-patterns/backend.txt hastab.py
+if .githooks/pre-commit >"$HOOK_OUT" 2>&1; then
+  echo "  ✗ missing-TAB config — accepted, expected reject (print should still scan)"
+  sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+elif grep -qF "no TAB separator" "$HOOK_OUT"; then
+  echo "  ✓ missing-TAB config line skipped with warning, valid pattern still scans"
+  PASS=$((PASS + 1))
+else
+  echo "  ✗ missing-TAB config — rejected but no warning emitted"
+  sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+reset_repo
+
+# 30. CI mode fails CLOSED when secrets.txt is absent (it would otherwise pass
+#     silently — disabling the scanner). Exercises the --ci code path directly.
+rm -f .forbidden-patterns/secrets.txt
+if printf '' | .githooks/lib/check-secrets --ci >"$HOOK_OUT" 2>&1; then
+  echo "  ✗ --ci absent-config — exited 0, expected fail-closed"
+  FAIL=$((FAIL + 1))
+elif grep -qF "secret scanner is disabled" "$HOOK_OUT"; then
+  echo "  ✓ --ci fails closed when secrets.txt is missing"
+  PASS=$((PASS + 1))
+else
+  echo "  ✗ --ci absent-config — failed without the expected message"
+  sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+reset_repo
+
 echo ""
 echo "Result: $PASS passed, $FAIL failed"
 exit $FAIL


### PR DESCRIPTION
## Summary

Third audit pass — **Root Cause C/D (fail-closed config trust + opt-out hardening)**. Closes the audit's remaining reproduced config-trust bypasses. All changes are clearly-correct with no design tradeoff.

> **Stacked on #8** (`fix/audit-detection-efficacy`). Review/merge #8 first; GitHub will auto-retarget this to `main`.

## What changed

| Finding | Fix |
|---|---|
| 🟠 **HIGH** — deleting the config in the same commit disables the scan | Hook refuses a staged deletion of any `.forbidden-patterns/*.txt`, **before** the empty-staged-list exit so a delete-only commit can't slip past. `--no-verify` stays the escape for a real uninstall. |
| 🟠 **HIGH** (CI side) | `check-secrets --ci` now fails **closed** when `secrets.txt` is absent — it's always installed, so its server-side absence means the scanner was disabled. |
| 🟠 **HIGH** — `scaffold-allow` substring anywhere whitelists secrets | Honored **only after a comment leader** (`#`, `//`, `/*`, `<!--`, `--`), so `token = "scaffold-allow..."` no longer exempts a real secret. |
| 🟡 **MEDIUM** — config line with no TAB → whole-line pattern | Lines without a TAB separator are skipped with a warning. |

## Verification

- `tests/run.sh`: **33/33** (4 new, #27–30), verified under GNU grep 3.11.
- Fixture **#30 invokes `.githooks/lib/check-secrets --ci` directly** — the first coverage of the `--ci` path, starting to close the "harness never exercises `--ci`" finding.
- Existing `scaffold-allow` exemption tests (#10/#12, comment form) still pass; #28 confirms the string-literal form no longer exempts.

## Still open (tracked in `SECURITY_AUDIT.md`)
`::error` annotation-field escaping (LOW); supply-chain (pin `curl|bash` actionlint installer, trusted-ref guardrails); ReDoS line-cap; broader `--ci`/per-pattern fixtures; and the gitleaks-layer decision for generic unquoted secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)