### PR TITLE
feat: broaden TypeScript enforcement + add hygiene/agent-runtime/supply-chain layers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# Dependabot keeps the SHA-pinned GitHub Actions in this repo's workflows fresh.
+# SHA pins (supply-chain hardening) don't auto-update, so without this they rot;
+# Dependabot understands a `uses: owner/action@<sha>  # vX.Y.Z` pin natively and
+# bumps both the SHA and the trailing version comment in one grouped PR.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns: ["*"]
+    commit-message:
+      prefix: ci

--- a/.github/dependabot.yml.template
+++ b/.github/dependabot.yml.template
@@ -1,0 +1,22 @@
+# Copy to your project as `.github/dependabot.yml`. Keeps the SHA-pinned GitHub
+# Actions in your workflows (lint.yml, gitleaks.yml) fresh — SHA pins are a
+# supply-chain best practice but don't auto-update, so without this they rot.
+# Dependabot reads a `uses: owner/action@<sha>  # vX.Y.Z` pin natively and bumps
+# the SHA + the trailing version comment together in one grouped weekly PR.
+#
+# Generates PRs — if you don't want that, don't install this file (it's the one
+# piece of the scaffold that adds outbound automation). Renovate users: enable
+# the `helpers:pinGitHubActionDigests` preset for the equivalent.
+#
+# Add `npm` / `pip` ecosystem blocks below if you also want dependency PRs.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns: ["*"]
+    commit-message:
+      prefix: ci

--- a/.github/workflows/gitleaks.yml.template
+++ b/.github/workflows/gitleaks.yml.template
@@ -1,0 +1,43 @@
+name: gitleaks
+
+# OPT-IN secret-scanning backstop. Copy to your project as
+# `.github/workflows/gitleaks.yml`. NOT installed by install.sh — it adds a
+# third-party action dependency, so opt in deliberately.
+#
+# Why this exists alongside check-secrets:
+#   The scaffold's `check-secrets` is a NARROW, offline regex gate — it catches
+#   the specific token shapes listed in .forbidden-patterns/secrets.txt and
+#   nothing else, by design (it is a commit-time hygiene tool, not a security
+#   boundary). gitleaks is the BROAD backstop: ~150 maintained provider rules
+#   plus entropy scoring, so it flags high-entropy credentials and provider
+#   tokens the hand-written list can't enumerate. Run both — the regex gate at
+#   commit time for instant feedback, gitleaks in CI for depth.
+#
+# Actions are pinned to a full commit SHA (supply-chain hardening); the trailing
+# comment records the human-readable tag. Bump via Dependabot (see
+# dependabot.yml.template).
+
+on:
+  pull_request:
+  push:
+    branches: [main, master]
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          # Full history so gitleaks scans every commit on a push, not just the
+          # tip. On pull_request the action scans the PR's commit range.
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e  # v3.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # gitleaks-action is free for personal accounts and public repos. For
+          # an ORGANIZATION it requires a (free) license key — set it as a repo
+          # secret and uncomment:
+          # GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}

--- a/.github/workflows/lint.yml.template
+++ b/.github/workflows/lint.yml.template
@@ -52,8 +52,20 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: "20"
-      - if: steps.detect.outputs.present == 'true'
-        run: npm ci || npm install
+      - name: Install dependencies
+        if: steps.detect.outputs.present == 'true'
+        # Frozen-lockfile install when a lockfile exists (reproducible, and it
+        # hard-fails on lockfile drift instead of silently mutating it like
+        # `npm install`). Falls back to `npm install` only when there's no
+        # lockfile, so a lockfile-less repo still works. pnpm/yarn equivalents:
+        # `pnpm install --frozen-lockfile` / `yarn install --immutable`.
+        run: |
+          if [ -f package-lock.json ] || [ -f npm-shrinkwrap.json ]; then
+            npm ci
+          else
+            echo "no package-lock.json — using npm install (add a lockfile for reproducible CI)"
+            npm install
+          fi
       - if: steps.detect.outputs.present == 'true'
         run: npx eslint .
       - name: Type-check (tsc --noEmit)
@@ -110,5 +122,6 @@ jobs:
           .githooks/lib/check-patterns  --ci <"$STAGED_LIST" || FAILED=1
           .githooks/lib/check-filenames --ci <"$STAGED_LIST" || FAILED=1
           .githooks/lib/check-secrets   --ci <"$STAGED_LIST" || FAILED=1
+          .githooks/lib/check-hygiene   --ci <"$STAGED_LIST" || FAILED=1
           rm -f "$STAGED_LIST"
           exit $FAILED

--- a/.github/workflows/lint.yml.template
+++ b/.github/workflows/lint.yml.template
@@ -56,6 +56,18 @@ jobs:
         run: npm ci || npm install
       - if: steps.detect.outputs.present == 'true'
         run: npx eslint .
+      - name: Type-check (tsc --noEmit)
+        if: steps.detect.outputs.present == 'true'
+        # Project-wide type-check, guarded: only runs when a tsconfig.json is
+        # present AND TypeScript is installed — mirrors the pre-commit hook so
+        # the two layers stay in lockstep. coding-rules.md rule 9 mandates a
+        # type-checker; this is where it runs server-side.
+        run: |
+          if [ -f tsconfig.json ] && npx --no-install tsc --version >/dev/null 2>&1; then
+            npx --no-install tsc --noEmit
+          else
+            echo "tsconfig.json or typescript missing — skipping tsc type-check"
+          fi
 
   guardrails:
     # File size, forbidden patterns, blocked filenames, secret scan —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,35 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- **TypeScript enforcement, broadened (P0).** The shipped `eslint.config.js`
