### PR TITLE
fix(security): close rename-to-skipped-extension secret bypass + escape ::error annotations

### DIFF
--- a/.github/workflows/lint.yml.template
+++ b/.github/workflows/lint.yml.template
@@ -60,6 +60,25 @@ jobs:
   guardrails:
     # File size, forbidden patterns, blocked filenames, secret scan —
     # the same lib/check-* scripts the pre-commit hook calls.
+    #
+    # Two limitations to know about (both inherent to how this job is wired,
+    # not bugs you can patch in the script):
+    #
+    #   1. Runs the check scripts AND pattern configs from the PR head. On a
+    #      `pull_request` build the checked-out tree is the PR's own content, so
+    #      a PR can weaken the very scanner meant to gate it (edit a check-*
+    #      script, delete a pattern from .forbidden-patterns/*). This is a
+    #      defense-in-depth backstop, NOT a trust boundary against a hostile
+    #      contributor — pair it with branch protection / required review, and
+    #      for untrusted forks gate merges on a scan run from the BASE ref
+    #      (e.g. check out `${{ github.base_ref }}`'s .githooks + configs and
+    #      run those against the PR's files).
+    #
+    #   2. Scans the committed blob (`git show :0:<path>`). For a Git-LFS- or
+    #      clean/smudge-filtered file the committed blob is the POINTER, not the
+    #      real content, so LFS-tracked text is not meaningfully scanned here.
+    #      If your repo keeps scannable text in LFS, add `lfs: true` to the
+    #      checkout below and scan the smudged working tree for those paths.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Security
+- **Rename-to-skipped-extension secret bypass (audit HIGH).** `check-secrets`
+  skipped files by extension (`*.png`, `*.zip`, `package-lock.json`, …), so a
+  plaintext secret renamed to a skipped name passed the scan in both the hook
+  and CI. The extension allowlist is removed: every tracked file's staged blob
+  is now scanned as text. NUL bytes are still stripped (so they can't hide
+  content — a NUL-based "binary, skip" sniff was deliberately rejected because
+  it would reopen that bypass), and the existing `MAX_LINE_LENGTH` line-drop
+  keeps a minified/binary blob from hanging the scan. New harness fixtures
+  cover `secret.png`, `secret in package-lock.json`, and NUL+binary-extension.
+- **`::error` annotation injection (audit LOW).** All four `lib/check-*`
+  scripts now percent-encode the `file=` property (`%`, CR, LF, `:`, `,`) and
+  the message body (`%`, CR, LF) per GitHub's workflow-command rules, so a
+  crafted filename or description can't forge or truncate a CI annotation.
+
+### Documented
+- **`lint.yml.template` guardrails job: two inherent limitations** now spelled
+  out in-file — it runs check scripts/configs from the PR head (defense in
+  depth, not a trust boundary against hostile forks; pair with branch
+  protection / scan from the base ref), and it scans the committed blob, so a
+  Git-LFS pointer is scanned rather than the LFS content (add `lfs: true` if
+  you keep scannable text in LFS).
+
+### Fixed
+- **`README.md` stale claims.** The size check is the staged blob's line count
+  (`git show :0:<path>`), not `wc -l`; the secret scan covers *every* tracked
+  file (no extension allowlist), not a vague "all files"; and the
+  hook-vs-CI file-scope asymmetry (changed-only vs all-tracked) is now noted
+  for all four checks, not just size.
+
 ## [v0.5.2] — 2026-05-25
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -183,9 +183,9 @@ Commit + CI-breaking (pre-commit hook + `lint.yml`):
 |---|---|
 | `print()`, `breakpoint()`, `pdb.set_trace()`, `ipdb.set_trace()` in Python files | regex |
 | `console.log` / `debugger` / `alert` in TS/JS | regex |
-| File size > 500 lines | `wc -l` per staged file |
+| File size > 500 lines | line count of the staged blob (`git show :0:<path>`, counting a final line with no trailing newline) |
 | TODO/FIXME without ticket ref | regex (opt-in; commented in template) |
