### PR TITLE
security: ReDoS line-length cap + pin actionlint installer to a SHA

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,11 +28,14 @@ jobs:
       - name: Install actionlint
         # Validates the rendered lint.yml is a parseable GitHub Actions
         # workflow — guards against the job-level `if: hashFiles(...)` class
-        # of error that silently disables every job. Version + download
-        # script both pinned for reproducibility.
+        # of error that silently disables every job. The download script is
+        # pinned to a COMMIT SHA, not the mutable v1.7.12 tag, so a moved tag
+        # or a compromised release can't swap the script under us. The `1.7.12`
+        # arg is the actionlint version the (pinned) script then downloads.
         run: |
           mkdir -p "$RUNNER_TEMP/bin"
-          bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/v1.7.12/scripts/download-actionlint.bash) 1.7.12 "$RUNNER_TEMP/bin"
+          # SHA is rhysd/actionlint tag v1.7.12.
+          bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/914e7df21a07ef503a81201c76d2b11c789d3fca/scripts/download-actionlint.bash) 1.7.12 "$RUNNER_TEMP/bin"
           echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
       - run: chmod +x tests/run.sh install.sh githooks/pre-commit.template
       - run: ./tests/run.sh

--- a/SECURITY_AUDIT.md
+++ b/SECURITY_AUDIT.md
@@ -48,6 +48,15 @@ High-specificity, low-false-positive pattern broadening (each validated against 
 
 Deliberately **not** done here (needs a design decision, not a regex tweak): the generic **unquoted / multi-line** hardcoded-credential gaps. Every loose regex either over-matches dotted identifiers (false positives, which erode trust) or still misses — this case is better served by layering a purpose-built secret scanner (gitleaks/trufflehog), the audit's standing recommendation. Tracked under Root Cause B below.
 
+### Update 2026-06-09 — fail-closed config trust (branch `fix/audit-config-trust`, Root Cause C)
+
+- HIGH `Deleting the forbidden-patterns config in the same commit disables the scan` → the hook now refuses a staged deletion of any `.forbidden-patterns/*.txt` (checked before the empty-staged-list exit, so a delete-only commit can't slip through); `--no-verify` remains the explicit escape for a genuine uninstall.
+- HIGH (CI side) → `check-secrets --ci` now fails **closed** when `secrets.txt` is absent (it is always installed by the scaffold, so its absence server-side means the scanner was disabled).
+- HIGH `scaffold-allow is a case-insensitive substring match anywhere on the line` → the marker is now honored **only after a comment leader** (`#`, `//`, `/*`, `<!--`, `--`), so it can't be smuggled inside a string literal to whitelist a real secret.
+- MEDIUM `Config line missing a TAB is promoted to a whole-line pattern` → pattern lines without a TAB separator are now skipped with a warning.
+
+Locked in with harness fixtures #27–30 (the #30 `--ci` test also begins closing the "harness never exercises the `--ci` path" finding). Still open from Root Cause C/D: escaping `::error` annotation fields (LOW), and a strict-token escape audit. 33/33 tests pass.
+
 **Status legend:** ✅ Fixed on this branch · 🟡 Partially addressed · ⬜ Open (tracked below).
 
 ## 🔴 Critical

--- a/SECURITY_AUDIT.md
+++ b/SECURITY_AUDIT.md
@@ -57,6 +57,13 @@ Deliberately **not** done here (needs a design decision, not a regex tweak): the
 
 Locked in with harness fixtures #27–30 (the #30 `--ci` test also begins closing the "harness never exercises the `--ci` path" finding). Still open from Root Cause C/D: escaping `::error` annotation fields (LOW), and a strict-token escape audit. 33/33 tests pass.
 
+### Update 2026-06-09 — ReDoS guard + supply-chain pin (branch `fix/audit-redos-supplychain`)
+
+- HIGH `Combined-ERE pre-filter blows up superlinearly on a long single line — hook and CI hang (ReDoS)` → both scanners now drop any line longer than `MAX_LINE_LENGTH` (default 50000, configurable) via a linear `awk` pass before the ERE ever sees it. Verified: an 800 KB single-line file now scans in ~0 s instead of hanging. A short secret on a normal line is still caught (fixture #31); over-long minified/generated lines are reported as skipped — point a dedicated scanner at those.
+- LOW (supply-chain) `actionlint installed via curl|bash from a mutable git tag` → `test.yml` now pins the download script to the **commit SHA** of `rhysd/actionlint` tag v1.7.12 (`914e7df…`), so a moved tag or compromised release can't swap the installer.
+
+34/34 tests pass; shellcheck clean. Remaining HIGH from the audit: rename-to-skip-listed-extension. Still open: fork-PR trusted-ref guardrails, Git-LFS blob scanning, `::error` annotation escaping, broader `--ci`/per-pattern fixtures, and the gitleaks-layer decision for generic unquoted secrets.
+
 **Status legend:** ✅ Fixed on this branch · 🟡 Partially addressed · ⬜ Open (tracked below).
 
 ## 🔴 Critical

--- a/forbidden-patterns/README.md
+++ b/forbidden-patterns/README.md
@@ -50,11 +50,15 @@ sees this on every blocked commit.
 
 ## Per-line opt-out: `scaffold-allow`
 
-A line containing the substring `scaffold-allow` (case-insensitive) is
-exempt from `check-patterns` and `check-secrets`. Use it as an inline
-escape valve when a match is intentional — a CLI entry point that needs
-`print`, a docs example showing an AWS key prefix, a test fixture with a
-synthetic credential. Mirrors the role `# noqa` plays for ruff.
+A line is exempt from `check-patterns` and `check-secrets` when it carries a
+`scaffold-allow` marker **after a comment leader** — `#`, `//`, `/*`, `<!--`,
+or `--` (case-insensitive). The comment-leader requirement is deliberate: it
+stops the bare substring from being smuggled inside a string literal to
+whitelist a real secret (e.g. `token = "scaffold-allow..."` is **not**
+exempt). Use it as an inline escape valve when a match is intentional — a CLI
+entry point that needs `print`, a docs example showing an AWS key prefix, a
+test fixture with a synthetic credential. Mirrors the role `# noqa` plays for
+ruff.
 
 ```python
 print("entering CLI")  # scaffold-allow — no logger configured yet

--- a/githooks/lib/check-patterns.template
+++ b/githooks/lib/check-patterns.template
@@ -21,6 +21,15 @@ set -euo pipefail
 CI_MODE=0
 [ "${1:-}" = "--ci" ] && CI_MODE=1
 
+# Cap the maximum scanned LINE length (see check-secrets): one very long line
+# can make the combined ERE hang the hook/CI. Over-long lines are dropped with
+# a warning. Linear awk length check; the ERE on a long line is not linear.
+MAX_LINE_LENGTH=${MAX_LINE_LENGTH:-50000}
+case "$MAX_LINE_LENGTH" in
+  ''|*[!0-9]*) echo "error: MAX_LINE_LENGTH must be a positive integer, got: $MAX_LINE_LENGTH" >&2; exit 2 ;;
+esac
+[ "$MAX_LINE_LENGTH" -gt 0 ] || { echo "error: MAX_LINE_LENGTH must be > 0" >&2; exit 2; }
+
 FILES=()
 while IFS= read -r -d '' f; do
   [ -n "$f" ] && FILES+=("$f")
@@ -96,7 +105,7 @@ scan() {
     use_prefilter=0
   fi
 
-  local file ext keep content pat desc m
+  local file ext keep content cap_rc pat desc m
   for file in "${FILES[@]}"; do
     keep=0
     for ext in "${exts[@]}"; do
@@ -104,8 +113,13 @@ scan() {
     done
     [ "$keep" -eq 1 ] || continue
 
-    # Scan the staged blob, not the working-tree path (see header).
-    content=$(git show ":0:$file" 2>/dev/null || true)
+    # Scan the staged blob, not the working-tree path (see header). awk (linear)
+    # drops over-long lines so the combined ERE never sees them (ReDoS guard).
+    cap_rc=0
+    content=$(git show ":0:$file" 2>/dev/null | awk -v n="$MAX_LINE_LENGTH" 'length > n { d=1; next } { print } END { exit (d ? 9 : 0) }') || cap_rc=$?
+    if [ "$cap_rc" -eq 9 ]; then
+      echo "warning: $file: line(s) over $MAX_LINE_LENGTH chars dropped from the scan (minified/generated?)" >&2
+    fi
     [ -n "$content" ] || continue
 
     if [ "$use_prefilter" -eq 1 ]; then

--- a/githooks/lib/check-patterns.template
+++ b/githooks/lib/check-patterns.template
@@ -10,8 +10,8 @@
 # bytes, and post-stage edits cannot hide content from the scan. Every grep
 # passes -a/--text for the same reason.
 #
-# Lines containing `scaffold-allow` (case-insensitive) are exempt — an
-# explicit per-line opt-out, like `# noqa`. Use sparingly.
+# A `scaffold-allow` marker exempts a line, but ONLY after a comment leader
+# (`#`, `//`, `/*`, `<!--`, `--`) — like `# noqa`. Use sparingly.
 #
 # Output: human-readable on tty; ::error file=...:: when --ci is passed.
 # Exit:   0 if all OK, 1 if any violation.
@@ -34,12 +34,20 @@ scan() {
   [ ${#FILES[@]} -eq 0 ] && return 0
 
   local raw_patterns=() raw_descs=()
-  local pattern description
-  while IFS=$'\t' read -r pattern description; do
-    pattern=${pattern%$'\r'}
-    description=${description%$'\r'}
+  local line pattern description
+  while IFS= read -r line || [ -n "$line" ]; do
+    line=${line%$'\r'}
+    [ -z "$line" ] && continue
+    case "$line" in \#*) continue ;; esac
+    # Require a real TAB separator (see check-secrets): a line without one would
+    # become a whole-line pattern with an empty description. Skip + warn.
+    case "$line" in
+      *$'\t'*) ;;
+      *) echo "warning: $config: line has no TAB separator, skipped: $line" >&2; continue ;;
+    esac
+    pattern=${line%%$'\t'*}
+    description=${line#*$'\t'}
     [ -z "$pattern" ] && continue
-    case "$pattern" in \#*) continue ;; esac
     raw_patterns+=("$pattern")
     raw_descs+=("$description")
   done <"$config"
@@ -110,7 +118,8 @@ scan() {
     for i in "${!patterns[@]}"; do
       pat="${patterns[$i]}"
       desc="${descriptions[$i]}"
-      m=$(grep -anE -- "$pat" <<<"$content" | grep -iv 'scaffold-allow' || true)
+      # Exempt only a comment-anchored marker (see check-secrets).
+      m=$(grep -anE -- "$pat" <<<"$content" | grep -ivE '(#|//|/\*|<!--|--)[[:space:]]*scaffold-allow' || true)
       [ -n "$m" ] || continue
       if [ "$CI_MODE" -eq 1 ]; then
         echo "::error file=$file::$desc"

--- a/githooks/lib/check-secrets.template
+++ b/githooks/lib/check-secrets.template
@@ -29,6 +29,17 @@ set -euo pipefail
 CI_MODE=0
 [ "${1:-}" = "--ci" ] && CI_MODE=1
 
+# Cap the maximum scanned LINE length. One pathologically long line (a minified
+# bundle, a base64 data: URI, a source map) can make the combined ERE blow up
+# superlinearly and hang the hook and CI (a denial of service). Lines longer
+# than this are dropped from the scan with a warning — point a dedicated secret
+# scanner at minified/generated assets instead.
+MAX_LINE_LENGTH=${MAX_LINE_LENGTH:-50000}
+case "$MAX_LINE_LENGTH" in
+  ''|*[!0-9]*) echo "error: MAX_LINE_LENGTH must be a positive integer, got: $MAX_LINE_LENGTH" >&2; exit 2 ;;
+esac
+[ "$MAX_LINE_LENGTH" -gt 0 ] || { echo "error: MAX_LINE_LENGTH must be > 0" >&2; exit 2; }
+
 CONFIG=".forbidden-patterns/secrets.txt"
 if [ ! -f "$CONFIG" ]; then
   # Fail CLOSED in CI: secrets.txt is always installed by the scaffold, so its
@@ -124,7 +135,12 @@ for file in "${FILES[@]}"; do
   # Scan the staged blob, not the working-tree path. $() strips any NUL bytes
   # and -a/--text keeps grep in text mode, so an embedded NUL cannot suppress a
   # match. A missing blob (e.g. a submodule gitlink) yields empty content.
-  content=$(git show ":0:$file" 2>/dev/null || true)
+  # awk (linear) also drops over-long lines here so the ERE never sees them.
+  cap_rc=0
+  content=$(git show ":0:$file" 2>/dev/null | awk -v n="$MAX_LINE_LENGTH" 'length > n { d=1; next } { print } END { exit (d ? 9 : 0) }') || cap_rc=$?
+  if [ "$cap_rc" -eq 9 ]; then
+    echo "warning: $file: line(s) over $MAX_LINE_LENGTH chars dropped from the scan (minified/generated?)" >&2
+  fi
   [ -n "$content" ] || continue
   if [ "$USE_PREFILTER" -eq 1 ]; then
     grep -aniE -- "$COMBINED" <<<"$content" >/dev/null 2>&1 || continue

--- a/githooks/lib/check-secrets.template
+++ b/githooks/lib/check-secrets.template
@@ -17,8 +17,9 @@
 # Pattern format: <regex><TAB><description>
 # (TAB is the field separator so regex can use literal `|` alternation.)
 #
-# Lines containing `scaffold-allow` (case-insensitive) are exempt — an
-# explicit per-line opt-out for documented test fixtures or example keys.
+# A `scaffold-allow` marker exempts a line, but ONLY when it appears after a
+# comment leader (`#`, `//`, `/*`, `<!--`, `--`) — so the substring can't be
+# smuggled inside a string literal to whitelist a real secret.
 #
 # Output: human-readable on tty; ::error file=...:: when --ci is passed.
 # Exit:   0 if all OK, 1 if any violation.
@@ -29,7 +30,17 @@ CI_MODE=0
 [ "${1:-}" = "--ci" ] && CI_MODE=1
 
 CONFIG=".forbidden-patterns/secrets.txt"
-[ -f "$CONFIG" ] || exit 0
+if [ ! -f "$CONFIG" ]; then
+  # Fail CLOSED in CI: secrets.txt is always installed by the scaffold, so its
+  # absence server-side means the secret scanner has been disabled (e.g. the
+  # config was deleted in a merged commit). Locally (hook) stay lenient — a
+  # fresh checkout may not have run install.sh yet.
+  if [ "$CI_MODE" -eq 1 ]; then
+    echo "::error::.forbidden-patterns/secrets.txt is missing — the secret scanner is disabled. Restore it (or remove the guardrails job intentionally)."
+    exit 1
+  fi
+  exit 0
+fi
 
 FILES=()
 while IFS= read -r -d '' f; do
@@ -52,11 +63,20 @@ done
 
 RAW_PATTERNS=()
 RAW_DESCS=()
-while IFS=$'\t' read -r pattern description; do
-  pattern=${pattern%$'\r'}
-  description=${description%$'\r'}
+while IFS= read -r line || [ -n "$line" ]; do
+  line=${line%$'\r'}
+  [ -z "$line" ] && continue
+  case "$line" in \#*) continue ;; esac
+  # Require a real TAB separator. Without one the whole line would become a
+  # pattern with an empty description — over-matching and emitting blank
+  # ::error annotations. Skip + warn instead.
+  case "$line" in
+    *$'\t'*) ;;
+    *) echo "warning: $CONFIG: line has no TAB separator, skipped: $line" >&2; continue ;;
+  esac
+  pattern=${line%%$'\t'*}
+  description=${line#*$'\t'}
   [ -z "$pattern" ] && continue
-  case "$pattern" in \#*) continue ;; esac
   RAW_PATTERNS+=("$pattern")
   RAW_DESCS+=("$description")
 done <"$CONFIG"
@@ -112,7 +132,9 @@ for file in "${FILES[@]}"; do
   for i in "${!PATTERNS[@]}"; do
     pat="${PATTERNS[$i]}"
     desc="${DESCRIPTIONS[$i]}"
-    m=$(grep -aniE -- "$pat" <<<"$content" | grep -iv 'scaffold-allow' || true)
+    # Exempt only a comment-anchored marker, so `scaffold-allow` inside a string
+    # literal cannot whitelist a real secret.
+    m=$(grep -aniE -- "$pat" <<<"$content" | grep -ivE '(#|//|/\*|<!--|--)[[:space:]]*scaffold-allow' || true)
     [ -n "$m" ] || continue
     if [ "$CI_MODE" -eq 1 ]; then
       echo "::error file=$file::$desc"

--- a/githooks/pre-commit.template
+++ b/githooks/pre-commit.template
@@ -30,6 +30,19 @@ LIB="$HOOK_DIR/lib"
 # shell variable cannot hold NUL bytes, so the list goes to a temp file and each
 # check is fed from it. (core.quotepath is irrelevant under -z, which never
 # C-quotes; kept only for defence in depth.)
+# Refuse to let a commit silently disable the scanners by deleting their config.
+# A staged deletion of a .forbidden-patterns/*.txt makes the matching check find
+# no config and exit 0 — a one-commit way to land a secret AND neuter the scan.
+# Checked BEFORE the empty-staged-list exit, since a delete-only commit has an
+# empty ACMR list. Use `git commit --no-verify` if a removal is intended (uninstall).
+DELETED_CONFIG=$(git diff --cached -z --name-only --diff-filter=D | tr '\0' '\n' | grep -E '^\.forbidden-patterns/.+\.txt$' || true)
+if [ -n "$DELETED_CONFIG" ]; then
+  echo "error: this commit deletes forbidden-pattern config, disabling the scanner:" >&2
+  printf '%s\n' "$DELETED_CONFIG" | sed 's/^/       /' >&2
+  echo "       Refusing — re-add it, or use 'git commit --no-verify' if intended." >&2
+  exit 1
+fi
+
 STAGED_LIST=$(mktemp)
 git -c core.quotepath=off diff --cached -z --name-only --diff-filter=ACMR >"$STAGED_LIST"
 if [ ! -s "$STAGED_LIST" ]; then

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -357,6 +357,27 @@ else
 fi
 reset_repo
 
+# 31. ReDoS guard: a line over MAX_LINE_LENGTH is dropped before the combined
+#     ERE (which can hang superlinearly on a long line), while a secret on a
+#     normal line is still caught. Long line is benign filler; AKIA split.
+{
+  echo "AKIA""IOSFODNN7EXAMPLE"
+  head -c 60000 /dev/zero | tr '\0' a
+  echo
+} >redos.txt
+git add redos.txt
+if .githooks/pre-commit >"$HOOK_OUT" 2>&1; then
+  echo "  ✗ ReDoS guard — accepted, expected reject (secret on the normal line)"
+  sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+elif grep -qF "AWS access key" "$HOOK_OUT" && grep -qF "chars dropped from the scan" "$HOOK_OUT"; then
+  echo "  ✓ over-long line dropped with warning; secret on normal line still caught"
+  PASS=$((PASS + 1))
+else
+  echo "  ✗ ReDoS guard — rejected but missing the secret hit or the drop warning"
+  sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+reset_repo
+
 echo ""
 echo "Result: $PASS passed, $FAIL failed"
 exit $FAIL

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -314,6 +314,49 @@ echo 'Console.log("ok");' >comp.ts
 git add comp.ts
 assert_passes "case-sensitive: Console.log not flagged as console.log"
 
+# 27. Deleting the secrets config in the same commit must not silently disable
+#     the scanner — the hook refuses a staged deletion of .forbidden-patterns/*.txt.
+git rm -q .forbidden-patterns/secrets.txt
+assert_rejects "deleting forbidden-pattern config is refused" "disabling the scanner"
+
+# 28. scaffold-allow only exempts when it follows a comment leader; the bare
+#     substring inside a string literal must NOT whitelist a real secret.
+echo 'note = "scaffold-allow AKIA''IOSFODNN7EXAMPLE"' >sneaky2.txt
+git add sneaky2.txt
+assert_rejects "scaffold-allow in a string does not exempt a secret" "AWS access key"
+
+# 29. A config line with no TAB separator is skipped with a warning (not promoted
+#     to a whole-line pattern); a valid pattern on another line still scans.
+printf 'this line has no tab separator at all\n' >>.forbidden-patterns/backend.txt
+echo 'pri''nt("debug")' >hastab.py
+git add .forbidden-patterns/backend.txt hastab.py
+if .githooks/pre-commit >"$HOOK_OUT" 2>&1; then
+  echo "  ✗ missing-TAB config — accepted, expected reject (print should still scan)"
+  sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+elif grep -qF "no TAB separator" "$HOOK_OUT"; then
+  echo "  ✓ missing-TAB config line skipped with warning, valid pattern still scans"
+  PASS=$((PASS + 1))
+else
+  echo "  ✗ missing-TAB config — rejected but no warning emitted"
+  sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+reset_repo
+
+# 30. CI mode fails CLOSED when secrets.txt is absent (it would otherwise pass
+#     silently — disabling the scanner). Exercises the --ci code path directly.
+rm -f .forbidden-patterns/secrets.txt
+if printf '' | .githooks/lib/check-secrets --ci >"$HOOK_OUT" 2>&1; then
+  echo "  ✗ --ci absent-config — exited 0, expected fail-closed"
+  FAIL=$((FAIL + 1))
+elif grep -qF "secret scanner is disabled" "$HOOK_OUT"; then
+  echo "  ✓ --ci fails closed when secrets.txt is missing"
+  PASS=$((PASS + 1))
+else
+  echo "  ✗ --ci absent-config — failed without the expected message"
+  sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+reset_repo
+
 echo ""
 echo "Result: $PASS passed, $FAIL failed"
 exit $FAIL


### PR DESCRIPTION
## Summary

Fourth audit pass — the last **HIGH** that wasn't a design decision (**ReDoS**), plus a supply-chain pin.

> **Stacked on #9** (`fix/audit-config-trust`), which is itself still open. Merge order: **#9 → this**. GitHub auto-retargets to `main` as each lands.

## What changed

| Finding | Fix |
|---|---|
| 🟠 **HIGH (ReDoS)** — combined-ERE hangs on a long single line | Both scanners drop any line longer than `MAX_LINE_LENGTH` (default 50000, configurable) via a **linear `awk` pass** before the ERE sees it. A short secret on a normal line is still caught; over-long generated lines are reported as skipped. |
| ⚪ **LOW (supply-chain)** — actionlint installed via `curl\|bash` of a **mutable tag** | `test.yml` pins the download-script URL to that tag's **commit SHA** (`914e7df…`), so a moved tag/compromised release can't swap the installer. |

## Verification

- **Empirical ReDoS proof:** an **800 KB single-line file** now scans in **~0 s** instead of hanging the hook/CI.
- `tests/run.sh`: **34/34** (new fixture #31 = cap engages + secret on normal line still caught), under GNU grep 3.11.
- **shellcheck clean** (verified locally with 0.10.0 — incl. avoiding SC2181), `bash -n` clean, `test.yml` valid YAML.

## Remaining after this (tracked in `SECURITY_AUDIT.md`)
One HIGH left — rename-to-skip-listed-extension. Plus: fork-PR trusted-ref guardrails, Git-LFS blob scanning, `::error` annotation escaping, broader `--ci`/per-pattern fixtures, README stale-claim cleanup, and the **gitleaks-layer decision** for generic unquoted secrets (still needs your call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)