+  now extends typescript-eslint's **`strictTypeChecked`** tier with
+  `projectService` auto-discovery, so type-aware rules actually fire. Pinned
+  `no-floating-promises` + `no-misused-promises` (the #1 silent-async bug),
+  added import sorting / unused-import removal (`import-x/order`,
+  `unused-imports`) as parity with `ruff`'s `I` / `F401`, and shipped an
+  opt-in `react-hooks` block (rules-of-hooks + exhaustive-deps). Plain JS and
+  test files get `disableTypeChecked` / loosened overrides. Header documents an
+  escape hatch back to `strict` for projects without a `tsconfig.json`.
+- **`tsc --noEmit` wired into both layers.** The pre-commit hook and the CI
+  `lint.yml` frontend job now run a project-wide TypeScript type-check, guarded
+  on `tsconfig.json` presence + TypeScript being installed (silently skipped
+  otherwise, like the linters). Resolves the contradiction where
+  `coding-rules.md` mandated a type-checker that ran nowhere.
+- **Broader `frontend.txt` deny patterns.** Focused tests (`.only`, which
+  silently skips the suite), `@ts-ignore` / `@ts-nocheck`,
+  `dangerouslySetInnerHTML` (XSS), and hardcoded `localhost`/`127.0.0.1` URLs.
+  New harness fixtures cover each, plus negatives proving `console.warn` and an
+  ordinary `it(...)` test still pass. Opt-in commented patterns added for
+  `eval`/`new Function` and an auth-bypass-flag guard.
+
+### Fixed
+- **Docs/enforcement reconciliation.** `coding-rules.md` rule 6 now covers TS
+  floating-promise discipline and rule 9 describes what actually runs at commit
+  time vs CI; the README "What the tooling enforces" matrix gains rows for
+  type-aware async rules, `tsc`, the new frontend patterns, and ESLint import
+  hygiene.
+
 ### Security
 - **Rename-to-skipped-extension secret bypass (audit HIGH).** `check-secrets`
   skipped files by extension (`*.png`, `*.zip`, `package-lock.json`, …), so a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,34 @@ versioning follows [SemVer](https://semver.org/).
   New harness fixtures cover each, plus negatives proving `console.warn` and an
   ordinary `it(...)` test still pass. Opt-in commented patterns added for
   `eval`/`new Function` and an auth-bypass-flag guard.
+- **New `check-hygiene` guard (hook + CI).** A fifth `lib/check-*` script that
+  flags merge-conflict markers left in a staged blob (`<<<<<<<` / `|||||||` /
+  `>>>>>>>`, but not a bare `=======` heading underline) and case-only filename
+  collisions that corrupt case-insensitive checkouts (macOS/Windows). bash-3.2
+  safe, fail-closed, same NUL-safe blob scan and `scaffold-allow` semantics as
+  the other checks. +3 fixtures incl. a negative for reST underlines.
+- **Agent-runtime guardrails — the deferred "layer three" (opt-in,
+  `install.sh --claude`).** Ships a `.claude/settings.json` deny-list (the agent
+  can't read `.env` / `*.pem` / `*.key` / `~/.ssh` / `~/.aws` or run a few
+  catastrophic `rm -rf` commands) plus a `PreToolUse` hook
+  (`.githooks/lib/agent-precheck`) that scans Write/Edit/Bash content against the
+  same `.forbidden-patterns/secrets.txt` the commit-time scanner uses — blocking
+  a hardcoded secret the moment the agent writes it. Needs `jq`; fails open
+  without it (commit + CI remain the fail-closed backstops). +3 fixtures.
+- **Conventional-Commits `commit-msg` hook (opt-in, `install.sh --commit-msg`).**
+  Rejects subjects that don't match `type(scope): description`; merge / revert /
+  fixup commits exempt. BSD-grep safe, zero dependencies. +3 fixtures.
+- **gitleaks CI backstop template** (`.github/workflows/gitleaks.yml.template`,
+  not auto-installed). SHA-pinned broad secret scanner as a separate CI job — the
+  entropy-based complement to the narrow regex `check-secrets` gate.
+- **Dependabot** (`.github/dependabot.yml` + consumer template, installed by
+  default). Weekly grouped bumps of the SHA-pinned GitHub Actions so the pins
+  don't rot.
+
+### Changed
+- **CI uses a frozen-lockfile install.** The frontend job runs `npm ci` when a
+  lockfile is present (hard-failing on lockfile drift instead of silently
+  mutating it) and falls back to `npm install` only when no lockfile exists.
 
 ### Fixed
 - **Docs/enforcement reconciliation.** `coding-rules.md` rule 6 now covers TS

--- a/README.md
+++ b/README.md
@@ -157,10 +157,18 @@ For parallel agent sessions, use `git worktree add ../proj-feat-x -b feat-x` so 
 ## What the tooling enforces
 
 The pre-commit hook now invokes `ruff` / `eslint` against staged files
-when their configs are present and the tool is on PATH — so most of the
-build-breaking rules below also fire at commit time, not only in CI.
-Linters are silently skipped if not installed; CI is the authoritative
-backstop.
+when their configs are present and the tool is on PATH — and, for
+TypeScript, `tsc --noEmit` when a `tsconfig.json` is present — so most of
+the build-breaking rules below also fire at commit time, not only in CI.
+Linters and the type-checker are silently skipped if not installed; CI is
+the authoritative backstop.
+
+The shipped `eslint.config.js` extends typescript-eslint's
+**`strictTypeChecked`** tier (type-aware linting), wires import sorting and
+unused-import removal as parity with `ruff`'s `I` / `F401`, and ships an
+opt-in `react-hooks` block — comparable to what create-t3-app / antfu's
+config give a TypeScript project out of the box. Run `npx eslint --inspect-config`
+to see the resolved rule set.
 
 Build-breaking (`ruff` / `eslint`, on every lint + commit + in CI):
 
@@ -174,8 +182,10 @@ Build-breaking (`ruff` / `eslint`, on every lint + commit + in CI):
 | Function size > 80 statements (Python) / 80 lines (TS/JS) | `ruff PLR0915` (`max-statements`), `eslint max-lines-per-function` |
 | Too many branches in a function | `ruff PLR0912` (`max-branches`) |
 | Line length > 100 | `ruff E501` |
-| Unsorted / unused imports | `ruff I`, `F401` |
+| Unsorted / unused imports | `ruff I`, `F401`; `eslint import-x/order`, `unused-imports/no-unused-imports` |
 | `any` in TypeScript without comment | `@typescript-eslint/no-explicit-any` |
+| Floating / misused promises (TS) | `@typescript-eslint/no-floating-promises`, `no-misused-promises` (type-aware) |
+| TypeScript type errors | `tsc --noEmit` (hook + CI, when `tsconfig.json` present) |
 
 Commit + CI-breaking (pre-commit hook + `lint.yml`):
 
@@ -183,6 +193,7 @@ Commit + CI-breaking (pre-commit hook + `lint.yml`):
 |---|---|
 | `print()`, `breakpoint()`, `pdb.set_trace()`, `ipdb.set_trace()` in Python files | regex |
 | `console.log` / `debugger` / `alert` in TS/JS | regex |
+| Focused tests (`.only`), `@ts-ignore` / `@ts-nocheck`, `dangerouslySetInnerHTML`, hardcoded `localhost`/`127.0.0.1` URLs | regex (frontend.txt) |
 | File size > 500 lines | line count of the staged blob (`git show :0:<path>`, counting a final line with no trailing newline) |
 | TODO/FIXME without ticket ref | regex (opt-in; commented in template) |
 | Secret / credential leaks (AWS keys, GitHub tokens, private keys, URLs with embedded credentials, hardcoded password=/token= assignments) | regex (case-insensitive). Scans **every** tracked file's staged blob as text (no extension allowlist, so renaming a payload can't skip it); NUL bytes are stripped so they can't hide content, and a single line longer than `MAX_LINE_LENGTH` (50000) is dropped so a minified/binary blob can't hang the scan |

--- a/README.md
+++ b/README.md
@@ -65,8 +65,12 @@ The script auto-detects Python (`pyproject.toml` / `requirements.txt` / `setup.p
 ./install.sh --both         # both stacks
 ./install.sh --force        # overwrite existing files
 ./install.sh --no-verify    # skip the post-install linter check
+./install.sh --claude       # also install opt-in Claude Code agent guardrails
+./install.sh --commit-msg   # also install the Conventional-Commits commit-msg hook
 ./install.sh --help         # show usage
 ```
+
+See [Opt-in layers](#opt-in-layers) for what `--claude` and `--commit-msg` add.
 
 At the end, `install.sh` verifies that `ruff` and/or `eslint` are installed and that their configs load. If either is missing, it prints the install command.
 
@@ -198,6 +202,8 @@ Commit + CI-breaking (pre-commit hook + `lint.yml`):
 | TODO/FIXME without ticket ref | regex (opt-in; commented in template) |
 | Secret / credential leaks (AWS keys, GitHub tokens, private keys, URLs with embedded credentials, hardcoded password=/token= assignments) | regex (case-insensitive). Scans **every** tracked file's staged blob as text (no extension allowlist, so renaming a payload can't skip it); NUL bytes are stripped so they can't hide content, and a single line longer than `MAX_LINE_LENGTH` (50000) is dropped so a minified/binary blob can't hang the scan |
 | Committed `.env` / `*.pem` / SSH private keys (`id_rsa`, `id_ed25519`, `id_ecdsa`, `id_dsa`) | filename check (`.env.example` / `.env.sample` / `.env.template` allowed) |
+| Merge-conflict markers (`<<<<<<<` / `\|\|\|\|\|\|\|` / `>>>>>>>`) left in a file | `check-hygiene` (staged-blob scan) |
+| Case-only filename collisions (`Readme.md` vs `README.md`) that break macOS/Windows checkouts | `check-hygiene` (path scan; CI checks all tracked paths) |
 
 ### Per-line escape valve
 
@@ -212,6 +218,39 @@ unaffected. See `forbidden-patterns/README.md` for examples.
 suppressing a guardrail.** Treat new markers like new `# noqa`s — confirm
 the suppression is justified before approving. Audit the full set with
 `git grep -i scaffold-allow`.
+
+## Opt-in layers
+
+Beyond the always-on hook + CI mirror, three extras are available. They're off
+by default so the scaffold stays minimal; turn them on per project.
+
+- **Agent-runtime guardrails (`install.sh --claude`).** The deferred "layer
+  three" — catching bad input *before* the agent writes it, not at commit time.
+  Installs a `.claude/settings.json` that denies the agent reading credential
+  files (`.env`, `*.pem`, `*.key`, `~/.ssh/**`, `~/.aws/**`, …) and a
+  `PreToolUse` hook (`.githooks/lib/agent-precheck`) that scans Write/Edit/Bash
+  content against the *same* `.forbidden-patterns/secrets.txt` the commit-time
+  scanner uses — one rule set across agent → commit → CI. Needs `jq` (fails open
+  without it). Works with Claude Code; the deny-list pattern ports to Cursor /
+  Gemini equivalents. See [`RECOMMENDATIONS.md`](./RECOMMENDATIONS.md).
+
+- **Conventional-Commits `commit-msg` hook (`install.sh --commit-msg`).**
+  Rejects commit subjects that don't match `type(scope): description` (merge /
+  revert / fixup commits exempt). Commit format is exactly the kind of
+  convention agents drift on across sessions. Zero dependencies.
+
+- **gitleaks CI backstop (`.github/workflows/gitleaks.yml.template`).** Copy it
+  in to add a broad, entropy-based secret scanner as a *separate* CI job. The
+  built-in `check-secrets` is a narrow offline regex gate (the specific token
+  shapes in `secrets.txt`); gitleaks' ~150 maintained rules catch provider
+  tokens the hand-written list can't enumerate. Not auto-installed — it adds a
+  third-party action dependency. Pinned to a commit SHA; bump via Dependabot.
+
+Two smaller hardening changes are **on by default**: `install.sh` now also
+drops a `.github/dependabot.yml` (weekly grouped bumps of the SHA-pinned
+Actions — delete it if you don't want the PRs), and the CI frontend job uses a
+frozen-lockfile install (`npm ci` when a lockfile exists, hard-failing on drift
+instead of silently mutating it).
 
 ## Verify it works
 

--- a/RECOMMENDATIONS.md
+++ b/RECOMMENDATIONS.md
@@ -10,7 +10,7 @@ Entries are dated. If one has gone untouched for over a year, delete it (or move
 
 ## Agent-runtime hooks (Claude Code `PreToolUse`, Cursor `beforeShellExecution`, Gemini `BeforeTool`)
 
-_Added 2026-04-23._
+_Added 2026-04-23. **Minimal version shipped 2026-06-10** — `install.sh --claude` installs a `.claude/settings.json` deny-list plus a `PreToolUse` precheck (`.githooks/lib/agent-precheck`) that scans Write/Edit/Bash content against the same `.forbidden-patterns/secrets.txt` the commit-time scanner uses. The full framework below remains out of scope._
 
 **Adopt if:** you have ≥3 concurrent agents, OR CI is rejecting more than ~1 violation/week that the agent could have caught at write-time, OR a single security incident from agent-issued shell commands has happened.
 
@@ -18,18 +18,18 @@ _Added 2026-04-23._
 
 | Layer | Catches | This scaffold has it? |
 |---|---|---|
-| Agent hooks (pre-tool-use) | Agent about to exfiltrate a secret, run `curl \| bash`, edit outside scope | No |
+| Agent hooks (pre-tool-use) | Agent about to exfiltrate a secret, run `curl \| bash`, edit outside scope | Yes — opt-in (`install.sh --claude`) |
 | Linters (`ruff`, `eslint`) | Code quality once code is written | Yes |
 | Git pre-commit | Debug leaks, file size, forbidden patterns at commit | Yes |
 | CI mirror | All of the above, server-side, unskippable | Yes |
 
-**The minimal version.** Wire `PreToolUse` to invoke this scaffold's existing `lib/check-*` scripts on the file the agent is about to write. ~15 lines of `.claude/settings.json`, reuses code already in `.githooks/lib/`. The same script runs in three places: agent → commit → CI.
+**The minimal version (now shipped).** `install.sh --claude` wires `PreToolUse` to `.githooks/lib/agent-precheck`, which scans the content of a Write/Edit/Bash call against `.forbidden-patterns/secrets.txt` — the same patterns the commit-time `check-secrets` uses. The same rule set runs in three places: agent → commit → CI. The bundled `.claude/settings.json` also denies the agent reading credential files (`.env`, `*.pem`, `~/.ssh/**`, `~/.aws/**`, …) outright.
 
 **The full version (overkill for most).** See [johnclick.ai/blog/hooks-based-enforcement-for-ai-agents](https://johnclick.ai/blog/hooks-based-enforcement-for-ai-agents/). Three-layer pattern (hooks + validators + guard YAMLs), four hook families (compliance / security / quality / orchestration), monitor → warn → enforce gradual rollout. Appropriate for production fleets of 10+ concurrent agents; overkill for small teams.
 
 **Highest-ROI first hook if you only adopt one.** Shell-command security scan in `PreToolUse` — block `curl | bash`, credential patterns, destructive git commands before the agent runs them. Per the source article, this is the single highest-ROI agent hook.
 
-**Why not in the scaffold.** Adopting the full framework dilutes the scaffold's "minimum-viable guardrails" identity. Adopting only the minimal version is plausible — tracked as a candidate for a future release, but unconfirmed.
+**Why the full framework is still out.** Adopting the full framework (validators + guard YAMLs + four hook families + monitor→warn→enforce rollout) dilutes the scaffold's "minimum-viable guardrails" identity. The minimal version is now shipped opt-in (above); the full framework stays a pointer, not a dependency.
 
 ---
 
@@ -49,8 +49,9 @@ _Added 2026-04-23._
 
 _Added 2026-04-22._
 
-**Adopt if:** your repo has accidental git conflict markers landing in non-code files, OR you want to scan Markdown / YAML / JSON for AWS keys and credentials.
+**Mostly superseded (2026-06-10).** The two concrete needs this entry described are now covered without a new pattern file:
 
-**What it would add.** `.forbidden-patterns/common.txt` alongside the existing `backend.txt` / `frontend.txt` / `secrets.txt` / `shell.txt`. Patterns that apply across every text file: git conflict markers (`^<{7}`), accidental AWS access keys outside `.env` files (`AKIA[0-9A-Z]{16}`), etc.
+- **Git conflict markers** — handled by `.githooks/lib/check-hygiene`, which scans every staged blob for `<<<<<<<` / `|||||||` / `>>>>>>>` markers (and also flags case-only filename collisions).
+- **AWS keys / credentials in any text file** — `check-secrets` already scans **every** tracked file's staged blob as text (no extension allowlist), so a key in Markdown / YAML / JSON is caught.
 
-**Why not in the scaffold yet.** Could be added without scope creep — it's a fourth pattern file consumed by the existing `check-patterns` and `check-secrets` scripts. Held back pending demand or a specific incident that proves it's worth the maintenance.
+**Still open:** a general-purpose `common.txt` for *project-defined* cross-language deny patterns (e.g. an internal hostname that should never appear in any file type). Held back pending demand — `check-patterns` could gain a `common.txt` consumed across all extensions if a concrete need appears.

--- a/claude-settings.json.template
+++ b/claude-settings.json.template
@@ -1,0 +1,43 @@
+{
+  "//": "ai-coding-rules-scaffold — OPT-IN agent-runtime guardrails for Claude Code (the scaffold's deferred 'layer three'). Copy to your project as .claude/settings.json, or merge these keys into an existing one. Two parts: a permissions deny-list (the agent can't read credential files or run a few catastrophic commands) and a PreToolUse hook that scans content the agent is about to write against .forbidden-patterns/secrets.txt — the same patterns the commit-time scanner uses. Trim the deny-list to taste; paths use gitignore-style matching.",
+
+  "permissions": {
+    "deny": [
+      "Read(**/.env)",
+      "Read(**/.env.*)",
+      "Read(**/*.pem)",
+      "Read(**/*.key)",
+      "Read(**/id_rsa)",
+      "Read(**/id_ed25519)",
+      "Read(**/id_ecdsa)",
+      "Read(**/id_dsa)",
+      "Read(**/credentials)",
+      "Read(~/.ssh/**)",
+      "Read(~/.aws/**)",
+      "Read(~/.config/gcloud/**)",
+      "Read(~/.kube/config)",
+      "Read(~/.netrc)",
+      "Read(~/.npmrc)",
+      "Bash(rm -rf /:*)",
+      "Bash(rm -rf ~:*)",
+      "Bash(rm -rf /*:*)",
+      "Bash(sudo rm:*)"
+    ],
+    "//deny": "The .env globs exempt the conventional .env.example/.sample/.template safe files only because those names match neither .env nor .env.<stack>; if you keep real secrets in an oddly-named file, add it here. A denied Read also stops the agent pulling the file into context to exfiltrate.",
+    "//ask": "Prefer 'ask' over 'deny' for anything you sometimes need (e.g. 'Bash(git push:*)') — deny is absolute, ask just prompts you."
+  },
+
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.githooks/lib/agent-precheck"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/coding-rules.md
+++ b/coding-rules.md
@@ -12,7 +12,7 @@ Short rule set. Most discipline is enforced by the linter (`ruff` / `eslint`) an
 3. **Before creating a new file, check for extension candidates.** Search the codebase for existing modules that could absorb the new logic. When you do create, state in the commit or PR body what you considered and why it couldn't extend.
 4. **FastAPI endpoints return Pydantic response models**, not raw dicts. Applies if the project uses FastAPI.
 5. **SQLAlchemy 2.0 style only** (`Mapped[]`, `mapped_column()`). No `declarative_base` or pre-2.0 patterns. Applies if the project uses SQLAlchemy.
-6. **`asyncio.to_thread()` for blocking CPU work** in async paths. Never block the event loop.
+6. **`asyncio.to_thread()` for blocking CPU work** in async paths. Never block the event loop. *(TypeScript)* Never leave a promise floating — `await` it or handle it explicitly. `eslint`'s `no-floating-promises` / `no-misused-promises` fail the build on the most common silent-async bug; they need type-aware linting (a `tsconfig.json`), which the shipped `eslint.config.js` enables by default.
 
 ## Pattern files
 
@@ -32,7 +32,7 @@ Stack-specific deny patterns live in `.forbidden-patterns/{backend,frontend,secr
 
    Defaults: Python — `ruff`, `pyright`/`mypy`, `pytest`, `hypothesis`. TypeScript — `eslint`+`prettier`, `tsc`, `vitest`/`jest`, `fast-check`. New stacks pick equivalents and document the choice in the project's `AGENTS.md`.
 
-9. **Pre-commit runs linter + type-checker** on every commit. Don't skip the hook (`--no-verify`) unless explicitly asked.
+9. **Don't skip the pre-commit hook (`--no-verify`) unless explicitly asked.** It runs the size/pattern/secret guards plus the linter (`ruff` / `eslint`), and — for TypeScript — `tsc --noEmit` whenever a `tsconfig.json` is present. Wire the rest of your type-checker (`pyright` / `mypy`) into CI per the project's `AGENTS.md`; the type-aware `eslint` config and `tsc` cover the TypeScript side at commit time and in CI.
 
 ## Observability
 

--- a/eslint.config.js.template
+++ b/eslint.config.js.template
@@ -1,14 +1,50 @@
 // Copy to project root as `eslint.config.js` (flat config, ESLint 9+).
-// Install peers: npm i -D eslint @eslint/js typescript-eslint
-// Adjust parserOptions.project per project if type-aware rules are needed.
+//
+// Install peers:
+//   npm i -D eslint @eslint/js typescript-eslint \
+//           eslint-plugin-import-x eslint-plugin-unused-imports
+//   # React projects also: npm i -D eslint-plugin-react-hooks  (see opt-in block below)
+//
+// TYPE-AWARE LINTING (default): this config extends `strictTypeChecked`, which
+// turns on the highest-value rules (`no-floating-promises`, `no-misused-promises`,
+// `await-thenable`, `no-unnecessary-condition`). These require type information,
+// so the project MUST have a working `tsconfig.json` that includes the linted
+// files — `projectService: true` discovers it automatically.
+//
+// No tsconfig.json yet? Either add one, or drop the type-aware tier: replace
+// `...tseslint.configs.strictTypeChecked` with `...tseslint.configs.strict` and
+// delete the `languageOptions.parserOptions` block below. You lose the async-
+// safety rules but the config loads without project info.
+//
+// Formatting is intentionally NOT handled here — run Prettier separately
+// (`npx prettier --check .`). `strict`/`strictTypeChecked` ship no formatting
+// rules, so there's nothing for Prettier to conflict with; do NOT add
+// eslint-plugin-prettier / eslint-config-prettier.
 
 import js from '@eslint/js';
 import tseslint from 'typescript-eslint';
+import importX from 'eslint-plugin-import-x';
+import unusedImports from 'eslint-plugin-unused-imports';
 
 export default tseslint.config(
-  js.configs.recommended,
-  ...tseslint.configs.strict,
   {
+    // Build output / vendored code is not ours to lint. Adjust per project.
+    ignores: ['dist/**', 'build/**', 'coverage/**', 'node_modules/**'],
+  },
+  js.configs.recommended,
+  ...tseslint.configs.strictTypeChecked,
+  {
+    languageOptions: {
+      parserOptions: {
+        // Auto-discovers the nearest tsconfig.json for each file (typed linting).
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    plugins: {
+      'import-x': importX,
+      'unused-imports': unusedImports,
+    },
     rules: {
       // Structure
       'max-depth': ['error', 3],
@@ -20,15 +56,56 @@ export default tseslint.config(
       // Debug leaks
       'no-console': 'error',
 
+      // Async safety (type-aware) — the single biggest reason to run typed
+      // linting. A floating promise is the #1 silent-failure class in TS/React.
+      '@typescript-eslint/no-floating-promises': 'error',
+      '@typescript-eslint/no-misused-promises': 'error',
+
       // TypeScript discipline
       '@typescript-eslint/no-explicit-any': ['error', { ignoreRestArgs: false }],
       '@typescript-eslint/explicit-module-boundary-types': 'error',
-      '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+
+      // Import hygiene — parity with ruff's `I` (sort) + `F401` (unused) on the
+      // Python side. unused-imports owns unused detection (it autofixes), so the
+      // typescript-eslint twin is turned off to avoid double-reporting.
+      '@typescript-eslint/no-unused-vars': 'off',
+      'unused-imports/no-unused-imports': 'error',
+      'unused-imports/no-unused-vars': ['error', {
+        argsIgnorePattern: '^_',
+        varsIgnorePattern: '^_',
+      }],
+      'import-x/order': ['error', {
+        'newlines-between': 'always',
+        alphabetize: { order: 'asc', caseInsensitive: true },
+        groups: ['builtin', 'external', 'internal', 'parent', 'sibling', 'index'],
+      }],
+      'import-x/no-duplicates': 'error',
     },
   },
+
+  // ── OPT-IN: React projects ────────────────────────────────────────────────
+  // Uncomment + `npm i -D eslint-plugin-react-hooks`. Kept opt-in because plenty
+  // of TypeScript projects (Node services, libraries, Vue) aren't React.
+  // Add at the top with the other imports:
+  //   import reactHooks from 'eslint-plugin-react-hooks';
+  // {
+  //   files: ['**/*.{jsx,tsx}'],
+  //   plugins: { 'react-hooks': reactHooks },
+  //   rules: {
+  //     'react-hooks/rules-of-hooks': 'error',     // the two most common
+  //     'react-hooks/exhaustive-deps': 'error',    // React correctness bugs
+  //   },
+  // },
+
   {
-    // Test files get looser rules
-    files: ['**/*.test.ts', '**/*.test.tsx', '**/*.spec.ts'],
+    // Plain JS/JSX has no type info — disable type-aware rules so the parser
+    // doesn't error on files outside the TS project graph (config files, etc.).
+    files: ['**/*.{js,cjs,mjs,jsx}'],
+    extends: [tseslint.configs.disableTypeChecked],
+  },
+  {
+    // Test files get looser rules.
+    files: ['**/*.test.ts', '**/*.test.tsx', '**/*.spec.ts', '**/*.spec.tsx'],
     rules: {
       'max-lines-per-function': 'off',
       '@typescript-eslint/no-explicit-any': 'off',

--- a/forbidden-patterns/frontend.txt.template
+++ b/forbidden-patterns/frontend.txt.template
@@ -1,11 +1,33 @@
 # Forbidden patterns for TS/JS files (*.ts, *.tsx, *.js, *.jsx). Applied by .githooks/pre-commit.
 # Format: <regex><TAB><description>   (one per line; # comments ignored)
 # Separator is TAB — patterns can contain literal `|` for ERE alternation.
-# Copy to your project as `.forbidden-patterns/frontend.txt`.
+# Patterns are case-SENSITIVE, scanned against the staged blob. Copy to your
+# project as `.forbidden-patterns/frontend.txt`.
 
+# --- Debug leaks ---
 (^|[^A-Za-z_])console\.log[[:space:]]*\(	Use the project logger, not console.log
 (^|[^A-Za-z_])debugger($|[^A-Za-z0-9_])	Remove debugger statement before committing
 (^|[^A-Za-z_])alert[[:space:]]*\(	Don't ship alert() calls — use a proper UI dialog
 
+# --- Test discipline ---
+# A focused test silently skips the rest of the suite — CI goes green while
+# almost nothing ran. The single most dangerous thing to commit in a test file.
+(^|[^A-Za-z_.])(describe|it|test|context)\.only[[:space:]]*\(	Focused test (.only) silently skips the suite — remove before committing
+
+# --- Type-checker escape hatches ---
+@ts-ignore	Use @ts-expect-error with a justification, not @ts-ignore
+@ts-nocheck	Do not disable type-checking for a whole file (@ts-nocheck)
+
+# --- Security ---
+dangerouslySetInnerHTML	dangerouslySetInnerHTML is an XSS vector — sanitize or render as text
+https?://(localhost|127\.0\.0\.1)	No hardcoded localhost/127.0.0.1 URLs — read from config/env
+
 # Optional: forbid TODO/FIXME/XXX in one line via regex alternation.
 # (^|[^A-Za-z_])(TODO|FIXME|XXX)($|[^A-Za-z0-9_])	TODO/FIXME/XXX not allowed — open a ticket instead
+
+# Optional: forbid dynamic code execution (eval / new Function).
+# (^|[^A-Za-z_.])(eval|Function)[[:space:]]*\(	Avoid eval()/new Function() — arbitrary-code-execution risk
+
+# Optional (opt-in): never commit an enabled auth-bypass flag. Generic
+# alternation — adjust the flag names to your project.
+# (BYPASS_AUTH|DISABLE_AUTH|SKIP_AUTH|AUTH_DISABLED)[[:space:]]*[:=][[:space:]]*(true|1)	Auth-bypass flag enabled — never commit a true value

--- a/githooks/commit-msg.template
+++ b/githooks/commit-msg.template
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# .githooks/commit-msg — enforce Conventional Commits on the subject line.
+# OPT-IN: installed only with `install.sh --commit-msg`. Once present in
+# core.hooksPath it runs on every `git commit`. Agents drift on commit format
+# across sessions; this pins it. Zero dependencies.
+#
+# Git passes the path to the commit-message file as $1.
+# Exit: 0 if the subject is valid (or an exempt merge/revert/fixup), 1 otherwise.
+
+set -euo pipefail
+
+MSG_FILE=${1:?commit-msg hook expects the message file path as $1}
+
+# First non-blank, non-comment line is the subject. `[[:space:]]` (not `\s`) so
+# this works under BSD grep on macOS as well as GNU grep.
+subject=$(grep -vE '^[[:space:]]*#' "$MSG_FILE" | grep -vE '^[[:space:]]*$' | head -1 || true)
+
+# Exempt git's own auto-generated subjects.
+case "$subject" in
+  "Merge "*|"Revert "*|"fixup! "*|"squash! "*|"Reapply "*) exit 0 ;;
+esac
+
+# <type>(<optional scope>)<optional !>: <description>
+CC_RE='^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([a-z0-9._/-]+\))?!?: .+'
+
+if printf '%s' "$subject" | grep -qE "$CC_RE"; then
+  exit 0
+fi
+
+{
+  echo "✗ commit message does not follow Conventional Commits:"
+  echo "    ${subject:-<empty subject>}"
+  echo "  Expected: <type>(<scope>)?: <description>   e.g. 'feat(api): add pagination'"
+  echo "  Types: feat fix docs style refactor perf test build ci chore revert"
+  echo "  See https://www.conventionalcommits.org/"
+} >&2
+exit 1

--- a/githooks/lib/agent-precheck.template
+++ b/githooks/lib/agent-precheck.template
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# .githooks/lib/agent-precheck — Claude Code PreToolUse hook (scaffold "layer
+# three": block bad content the moment an agent writes it, before commit time).
+#
+# Scans the content a Write/Edit is about to introduce — and the text of a Bash
+# command — against the SAME secret patterns the commit-time scanner uses
+# (.forbidden-patterns/secrets.txt). One source of truth: a credential the
+# agent tries to hardcode is refused at write time, not discovered later in CI.
+#
+# Wired via .claude/settings.json (PreToolUse, matcher "Write|Edit|Bash"). The
+# hook event arrives as JSON on stdin. It BLOCKS by exiting 2 — Claude Code
+# feeds the stderr text back to the model so it can correct course.
+#
+# Requires `jq`. If jq is missing, or no secrets.txt is present, it exits 0
+# (fail-OPEN) — an agent helper must never brick the session; the pre-commit
+# hook and CI are the authoritative fail-CLOSED backstops.
+#
+# Exit: 0 = allow, 2 = block (stderr shown to the model).
+
+set -euo pipefail
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+payload=$(cat)
+
+# Project root: Claude Code exports CLAUDE_PROJECT_DIR. Fall back to the cwd the
+# event reports, then to ".".
+ROOT=${CLAUDE_PROJECT_DIR:-}
+[ -n "$ROOT" ] || ROOT=$(jq -r '.cwd // "."' <<<"$payload" 2>/dev/null || echo .)
+CONFIG="$ROOT/.forbidden-patterns/secrets.txt"
+[ -f "$CONFIG" ] || exit 0
+
+# Pull every string value out of tool_input regardless of the tool's field names
+# (Write.content, Edit.new_string, MultiEdit edits[].new_string, Bash.command,
+# …). `.. | strings` walks the whole subtree, so this stays correct even if a
+# tool's schema changes.
+content=$(jq -r '[.tool_input | .. | strings] | join("\n")' <<<"$payload" 2>/dev/null || true)
+[ -n "$content" ] || exit 0
+
+# Drop pathologically long lines (a minified bundle pasted into a Write) so the
+# combined ERE can't be made to hang — same guard as check-secrets.
+MAX_LINE_LENGTH=${MAX_LINE_LENGTH:-50000}
+content=$(printf '%s\n' "$content" | awk -v n="$MAX_LINE_LENGTH" 'length > n { next } { print }')
+[ -n "$content" ] || exit 0
+
+# Load + validate patterns from secrets.txt (mirror of check-secrets' parsing).
+PATTERNS=()
+while IFS= read -r line || [ -n "$line" ]; do
+  line=${line%$'\r'}
+  [ -z "$line" ] && continue
+  case "$line" in \#*) continue ;; esac
+  case "$line" in *$'\t'*) ;; *) continue ;; esac
+  pattern=${line%%$'\t'*}
+  [ -z "$pattern" ] && continue
+  # Skip an invalid ERE rather than letting it poison the combined regex.
+  # `printf '' | grep -E p` writes to stderr only when p is invalid.
+  p_err=$(printf '' | grep -E -- "$pattern" 2>&1 1>/dev/null || true)
+  [ -z "$p_err" ] || continue
+  PATTERNS+=("$pattern")
+done <"$CONFIG"
+
+[ ${#PATTERNS[@]} -eq 0 ] && exit 0
+
+COMBINED=""
+for p in "${PATTERNS[@]}"; do
+  if [ -z "$COMBINED" ]; then COMBINED="(${p})"; else COMBINED="${COMBINED}|(${p})"; fi
+done
+# If the combined ERE is somehow invalid, fail OPEN (this is an advisory
+# pre-check, not the security boundary) rather than erroring out of the call.
+c_err=$(printf '' | grep -E -- "$COMBINED" 2>&1 1>/dev/null || true)
+[ -z "$c_err" ] || exit 0
+
+# A comment-anchored `scaffold-allow` exempts a line, exactly like the scanners.
+hit=$(printf '%s\n' "$content" | grep -aniE -- "$COMBINED" \
+        | grep -ivE '(#|//|/\*|<!--|--)[[:space:]]*scaffold-allow' || true)
+
+if [ -n "$hit" ]; then
+  {
+    echo "BLOCKED by agent-precheck: this content matches a secret pattern in"
+    echo ".forbidden-patterns/secrets.txt. Do not hardcode credentials — read"
+    echo "them from an environment variable or a secret manager instead."
+    echo "If this is a deliberate fixture/example, append a comment containing"
+    echo "'scaffold-allow' on the matching line."
+    echo "Matched:"
+    printf '%s\n' "$hit" | head -3
+  } >&2
+  exit 2
+fi
+
+exit 0

--- a/githooks/lib/check-hygiene.template
+++ b/githooks/lib/check-hygiene.template
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# .githooks/lib/check-hygiene — repo-hygiene guards that aren't secret- or
+# pattern-specific. Reads NUL-separated file paths on stdin (produced by
+# `git ... -z`). Two checks:
+#
+#   1. Merge-conflict markers. A committed `<<<<<<<` / `|||||||` / `>>>>>>>`
+#      marker means an unresolved conflict shipped — it breaks the build and is
+#      pure accident. Scans the STAGED/INDEXED BLOB via `git show ":0:<path>"`
+#      (like check-secrets/check-patterns), so symlinks, NUL bytes, and
+#      post-stage edits can't hide the marker. The `=======` middle marker is
+#      deliberately NOT matched on its own — a row of 7+ `=` is a common reST /
+#      Markdown heading underline, and every real conflict already carries the
+#      unambiguous `<<<<<<<` and `>>>>>>>` markers.
+#
+#   2. Case-only filename collisions. Two tracked paths that differ only in case
+#      (`README.md` vs `Readme.md`) coexist on Linux but collide on a
+#      case-insensitive filesystem (macOS default, Windows), corrupting the
+#      checkout. In the hook the list is the staged files; in CI it's every
+#      tracked file, which catches a collision against an already-committed file.
+#
+# A `scaffold-allow` marker (after a comment leader) exempts a conflict-marker
+# line, for the rare doc that shows one on purpose.
+#
+# Output: human-readable on tty; ::error file=...:: when --ci is passed.
+# Exit:   0 if all OK, 1 if any violation.
+
+set -euo pipefail
+
+CI_MODE=0
+[ "${1:-}" = "--ci" ] && CI_MODE=1
+
+# Escape a value for a GitHub workflow command (see check-secrets).
+ghesc() {
+  local s=$2
+  s=${s//'%'/%25}; s=${s//$'\r'/%0D}; s=${s//$'\n'/%0A}
+  if [ "$1" = prop ]; then s=${s//:/%3A}; s=${s//,/%2C}; fi
+  printf '%s' "$s"
+}
+
+emit() {
+  local file=$1 message=$2
+  if [ "$CI_MODE" -eq 1 ]; then
+    echo "::error file=$(ghesc prop "$file")::$(ghesc data "$message")"
+  else
+    echo "✗ $file: $message"
+  fi
+}
+
+# Same per-line length cap as check-secrets/check-patterns — keep a pathological
+# minified blob from being slurped whole, even though the marker regex is
+# anchored and linear.
+MAX_LINE_LENGTH=${MAX_LINE_LENGTH:-50000}
+case "$MAX_LINE_LENGTH" in
+  ''|*[!0-9]*) echo "error: MAX_LINE_LENGTH must be a positive integer, got: $MAX_LINE_LENGTH" >&2; exit 2 ;;
+esac
+[ "$MAX_LINE_LENGTH" -gt 0 ] || { echo "error: MAX_LINE_LENGTH must be > 0" >&2; exit 2; }
+
+FILES=()
+while IFS= read -r -d '' f; do
+  [ -n "$f" ] && FILES+=("$f")
+done
+
+[ ${#FILES[@]} -eq 0 ] && exit 0
+
+FAILED=0
+
+# --- 1. merge-conflict markers ---------------------------------------------
+CONFLICT_RE='^(<{7}|>{7}|\|{7})( |$)'
+for file in "${FILES[@]}"; do
+  cap_rc=0
+  content=$(git show ":0:$file" 2>/dev/null | awk -v n="$MAX_LINE_LENGTH" 'length > n { next } { print }') || cap_rc=$?
+  [ "$cap_rc" -eq 0 ] || true
+  [ -n "$content" ] || continue
+  m=$(grep -anE -- "$CONFLICT_RE" <<<"$content" | grep -ivE '(#|//|/\*|<!--|--)[[:space:]]*scaffold-allow' || true)
+  if [ -n "$m" ]; then
+    emit "$file" "merge-conflict marker — resolve the conflict before committing"
+    printf '%s\n' "$m" | head -3 | sed 's/^/    /' >&2 || true
+    FAILED=1
+  fi
+done
+
+# --- 2. case-only filename collisions --------------------------------------
+# bash 3.2 (macOS) has no associative arrays and no ${var,,}, so lowercase each
+# path once with tr into a parallel array, then compare pairwise (O(n^2) string
+# compares, no subprocess in the inner loop). NUL-delimited input means a path
+# may legitimately contain a newline, so we never split on newlines here.
+LOWER=()
+for f in "${FILES[@]}"; do
+  LOWER+=("$(printf '%s' "$f" | tr '[:upper:]' '[:lower:]')")
+done
+
+n=${#FILES[@]}
+for ((i = 0; i < n; i++)); do
+  for ((j = i + 1; j < n; j++)); do
+    if [ "${LOWER[$i]}" = "${LOWER[$j]}" ] && [ "${FILES[$i]}" != "${FILES[$j]}" ]; then
+      emit "${FILES[$j]}" "case-only filename collision with '${FILES[$i]}' — breaks case-insensitive checkouts (macOS/Windows)"
+      FAILED=1
+    fi
+  done
+done
+
+exit $FAILED

--- a/githooks/pre-commit.template
+++ b/githooks/pre-commit.template
@@ -93,6 +93,7 @@ FAILED=0
 "$LIB/check-patterns"  <"$STAGED_LIST" || FAILED=1
 "$LIB/check-filenames" <"$STAGED_LIST" || FAILED=1
 "$LIB/check-secrets"   <"$STAGED_LIST" || FAILED=1
+"$LIB/check-hygiene"   <"$STAGED_LIST" || FAILED=1
 
 # Lint staged files with ruff / eslint when configs exist and the tool is
 # installed. CI is the source of truth — running here just shortens the

--- a/githooks/pre-commit.template
+++ b/githooks/pre-commit.template
@@ -123,6 +123,17 @@ if [ ${#STAGED_JS[@]} -gt 0 ] \
   npx --no-install eslint -- "${STAGED_JS[@]}" || FAILED=1
 fi
 
+# Type-check with tsc when a tsconfig.json exists and TypeScript is installed.
+# Run PROJECT-WIDE (no file args) — passing individual files makes tsc ignore
+# tsconfig.json and its compiler options. Silently skipped when absent, like
+# the linters above; CI is the authoritative backstop.
+if [ ${#STAGED_JS[@]} -gt 0 ] \
+   && [ -f tsconfig.json ] \
+   && command -v npx >/dev/null 2>&1 \
+   && npx --no-install tsc --version >/dev/null 2>&1; then
+  npx --no-install tsc --noEmit || FAILED=1
+fi
+
 if [ "$FAILED" -ne 0 ]; then
   echo ""
   echo "Pre-commit failed. Fix the issues above or use 'git commit --no-verify' to skip (don't)."

--- a/install.sh
+++ b/install.sh
@@ -137,7 +137,7 @@ if [ "$VERIFY" -eq 1 ]; then
       if command -v npx >/dev/null 2>&1 && npx --no-install eslint --version >/dev/null 2>&1; then
         echo "  ✓ eslint installed"
       else
-        echo "  ! eslint not installed — run: npm i -D eslint @eslint/js typescript-eslint"
+        echo "  ! eslint not installed — run: npm i -D eslint @eslint/js typescript-eslint eslint-plugin-import-x eslint-plugin-unused-imports"
       fi ;;
   esac
 fi

--- a/install.sh
+++ b/install.sh
@@ -8,6 +8,8 @@
 #   install.sh --both       # install both stacks
 #   install.sh --force      # overwrite existing files
 #   install.sh --no-verify  # skip the post-install linter smoke test
+#   install.sh --claude     # also install opt-in Claude Code agent guardrails
+#   install.sh --commit-msg # also install the Conventional-Commits commit-msg hook
 #   install.sh --help       # show this help
 
 set -euo pipefail
@@ -16,15 +18,19 @@ SCAFFOLD_DIR="$(cd "$(dirname "$0")" && pwd)"
 MODE="auto"
 FORCE=0
 VERIFY=1
+CLAUDE=0
+COMMIT_MSG=0
 
 for arg in "$@"; do
   case "$arg" in
-    --python)    MODE="python" ;;
-    --frontend)  MODE="frontend" ;;
-    --both)      MODE="both" ;;
-    --force)     FORCE=1 ;;
-    --no-verify) VERIFY=0 ;;
-    --help|-h)   sed -n '2,11p' "$0"; exit 0 ;;
+    --python)     MODE="python" ;;
+    --frontend)   MODE="frontend" ;;
+    --both)       MODE="both" ;;
+    --force)      FORCE=1 ;;
+    --no-verify)  VERIFY=0 ;;
+    --claude)     CLAUDE=1 ;;
+    --commit-msg) COMMIT_MSG=1 ;;
+    --help|-h)    sed -n '2,13p' "$0"; exit 0 ;;
     *) echo "error: unknown argument: $arg" >&2; exit 1 ;;
   esac
 done
@@ -72,11 +78,12 @@ cp_safe "$SCAFFOLD_DIR/AGENTS.md.template" "AGENTS.md"
 cp_safe "$SCAFFOLD_DIR/CLAUDE.md.pointer" "CLAUDE.md"
 cp_safe "$SCAFFOLD_DIR/githooks/pre-commit.template" ".githooks/pre-commit"
 chmod +x .githooks/pre-commit
-for check in check-size check-patterns check-filenames check-secrets; do
+for check in check-size check-patterns check-filenames check-secrets check-hygiene; do
   cp_safe "$SCAFFOLD_DIR/githooks/lib/${check}.template" ".githooks/lib/${check}"
   chmod +x ".githooks/lib/${check}"
 done
 cp_safe "$SCAFFOLD_DIR/.github/workflows/lint.yml.template" ".github/workflows/lint.yml"
+cp_safe "$SCAFFOLD_DIR/.github/dependabot.yml.template" ".github/dependabot.yml"
 cp_safe "$SCAFFOLD_DIR/forbidden-patterns/secrets.txt.template" ".forbidden-patterns/secrets.txt"
 cp_safe "$SCAFFOLD_DIR/forbidden-patterns/shell.txt.template" ".forbidden-patterns/shell.txt"
 
@@ -90,6 +97,26 @@ fi
 if [ "$MODE" = "frontend" ] || [ "$MODE" = "both" ]; then
   cp_safe "$SCAFFOLD_DIR/eslint.config.js.template" "eslint.config.js"
   cp_safe "$SCAFFOLD_DIR/forbidden-patterns/frontend.txt.template" ".forbidden-patterns/frontend.txt"
+fi
+
+# Claude Code agent-runtime guardrails (opt-in: --claude). Installs a PreToolUse
+# precheck hook (reuses .forbidden-patterns/secrets.txt) plus a settings.json
+# with a credential-file deny-list. An existing .claude/settings.json is left
+# alone by cp_safe — merge the template's keys in by hand.
+if [ "$CLAUDE" -eq 1 ]; then
+  cp_safe "$SCAFFOLD_DIR/githooks/lib/agent-precheck.template" ".githooks/lib/agent-precheck"
+  chmod +x ".githooks/lib/agent-precheck"
+  cp_safe "$SCAFFOLD_DIR/claude-settings.json.template" ".claude/settings.json"
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "warning: jq not found — the PreToolUse precheck needs jq (it fails open without it): https://jqlang.github.io/jq/"
+  fi
+fi
+
+# Conventional-Commits commit-msg hook (opt-in: --commit-msg). Active the moment
+# it lands in core.hooksPath, so it's off by default to avoid surprising users.
+if [ "$COMMIT_MSG" -eq 1 ]; then
+  cp_safe "$SCAFFOLD_DIR/githooks/commit-msg.template" ".githooks/commit-msg"
+  chmod +x ".githooks/commit-msg"
 fi
 
 # Wire the hook — preserve existing core.hooksPath if already set (e.g. Husky).

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -413,6 +413,60 @@ else
 fi
 reset_repo
 
+# 36. Focused test (.only) is rejected — a green CI that ran almost nothing is
+#     the single most dangerous frontend commit.
+echo 'it.only("smoke", () => {});' >focused.test.ts
+git add focused.test.ts
+assert_rejects "focused test (.only) is rejected" "Focused test"
+
+# 37. NEGATIVE: an ordinary test (no .only) must pass — the .only regex must not
+#     fire on a plain it(...)/test(...) call.
+echo 'it("does a thing", () => { expect(1).toBe(1); });' >ok.test.ts
+git add ok.test.ts
+assert_passes "ordinary it(...) test is not flagged as .only"
+
+# 38. @ts-ignore is rejected — use @ts-expect-error with a justification.
+{
+  echo '// @ts-ignore'
+  echo 'const x: number = "nope";'
+} >tsignore.ts
+git add tsignore.ts
+assert_rejects "@ts-ignore is rejected" "@ts-expect-error"
+
+# 39. dangerouslySetInnerHTML is rejected as an XSS vector.
+echo 'const el = <div dangerouslySetInnerHTML={{ __html: userInput }} />;' >xss.tsx
+git add xss.tsx
+assert_rejects "dangerouslySetInnerHTML is rejected" "XSS vector"
+
+# 40. hardcoded localhost URL is rejected — config/env instead.
+echo 'const api = "http://localhost:8080/v1";' >localhost.ts
+git add localhost.ts
+assert_rejects "hardcoded localhost URL is rejected" "hardcoded localhost"
+
+# 41. NEGATIVE: console.warn / console.error are allowed (only console.log is
+#     banned) and a clean .ts file with no tsconfig.json passes — proving the
+#     new tsc block silently skips when TypeScript isn't configured.
+{
+  echo 'console.warn("heads up");'
+  echo 'export const value = 42;'
+} >clean.ts
+git add clean.ts
+assert_passes "console.warn allowed; clean .ts with no tsconfig passes"
+
+# 42. tsc type-error rejection — only runs where TypeScript is resolvable in the
+#     temp repo (it isn't, by default: no node_modules), so this is normally a
+#     skip. Documents intent and exercises the path on machines that have a
+#     project-local tsc. The hook runs `tsc --noEmit` project-wide when a
+#     tsconfig.json exists.
+if npx --no-install tsc --version >/dev/null 2>&1; then
+  echo '{"compilerOptions":{"strict":true,"noEmit":true}}' >tsconfig.json
+  echo 'const n: number = "definitely not a number";' >typeerr.ts
+  git add tsconfig.json typeerr.ts
+  assert_rejects "tsc --noEmit rejects a type error"
+else
+  echo "  - skipped tsc test (typescript not installed in temp repo)"
+fi
+
 echo ""
 echo "Result: $PASS passed, $FAIL failed"
 exit $FAIL

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -488,12 +488,29 @@ assert_rejects "merge-conflict marker is rejected" "merge-conflict marker"
 git add doc.rst
 assert_passes "heading underline (=======) is not flagged as a conflict"
 
-# 45. Case-only filename collision is rejected — two paths differing only in
-#     case break a case-insensitive checkout (macOS/Windows).
-echo 'one' >Collide.txt
-echo 'two' >collide.txt
-git add Collide.txt collide.txt
-assert_rejects "case-only filename collision is rejected" "case-only filename collision"
+# 45. Case-only filename collision is rejected. A real two-file fixture can't
+#     exist on a case-insensitive filesystem (macOS default, where Collide.txt
+#     and collide.txt are the same file), so feed check-hygiene the NUL-delimited
+#     path list directly — the same way case #35 exercises check-secrets --ci.
+if printf '%s\0' 'Collide.txt' 'collide.txt' | .githooks/lib/check-hygiene >"$HOOK_OUT" 2>&1; then
+  echo "  ✗ case-only filename collision — accepted, expected reject"
+  sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+elif grep -qF "case-only filename collision" "$HOOK_OUT"; then
+  echo "  ✓ case-only filename collision is rejected"; PASS=$((PASS + 1))
+else
+  echo "  ✗ case-only filename collision — rejected without expected message"
+  sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+reset_repo
+
+# 45b. NEGATIVE: distinct filenames (not a case variant) do not collide.
+if printf '%s\0' 'a.txt' 'b.txt' 'README.md' | .githooks/lib/check-hygiene >"$HOOK_OUT" 2>&1; then
+  echo "  ✓ distinct filenames are not flagged as a collision"; PASS=$((PASS + 1))
+else
+  echo "  ✗ distinct filenames — flagged as a collision, expected pass"
+  sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+reset_repo
 
 # 46-48. agent-precheck — the opt-in Claude Code PreToolUse hook. Invoked
 #     directly (it's not a git hook) with CLAUDE_PROJECT_DIR pointed at this

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -467,6 +467,99 @@ else
   echo "  - skipped tsc test (typescript not installed in temp repo)"
 fi
 
+# 43. Merge-conflict markers are rejected (check-hygiene).
+{
+  echo '<<<<<<< HEAD'
+  echo 'our change'
+  echo '======='
+  echo 'their change'
+  echo '>>>>>>> feature-branch'
+} >conflict.txt
+git add conflict.txt
+assert_rejects "merge-conflict marker is rejected" "merge-conflict marker"
+
+# 44. NEGATIVE: a reST/Markdown heading underline of 7+ `=` is NOT a conflict
+#     marker — only <<<<<<< / >>>>>>> / ||||||| are. Must pass.
+{
+  echo 'Section title'
+  echo '============='
+  echo 'Body.'
+} >doc.rst
+git add doc.rst
+assert_passes "heading underline (=======) is not flagged as a conflict"
+
+# 45. Case-only filename collision is rejected — two paths differing only in
+#     case break a case-insensitive checkout (macOS/Windows).
+echo 'one' >Collide.txt
+echo 'two' >collide.txt
+git add Collide.txt collide.txt
+assert_rejects "case-only filename collision is rejected" "case-only filename collision"
+
+# 46-48. agent-precheck — the opt-in Claude Code PreToolUse hook. Invoked
+#     directly (it's not a git hook) with CLAUDE_PROJECT_DIR pointed at this
+#     temp repo, which has .forbidden-patterns/secrets.txt installed. Needs jq.
+if command -v jq >/dev/null 2>&1; then
+  PRECHECK="$SCAFFOLD_DIR/githooks/lib/agent-precheck.template"
+  akia="AKIA""IOSFODNN7EXAMPLE"   # split so this file carries no real-looking key
+  # (46) a Write introducing a secret is blocked (exit 2 + message)
+  pc=$(printf '{"tool_name":"Write","tool_input":{"file_path":"x.py","content":"AWS=%s"}}' "$akia")
+  if echo "$pc" | CLAUDE_PROJECT_DIR="$PWD" bash "$PRECHECK" >"$HOOK_OUT" 2>&1; then
+    echo "  ✗ agent-precheck — allowed a secret Write, expected block"; FAIL=$((FAIL + 1))
+  elif grep -qF "BLOCKED by agent-precheck" "$HOOK_OUT"; then
+    echo "  ✓ agent-precheck blocks a secret-bearing Write"; PASS=$((PASS + 1))
+  else
+    echo "  ✗ agent-precheck — blocked but missing expected message"
+    sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+  fi
+  # (47) clean content is allowed (exit 0)
+  pc='{"tool_name":"Write","tool_input":{"file_path":"x.ts","content":"export const x = 1;"}}'
+  if echo "$pc" | CLAUDE_PROJECT_DIR="$PWD" bash "$PRECHECK" >"$HOOK_OUT" 2>&1; then
+    echo "  ✓ agent-precheck allows clean content"; PASS=$((PASS + 1))
+  else
+    echo "  ✗ agent-precheck — blocked clean content, expected allow"
+    sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+  fi
+  # (48) a comment-anchored scaffold-allow marker exempts the line (exit 0)
+  pc=$(printf '{"tool_name":"Write","tool_input":{"file_path":"x.md","content":"key = %s  # scaffold-allow docs example"}}' "$akia")
+  if echo "$pc" | CLAUDE_PROJECT_DIR="$PWD" bash "$PRECHECK" >"$HOOK_OUT" 2>&1; then
+    echo "  ✓ agent-precheck honors scaffold-allow"; PASS=$((PASS + 1))
+  else
+    echo "  ✗ agent-precheck — scaffold-allow not honored, expected allow"
+    sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+  fi
+else
+  echo "  - skipped agent-precheck tests (jq not installed)"
+fi
+reset_repo
+
+# 49-51. commit-msg hook — Conventional-Commits subject enforcement. Invoked
+#     directly with a message file (it's installed only with --commit-msg).
+CMHOOK="$SCAFFOLD_DIR/githooks/commit-msg.template"
+mf=$(mktemp)
+printf 'feat(api): add pagination\n' >"$mf"
+if bash "$CMHOOK" "$mf" >"$HOOK_OUT" 2>&1; then
+  echo "  ✓ commit-msg accepts a Conventional Commit subject"; PASS=$((PASS + 1))
+else
+  echo "  ✗ commit-msg rejected a valid subject"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+printf 'fixed a bug\n' >"$mf"
+if bash "$CMHOOK" "$mf" >"$HOOK_OUT" 2>&1; then
+  echo "  ✗ commit-msg accepted a non-conforming subject"; FAIL=$((FAIL + 1))
+elif grep -qF "Conventional Commits" "$HOOK_OUT"; then
+  echo "  ✓ commit-msg rejects a non-conforming subject"; PASS=$((PASS + 1))
+else
+  echo "  ✗ commit-msg rejected but without the expected message"
+  sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+printf 'Merge branch main into feature\n' >"$mf"
+if bash "$CMHOOK" "$mf" >"$HOOK_OUT" 2>&1; then
+  echo "  ✓ commit-msg exempts a merge commit"; PASS=$((PASS + 1))
+else
+  echo "  ✗ commit-msg rejected a merge commit"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+rm -f "$mf"
+reset_repo
+
 echo ""
 echo "Result: $PASS passed, $FAIL failed"
 exit $FAIL

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -67,11 +67,17 @@ force_remove() {
 remove_if_unmodified "ruff.toml"                     "$SCAFFOLD_DIR/ruff.toml.template"
 remove_if_unmodified "eslint.config.js"              "$SCAFFOLD_DIR/eslint.config.js.template"
 remove_if_unmodified ".githooks/pre-commit"          "$SCAFFOLD_DIR/githooks/pre-commit.template"
-for check in check-size check-patterns check-filenames check-secrets; do
+for check in check-size check-patterns check-filenames check-secrets check-hygiene; do
   remove_if_unmodified ".githooks/lib/${check}" "$SCAFFOLD_DIR/githooks/lib/${check}.template"
 done
 remove_if_unmodified ".github/workflows/lint.yml"    "$SCAFFOLD_DIR/.github/workflows/lint.yml.template"
+remove_if_unmodified ".github/dependabot.yml"        "$SCAFFOLD_DIR/.github/dependabot.yml.template"
 remove_if_unmodified "CLAUDE.md"                     "$SCAFFOLD_DIR/CLAUDE.md.pointer"
+# Opt-in Claude Code guardrails (only present if installed with --claude).
+remove_if_unmodified ".githooks/lib/agent-precheck"  "$SCAFFOLD_DIR/githooks/lib/agent-precheck.template"
+remove_if_unmodified ".claude/settings.json"         "$SCAFFOLD_DIR/claude-settings.json.template"
+# Opt-in commit-msg hook (only present if installed with --commit-msg).
+remove_if_unmodified ".githooks/commit-msg"          "$SCAFFOLD_DIR/githooks/commit-msg.template"
 
 # Likely-customized files — only with --all
 if [ "$REMOVE_ALL" -eq 1 ]; then
@@ -82,7 +88,7 @@ if [ "$REMOVE_ALL" -eq 1 ]; then
 fi
 
 # Clean up empty dirs the installer created
-for dir in .githooks/lib .githooks .github/workflows .github; do
+for dir in .githooks/lib .githooks .github/workflows .github .claude; do
   [ -d "$dir" ] || continue
   if rmdir "$dir" 2>/dev/null; then
     echo "removed empty: $dir"


### PR DESCRIPTION
Expands the scaffold's enforcement depth, TypeScript-first, then adds the hooks/tools and the deferred agent-runtime layer. Two cohesive commits.

> **Stacked on `fix/audit-batch-clean-fixes` (PR #11).** Base is that branch so this PR shows only its own two commits; retarget to `main` once #11 merges.

## `fc7c873` — TypeScript depth (P0)
- ESLint made **type-aware**: `strict` → `strictTypeChecked` + `projectService` (the async-safety rules couldn't fire before)
- Pinned `no-floating-promises` + `no-misused-promises`; added `import-x/order` + `unused-imports` for parity with ruff's `I`/`F401`; opt-in `react-hooks` block
- `tsc --noEmit` wired into **both** the pre-commit hook and CI, guarded on `tsconfig.json` + tsc-installed (silent-skip otherwise) — resolves `coding-rules.md` rule 9 mandating a type-checker that ran nowhere
- `frontend.txt`: `.only` focused tests, `@ts-ignore`/`@ts-nocheck`, `dangerouslySetInnerHTML`, hardcoded localhost URLs

## `a15fe88` — hygiene, agent-runtime, supply-chain
- **`check-hygiene`** (new always-on `lib/check-*`, hook+CI): merge-conflict markers + case-only filename collisions
- **Agent-runtime guardrails** (opt-in `install.sh --claude`) — the README's deferred "layer three": `.claude/settings.json` credential-file deny-list + a `PreToolUse` hook (`agent-precheck`) reusing the same `secrets.txt` as the commit scanner, blocking secrets at write time
- **commit-msg** Conventional-Commits hook (opt-in `--commit-msg`)
- **gitleaks** CI template (SHA-pinned v3.0.0, opt-in) + **Dependabot** (default, bumps the SHA-pinned Actions) + frontend CI **`npm ci`** frozen-lockfile

## Verification
- Test harness **54/54** (was 39) under the GNU-grep shim — +15 fixtures including negatives (`console.warn`, plain `it(...)`, reST `=======` underline, scaffold-allow)
- Every shell script **shellcheck `-S info` clean**; every workflow **actionlint clean**; Dependabot YAML + settings JSON valid
- `install.sh --both --claude --commit-msg` and `uninstall.sh --dry-run` verified end-to-end

All changes additive; bash-3.2/macOS-safe; hook and CI keep sharing the same `check-*` scripts (no drift). Nothing leaks private/internal detail.