-| Secret / credential leaks (AWS keys, GitHub tokens, private keys, URLs with embedded credentials, hardcoded password=/token= assignments) | regex (case-insensitive, all files) |
+| Secret / credential leaks (AWS keys, GitHub tokens, private keys, URLs with embedded credentials, hardcoded password=/token= assignments) | regex (case-insensitive). Scans **every** tracked file's staged blob as text (no extension allowlist, so renaming a payload can't skip it); NUL bytes are stripped so they can't hide content, and a single line longer than `MAX_LINE_LENGTH` (50000) is dropped so a minified/binary blob can't hang the scan |
 | Committed `.env` / `*.pem` / SSH private keys (`id_rsa`, `id_ed25519`, `id_ecdsa`, `id_dsa`) | filename check (`.env.example` / `.env.sample` / `.env.template` allowed) |
 
 ### Per-line escape valve
@@ -220,7 +220,7 @@ git commit -m "should be rejected"
 - **`.forbidden-patterns/*.txt`** — simple `regex|description` lines. Add deprecated import paths, old service names, etc. Lines starting with `#` are comments; an opt-in TODO/FIXME pattern is pre-seeded as a comment.
 - **`ruff.toml`** — enables `E,F,I,W,B,UP,SIM,PTH,ANN,BLE,C90,PL,PT,RUF`. Trim `ignore = [...]` if a rule fights your style.
 - **Pre-commit hook** — `MAX_LINES=500` by default. Override per-invocation: `MAX_LINES=800 git commit`. Edit the hook to change permanently. The CI workflow reads the same env var.
-- **Adopting on an existing codebase** — the CI size check runs against *all* tracked source files, not just changed ones. If the repo already has files over 500 lines, the first PR will fail. Either extract the offenders first (preferred — this is the debt the rule is meant to catch) or set `MAX_LINES` higher temporarily in both the hook and CI, then ratchet it down as you refactor.
+- **Adopting on an existing codebase** — the local hook scans only the files in a given commit, but the CI job scans *all* tracked files (size, patterns, filenames, and secrets alike), not just changed ones. So the first PR after adoption surfaces pre-existing debt: a file already over 500 lines, an existing `print()`, or a secret already in history all fail in CI even if the PR didn't touch them. For the size case, extract the offenders first (preferred — this is the debt the rule is meant to catch) or set `MAX_LINES` higher temporarily in both the hook and CI, then ratchet it down as you refactor.
 
 ## Update & uninstall
 

--- a/SECURITY_AUDIT.md
+++ b/SECURITY_AUDIT.md
@@ -64,6 +64,15 @@ Locked in with harness fixtures #27–30 (the #30 `--ci` test also begins closin
 
 34/34 tests pass; shellcheck clean. Remaining HIGH from the audit: rename-to-skip-listed-extension. Still open: fork-PR trusted-ref guardrails, Git-LFS blob scanning, `::error` annotation escaping, broader `--ci`/per-pattern fixtures, and the gitleaks-layer decision for generic unquoted secrets.
 
+### Update 2026-06-10 — clean-fix batch (branch `fix/audit-batch-clean-fixes`)
+
+- HIGH `Renaming a secret to a skip-listed extension smuggles it past the scan` → `check-secrets` extension allowlist **removed**; every tracked file's staged blob is scanned as text. A NUL "binary, skip" sniff was deliberately rejected (it reopens the NUL bypass); large blobs are still handled by the `MAX_LINE_LENGTH` line-drop. `check-size`'s skip is intentionally kept (quality nudge, not a security boundary). Fixtures #32–34.
+- LOW `::error annotation fields echoed unescaped (annotation / file-target spoofing)` → all four `lib/check-*` scripts now percent-encode the `file=` property (`%`,CR,LF,`:`,`,`) and message body (`%`,CR,LF) per GitHub workflow-command rules. Fixture #35.
+- MEDIUM `fork-PR-from-head guardrail` and `Git-LFS pointer scanning` → **documented** in `lint.yml.template` as inherent limitations with consumer hardening guidance (base-ref scan / branch protection; `lfs: true`), rather than shipping an untested workflow restructure.
+- Docs: README `wc -l`, "all files", and file-scope-asymmetry claims corrected.
+
+39/39 tests pass (the actionlint workflow-validation case now runs); shellcheck clean. Still open: broader uninstall/`--force`/`--all` fixtures, the `pull_request` hardening/runner notes, and the **gitleaks-layer decision** for generic unquoted secrets (needs a design call, not code).
+
 **Status legend:** ✅ Fixed on this branch · 🟡 Partially addressed · ⬜ Open (tracked below).
 
 ## 🔴 Critical
@@ -110,7 +119,19 @@ Locked in with harness fixtures #27–30 (the #30 `--ci` test also begins closin
 - **Recommendation:** Require the marker as a strict end-of-line comment token (e.g. match `(#\|//)\s*scaffold-allow\b` at line end only), and consider NOT honoring scaffold-allow for the secrets check at all (or require an explicit secret-specific token), so a code-style opt-out cannot whitelist credentials. Document th…
 - **Verifier note:** Finder's framing is essentially accurate. One nuance: the claim that 'even benign-looking lines' smuggle credentials slightly overstates accidental risk — 'scaffold-allow' is a project-specific litera…
 
-### ⬜ Open · `high` — Renaming a secret/oversized payload to a skip-listed extension or path smuggles it past both checks
+### ✅ Fixed · `high` — Renaming a secret/oversized payload to a skip-listed extension or path smuggles it past both checks
+
+> **Fixed (secret scan):** `check-secrets` no longer skips by extension — every
+> tracked file's staged blob is scanned as text. A NUL-byte "binary, skip"
+> sniff was deliberately rejected (it would reopen the NUL bypass closed by the
+> dangling-symlink/NUL findings); large minified/binary blobs are instead
+> dropped by the existing `MAX_LINE_LENGTH` cap. Harness fixtures #32–34 cover
+> `secret.png`, `secret in package-lock.json`, and NUL+binary-extension.
+> **Note (size scan):** `check-size`'s extension skip is intentionally retained
+> — it's a code-modularity nudge, not a security boundary, and content-scanning
+> data files (`.csv`/`.sql`/`.json`) for line count would false-positive on
+> legitimate large data. Renaming code to dodge the line cap has no security
+> impact.
 
 - **Location:** `githooks/lib/check-secrets.template:25-34`  ·  *(reproduced: yes, confidence: high, dimension: scanner-bypass)*
 - **What:** check-secrets skips a large extension list (*.svg,*.png,*.jpg,*.lock,*.zip,... and package-lock.json/pnpm-lock.yaml/go.sum) and the entire `.forbidden-patterns/*` directory. check-size (check-size.template line 27-30) skips *.md,*.json,*.toml,*.yaml,*.yml,*.lock,*.txt,*.csv,*.sql and image types. These are name-based, not content-based, so renaming a text pa…
@@ -168,7 +189,16 @@ Locked in with harness fixtures #27–30 (the #30 `--ci` test also begins closin
 
 ## 🟡 Medium
 
-### ⬜ Open · `medium` — Distributed guardrails job runs check scripts and pattern lists from PR head — a fork PR can neuter the server-side guardrail
+### 🟡 Documented · `medium` — Distributed guardrails job runs check scripts and pattern lists from PR head — a fork PR can neuter the server-side guardrail
+
+> **Documented, not structurally changed.** This is inherent to a
+> `pull_request` workflow running detectors from PR head (the verifier note
+> below confirms it grants no new code-exec beyond the existing python/frontend
+> jobs). The `guardrails` job in `lint.yml.template` now states this in-file:
+> it is defense in depth, not a trust boundary against a hostile fork — pair it
+> with branch protection / required review, and for untrusted forks gate merges
+> on a scan run from the base ref. A full base-ref-checkout restructure is left
+> as a documented consumer option rather than shipped untested.
 
 - **Location:** `.github/workflows/lint.yml.template:60-77`  ·  *(reproduced: yes, confidence: high, dimension: supply-chain-ci)*
 - **What:** The `guardrails` job is the server-side mirror of the pre-commit hook. It does `chmod +x .githooks/lib/check-*` and runs `.githooks/lib/check-{size,patterns,filenames,secrets}` (lines 68-76) — but these scripts, and the `.forbidden-patterns/*.txt` config files they read, are taken from the PR HEAD (the checked-out merge ref). On a `pull_request` event the sa…
@@ -176,7 +206,15 @@ Locked in with harness fixtures #27–30 (the #30 `--ci` test also begins closin
 - **Recommendation:** Run the check scripts and pattern configs from a TRUSTED ref (e.g., checkout the base branch's .githooks/.forbidden-patterns, or pin/vendor them), then scan the PR's file contents with the trusted scanner. Alternatively gate guardrails behind a separate workflow that fetches the scanner from the bas…
 - **Verifier note:** This is not a code bug but an inherent property of `pull_request` workflows running detectors from PR head; it grants no new code-exec beyond the existing python/frontend jobs (which already run ruff/…
 
-### ⬜ Open · `medium` — CI guardrails scan reads the working tree by path, so a Git-LFS (or clean/smudge-filter) consumer repo can ship a secret in the committed blob while CI scans only the LFS pointer text — server-side-only bypass of the unskippable backstop
+### 🟡 Documented · `medium` — CI guardrails scan reads the working tree by path, so a Git-LFS (or clean/smudge-filter) consumer repo can ship a secret in the committed blob while CI scans only the LFS pointer text — server-side-only bypass of the unskippable backstop
+
+> **Documented, not structurally changed.** The scanners read the committed
+> blob (`git show :0:<path>`), which for an LFS-tracked file is the pointer,
+> not the smudged content — so LFS-stored text isn't meaningfully scanned. A
+> generic fix means trusting the smudge filter (fetch LFS, scan the working
+> tree) which is fragile and LFS-config-specific. The `guardrails` job now
+> documents the limitation and points consumers at `lfs: true` + working-tree
+> scanning if they keep scannable text in LFS.
 
 - **Location:** `.github/workflows/lint.yml.template:65-77`  ·  *(reproduced: yes, confidence: high, dimension: completeness-probe)*
 - **What:** Both check-secrets and check-patterns scan the WORKING TREE by path: they `[ -f "$f" ]`-test a path from `git ls-files` and then `grep -nE -- "$pat" "$file"`. They never read the committed blob (`git show :file` / `git cat-file -p HEAD:file` / `git grep --cached`). Git's content-filtering layer (gitattributes `filter=` clean/smudge, of which Git-LFS is the c…
@@ -279,10 +317,10 @@ Locked in with harness fixtures #27–30 (the #30 `--ci` test also begins closin
 | ⬜ Open | Distributed lint.yml frontend job executes attacker-controlled lifecycle scripts and eslint config from fork P… | `lint.yml.template:41-58` |
 | ⬜ Open | All workflows trigger on bare `pull_request` with no concurrency control or runner hardening notes | `lint.yml.template:8-14` |
 | ⬜ Open | actionlint binary downloaded via curl\|bash from a mutable git tag with no checksum/signature verification | `test.yml:33-36` |
-| ⬜ Open | README claims size check uses `wc -l`, but code uses `grep -c ''` (stale doc, contradicts CHANGELOG) | `README.md:186` |
-| ⬜ Open | Secrets-scan docs overstate coverage: README says 'all files', but lockfiles/binaries are skipped | `README.md:188` |
+| ✅ Fixed | README claims size check uses `wc -l`, but code uses `grep -c ''` (stale doc, contradicts CHANGELOG) | `README.md:186` |
+| ✅ Fixed | Secrets-scan docs overstate coverage: README says 'all files', but lockfiles/binaries are skipped (now every tracked file IS scanned; doc corrected) | `README.md:188` |
 | ⬜ Open | 'Hook and CI can never drift' claim is only true for the 4 lib checks; ruff/eslint are unshared, unpinned, and… | `README.md:6,39,104` |
-| ⬜ Open | File-scope asymmetry (hook=changed-only, CI=all-tracked) documented only for size, not for secrets/patterns/fi… | `README.md:223` |
+| ✅ Fixed | File-scope asymmetry (hook=changed-only, CI=all-tracked) documented only for size, not for secrets/patterns/fi… | `README.md:223` |
 | ⬜ Open | No CR-stripping, no .gitattributes, and no line-ending guidance for distributed config files | `README.md:1` |
 | ⬜ Open | print/console.log/alert/os.path.join patterns fire inside comments and string literals (false positives); os.p… | `backend.txt.template:7-8` |
 | ⬜ Open | AWS key coverage limited to AKIA; temporary (ASIA) and other AWS key-ID prefixes are not detected, contrary to… | `secrets.txt.template:13` |
@@ -292,8 +330,8 @@ Locked in with harness fixtures #27–30 (the #30 `--ci` test also begins closin
 | ✅ Fixed | `printf \| head -3 \| sed` aborts check-patterns/check-secrets via SIGPIPE under pipefail (exit 141) | `check-patterns.template:92` |
 | ⬜ Open | Pattern-validation oracle drops functional patterns on any stderr (warnings) and is grep-implementation/locale… | `check-patterns.template:48-56` |
 | ✅ Fixed | Combined-ERE prefilter conflates grep error (exit 2) with no-match, skipping the file (fail-open control flow) | `check-patterns.template:81` |
-| ⬜ Open | Pattern-config description field is echoed unescaped into ::error workflow command (annotation spoofing in CI) | `check-patterns.template:85-89` |
-| ⬜ Open | Committed filename containing `::` corrupts the file= property of every ::error annotation (file-target spoofi… | `check-patterns.template:89` |
+| ✅ Fixed | Pattern-config description field is echoed unescaped into ::error workflow command (annotation spoofing in CI) — all four check-* scripts now percent-encode message + file= per GitHub workflow-command rules | `check-patterns.template:85-89` |
+| ✅ Fixed | Committed filename containing `::` corrupts the file= property of every ::error annotation (file-target spoofing) — file= now percent-encodes `%`,CR,LF,`:`,`,` (fixture #35) | `check-patterns.template:89` |
 | ✅ Fixed | Scan reads working-tree/index via filesystem, not the git blob — divergence between scanned bytes and committe… | `check-secrets.template:78-79` |
 | ⬜ Open | scaffold-allow exempts an entire physical line — one marker hides multiple secrets on minified/single-line fil… | `check-secrets.template:83` |
 | ⬜ Open | Case-insensitive secrets scan makes prefix tokens (AKIA, AIza, sk-, BEGIN PRIVATE KEY) match lowercase, enabli… | `check-secrets.template:79` |

--- a/githooks/lib/check-filenames.template
+++ b/githooks/lib/check-filenames.template
@@ -13,10 +13,20 @@ set -euo pipefail
 CI_MODE=0
 [ "${1:-}" = "--ci" ] && CI_MODE=1
 
+# Escape a value for a GitHub workflow command (see check-secrets): %, CR, LF
+# always; : and , for property values (file=). A filename is attacker-controlled
+# in a PR, so escaping it stops a crafted name forging/truncating the annotation.
+ghesc() {
+  local s=$2
+  s=${s//'%'/%25}; s=${s//$'\r'/%0D}; s=${s//$'\n'/%0A}
+  if [ "$1" = prop ]; then s=${s//:/%3A}; s=${s//,/%2C}; fi
+  printf '%s' "$s"
+}
+
 emit() {
   local file=$1 message=$2
   if [ "$CI_MODE" -eq 1 ]; then
-    echo "::error file=$file::$message"
+    echo "::error file=$(ghesc prop "$file")::$(ghesc data "$message")"
   else
     echo "✗ $file: $message"
   fi

--- a/githooks/lib/check-patterns.template
+++ b/githooks/lib/check-patterns.template
@@ -21,6 +21,16 @@ set -euo pipefail
 CI_MODE=0
 [ "${1:-}" = "--ci" ] && CI_MODE=1
 
+# Escape a value for a GitHub workflow command (see check-secrets). `data` mode
+# escapes %, CR, LF; `prop` mode (file=) additionally escapes : and , so a
+# crafted filename/description can't forge or truncate the annotation.
+ghesc() {
+  local s=$2
+  s=${s//'%'/%25}; s=${s//$'\r'/%0D}; s=${s//$'\n'/%0A}
+  if [ "$1" = prop ]; then s=${s//:/%3A}; s=${s//,/%2C}; fi
+  printf '%s' "$s"
+}
+
 # Cap the maximum scanned LINE length (see check-secrets): one very long line
 # can make the combined ERE hang the hook/CI. Over-long lines are dropped with
 # a warning. Linear awk length check; the ERE on a long line is not linear.
@@ -136,7 +146,7 @@ scan() {
       m=$(grep -anE -- "$pat" <<<"$content" | grep -ivE '(#|//|/\*|<!--|--)[[:space:]]*scaffold-allow' || true)
       [ -n "$m" ] || continue
       if [ "$CI_MODE" -eq 1 ]; then
-        echo "::error file=$file::$desc"
+        echo "::error file=$(ghesc prop "$file")::$(ghesc data "$desc")"
       else
         echo "✗ $file: $desc"
         printf '%s\n' "$m" | head -3 | sed 's/^/    /' || true

--- a/githooks/lib/check-secrets.template
+++ b/githooks/lib/check-secrets.template
@@ -29,6 +29,18 @@ set -euo pipefail
 CI_MODE=0
 [ "${1:-}" = "--ci" ] && CI_MODE=1
 
+# Escape a value for a GitHub workflow command. `data` mode (message body)
+# escapes %, CR, LF; `prop` mode (a property value like file=) additionally
+# escapes : and , — otherwise a filename/description containing `::`, a comma,
+# or a newline could forge or truncate the annotation. % must be replaced first.
+# https://docs.github.com/actions/reference/workflow-commands-for-github-actions
+ghesc() {
+  local s=$2
+  s=${s//'%'/%25}; s=${s//$'\r'/%0D}; s=${s//$'\n'/%0A}
+  if [ "$1" = prop ]; then s=${s//:/%3A}; s=${s//,/%2C}; fi
+  printf '%s' "$s"
+}
+
 # Cap the maximum scanned LINE length. One pathologically long line (a minified
 # bundle, a base64 data: URI, a source map) can make the combined ERE blow up
 # superlinearly and hang the hook and CI (a denial of service). Lines longer
@@ -56,15 +68,17 @@ fi
 FILES=()
 while IFS= read -r -d '' f; do
   [ -z "$f" ] && continue
+  # Skip NOTHING by extension. The old skip list (*.png, *.zip, package-lock.json,
+  # …) let an attacker rename a secret-bearing text file to a skipped name and
+  # smuggle it past the scan. We also do NOT sniff for binaries by NUL byte: a
+  # NUL is attacker-controlled, so "skip blobs with a NUL" is the very evasion
+  # the dangling-symlink / NUL-byte fixes closed (inject one NUL → classified
+  # binary → skipped). Instead every blob is scanned as text — $() strips NULs
+  # and grep runs -a/--text — and a genuine large binary is dropped harmlessly
+  # by the per-line length cap below (a no-newline blob is one over-long line).
+  # Only the pattern-config dir is skipped (scanning it would match the regexes
+  # it stores).
   case "$f" in
-    # Images / docs
-    *.svg|*.png|*.jpg|*.jpeg|*.gif|*.ico|*.pdf) continue ;;
-    # Archives / fonts / media
-    *.lock|*.zip|*.tar|*.gz|*.bz2|*.xz|*.7z|*.woff|*.woff2|*.ttf|*.otf|*.eot|*.mp4|*.mov|*.mp3|*.wav) continue ;;
-    # Compiled / binary
-    *.exe|*.dll|*.so|*.dylib|*.bin|*.class|*.pyc|*.pyo|*.o|*.a|*.parquet) continue ;;
-    # Lockfiles whose extension isn't `.lock` (those are caught above)
-    package-lock.json|pnpm-lock.yaml|go.sum) continue ;;
     .forbidden-patterns/*) continue ;;
   esac
   FILES+=("$f")
@@ -153,7 +167,7 @@ for file in "${FILES[@]}"; do
     m=$(grep -aniE -- "$pat" <<<"$content" | grep -ivE '(#|//|/\*|<!--|--)[[:space:]]*scaffold-allow' || true)
     [ -n "$m" ] || continue
     if [ "$CI_MODE" -eq 1 ]; then
-      echo "::error file=$file::$desc"
+      echo "::error file=$(ghesc prop "$file")::$(ghesc data "$desc")"
     else
       echo "✗ $file: $desc"
       printf '%s\n' "$m" | head -3 | sed 's/^/    /' || true

--- a/githooks/lib/check-size.template
+++ b/githooks/lib/check-size.template
@@ -23,6 +23,17 @@ esac
 CI_MODE=0
 [ "${1:-}" = "--ci" ] && CI_MODE=1
 
+# Escape a value for a GitHub workflow command (see check-secrets). `prop` mode
+# (file=) escapes %, CR, LF, : and , so a crafted filename can't forge or
+# truncate the annotation. The message body here is fixed text, so only file=
+# needs escaping.
+ghesc() {
+  local s=$2
+  s=${s//'%'/%25}; s=${s//$'\r'/%0D}; s=${s//$'\n'/%0A}
+  if [ "$1" = prop ]; then s=${s//:/%3A}; s=${s//,/%2C}; fi
+  printf '%s' "$s"
+}
+
 FAILED=0
 while IFS= read -r -d '' file; do
   [ -z "$file" ] && continue
@@ -36,7 +47,7 @@ while IFS= read -r -d '' file; do
   lines=$(git show ":0:$file" 2>/dev/null | grep -ac '' || true)
   if [ "$lines" -gt "$MAX_LINES" ]; then
     if [ "$CI_MODE" -eq 1 ]; then
-      echo "::error file=$file::$lines lines (max $MAX_LINES) — extract a module"
+      echo "::error file=$(ghesc prop "$file")::$lines lines (max $MAX_LINES) — extract a module"
     else
       echo "✗ $file: $lines lines (max $MAX_LINES) — extract a module"
     fi

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -378,6 +378,41 @@ else
 fi
 reset_repo
 
+# 32. Rename bypass: a secret-bearing TEXT file given a binary extension is
+#     still scanned. Binary is decided by CONTENT (a NUL byte), not by the name,
+#     so .png/.zip/etc. no longer smuggle a plaintext secret past the scan.
+echo "AKIA""IOSFODNN7EXAMPLE" >logo.png
+git add logo.png
+assert_rejects "secret renamed to .png is still scanned" "AWS access key"
+
+# 33. Same rename bypass via a lockfile name the old extension list skipped.
+echo "AKIA""IOSFODNN7EXAMPLE" >package-lock.json
+git add package-lock.json
+assert_rejects "secret in package-lock.json is still scanned" "AWS access key"
+
+# 34. Defense in depth: a secret in a file with BOTH a binary extension AND a
+#     NUL byte is still caught. We skip nothing by name, and a NUL never marks a
+#     blob "binary, skip" (that would reopen the NUL-byte bypass) — so combining
+#     the two evasions still fails. \000 writes the NUL; AKIA literal split.
+printf 'AKIA''IOSFODNN7EXAMPLE\000trailing\n' >payload.png
+git add payload.png
+assert_rejects "secret with NUL + binary extension is still scanned" "AWS access key"
+
+# 35. --ci annotation escaping: a filename containing ':' and ',' is
+#     percent-encoded in the ::error property (%3A / %2C) so a crafted name
+#     can't forge or truncate the annotation. Exercises the --ci path directly.
+echo "AKIA""IOSFODNN7EXAMPLE" >'weird:name,x.txt'
+git add 'weird:name,x.txt'
+printf '%s\0' 'weird:name,x.txt' | .githooks/lib/check-secrets --ci >"$HOOK_OUT" 2>&1 || true
+if grep -qF 'file=weird%3Aname%2Cx.txt' "$HOOK_OUT"; then
+  echo "  ✓ --ci ::error escapes : and , in the filename property"
+  PASS=$((PASS + 1))
+else
+  echo "  ✗ --ci ::error escaping — expected percent-encoded filename, got:"
+  sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+reset_repo
+
 echo ""
 echo "Result: $PASS passed, $FAIL failed"
 exit $FAIL


### PR DESCRIPTION
Batch of clean audit fixes from `SECURITY_AUDIT.md` (update 2026-06-10). All items are clearly-correct and low-risk; the two genuinely design-level findings are *documented*, not half-fixed.

## Fixes

### `check-secrets`: rename-to-skipped-extension secret bypass (audit **HIGH** — the last open HIGH)
The scanner skipped files by extension (`*.png`, `*.zip`, `package-lock.json`, …), so a plaintext secret renamed to a skipped name passed **both** the hook and CI. The extension allowlist is removed — every tracked file's staged blob is now scanned as text.

A NUL-byte "binary, skip" sniff (the audit's literal recommendation) was **deliberately rejected**: a NUL is attacker-controlled, so skipping on it would reopen the NUL bypass the symlink/NUL fixes (#7) closed. Large minified/binary blobs are still handled by the existing `MAX_LINE_LENGTH` line-drop. `check-size` keeps its extension skip on purpose — it's a modularity nudge, not a security boundary, and line-counting data files would false-positive.

### `::error` annotation injection (audit **LOW**)
All four `lib/check-*` scripts now percent-encode the `file=` property (`%`, CR, LF, `:`, `,`) and the message body (`%`, CR, LF) per GitHub's workflow-command rules, so a crafted filename/description can't forge or truncate a CI annotation.

### `lint.yml.template`: two inherent limitations documented (audit MEDIUM ×2 → 🟡 Documented)
- runs check scripts/configs from the **PR head** (defense in depth, not a fork trust boundary; pair with branch protection / base-ref scan)
- scans the **committed blob**, so a Git-LFS *pointer* is scanned, not the LFS content (`lfs: true` + working-tree scan if you keep scannable text in LFS)

Documented in-file rather than shipping an untested workflow restructure.

### Docs
- **README**: size check is the staged-blob line count (`git show :0:<path>`), not `wc -l`; secret scan covers **every** tracked file, not a vague "all files"; hook-vs-CI file-scope asymmetry noted for all four checks.
- **CHANGELOG**: `[Unreleased]` entry.
- **SECURITY_AUDIT.md**: per-finding statuses reconciled for everything above.

## Verification
- **39/39** harness tests pass under the GNU-grep shim (+5 new fixtures: `secret.png`, secret in `package-lock.json`, NUL+binary-extension, `::error` `:`/`,` escaping; the actionlint workflow-validation case now runs)
- **shellcheck `-S info`** clean · **actionlint** clean

## Still open (not in this PR)
Broader uninstall/`--force`/`--all` fixtures, `pull_request` runner hardening, and the **gitleaks/trufflehog backstop** decision for generic unquoted secrets (needs a design call, not code).