### PR TITLE
feat: multi-language forbidden patterns + per-project rule overrides (.scaffold.toml)

### DIFF
--- a/.github/workflows/lint.yml.template
+++ b/.github/workflows/lint.yml.template
@@ -81,6 +81,98 @@ jobs:
             echo "tsconfig.json or typescript missing — skipping tsc type-check"
           fi
 
+  php:
+    # Same detect-in-a-step pattern as `python` / `frontend`. No-ops on repos
+    # with no PHP, so it's safe to leave enabled in a polyglot org.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - id: detect
+        run: |
+          if [ -f composer.json ] || git ls-files '*.php' '*.phtml' | grep -q .; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          fi
+      - if: steps.detect.outputs.present == 'true'
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240  # 2.37.2
+        with:
+          php-version: "8.3"
+          tools: composer
+      - name: Lint PHP (php -l syntax; phpcs when configured)
+        if: steps.detect.outputs.present == 'true'
+        run: |
+          fail=0
+          git ls-files -z '*.php' '*.phtml' | xargs -0 -r -n1 php -l >/dev/null || fail=1
+          if [ -f composer.json ] && [ -f composer.lock ]; then
+            composer install --no-interaction --no-progress --prefer-dist || true
+          fi
+          if [ -x vendor/bin/phpcs ]; then vendor/bin/phpcs || fail=1; fi
+          exit $fail
+
+  # ── OPT-IN linter jobs for other languages ────────────────────────────────
+  # The forbidden-pattern + secret + size + hygiene guardrails below already run
+  # for EVERY language. These jobs add each language's real linter/type-checker.
+  # Uncomment the ones your team uses (actions are pinned to a commit SHA; the
+  # trailing comment is the version — bump via Dependabot). Each no-ops on repos
+  # that don't use that language.
+  #
+  # go:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+  #     - id: detect
+  #       run: '[ -f go.mod ] && echo "present=true" >> "$GITHUB_OUTPUT" || true'
+  #     - if: steps.detect.outputs.present == 'true'
+  #       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
+  #       with:
+  #         go-version: stable
+  #     - if: steps.detect.outputs.present == 'true'
+  #       run: go vet ./...
+  #     - if: steps.detect.outputs.present == 'true'
+  #       uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee  # v9.2.1
+  #
+  # rust:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+  #     - id: detect
+  #       run: '[ -f Cargo.toml ] && echo "present=true" >> "$GITHUB_OUTPUT" || true'
+  #     - if: steps.detect.outputs.present == 'true'
+  #       uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+  #       with:
+  #         components: clippy
+  #     - if: steps.detect.outputs.present == 'true'
+  #       run: cargo clippy --all-targets -- -D warnings
+  #
+  # java:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+  #     - id: detect
+  #       run: '{ [ -f pom.xml ] || [ -f build.gradle ] || [ -f build.gradle.kts ]; } && echo "present=true" >> "$GITHUB_OUTPUT" || true'
+  #     - if: steps.detect.outputs.present == 'true'
+  #       uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
+  #       with:
+  #         distribution: temurin
+  #         java-version: "21"
+  #     # Wire your build's check goal, e.g. `mvn -B checkstyle:check` or
+  #     # `./gradlew check` (Gradle picks up ktlint/spotless/detekt for Kotlin).
+  #     - if: steps.detect.outputs.present == 'true'
+  #       run: echo "add your build's lint/check task here (mvn checkstyle:check / ./gradlew check)"
+  #
+  # ruby:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+  #     - id: detect
+  #       run: '[ -f Gemfile ] && echo "present=true" >> "$GITHUB_OUTPUT" || true'
+  #     - if: steps.detect.outputs.present == 'true'
+  #       uses: ruby/setup-ruby@12fd324f1d0b43274fdc8130f6980590a667c455  # v1.312.0
+  #       with:
+  #         ruby-version: "3.3"
+  #         bundler-cache: true
+  #     - if: steps.detect.outputs.present == 'true'
+  #       run: bundle exec rubocop
+
   guardrails:
     # File size, forbidden patterns, blocked filenames, secret scan —
     # the same lib/check-* scripts the pre-commit hook calls.

--- a/.github/workflows/lint.yml.template
+++ b/.github/workflows/lint.yml.template
@@ -183,12 +183,17 @@ jobs:
     #   1. Runs the check scripts AND pattern configs from the PR head. On a
     #      `pull_request` build the checked-out tree is the PR's own content, so
     #      a PR can weaken the very scanner meant to gate it (edit a check-*
-    #      script, delete a pattern from .forbidden-patterns/*). This is a
+    #      script, delete a pattern from .forbidden-patterns/*, or add a
+    #      `.scaffold.toml` that disables/downgrades a rule). The override file
+    #      is committed and the "active rule overrides" step below prints it into
+    #      the log, so a weakened rule is visible in review — but treat changes
+    #      to .scaffold.toml and .githooks/** as security-relevant. This is a
     #      defense-in-depth backstop, NOT a trust boundary against a hostile
     #      contributor — pair it with branch protection / required review, and
     #      for untrusted forks gate merges on a scan run from the BASE ref
     #      (e.g. check out `${{ github.base_ref }}`'s .githooks + configs and
-    #      run those against the PR's files).
+    #      run those against the PR's files). Note: secrets/credential-filename
+    #      blocking is NOT overridable by .scaffold.toml, by design.
     #
     #   2. Scans the committed blob (`git show :0:<path>`). For a Git-LFS- or
     #      clean/smudge-filtered file the committed blob is the POINTER, not the
@@ -198,9 +203,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: Show active rule overrides (.scaffold.toml)
+        # Print every per-project override into the log so a disabled or
+        # downgraded rule is visible in review, not silent. Informational only.
+        run: |
+          chmod +x .githooks/lib/scaffold-audit 2>/dev/null || true
+          if [ -x .githooks/lib/scaffold-audit ]; then .githooks/lib/scaffold-audit; fi
       - name: Run scaffold checks
         run: |
-          chmod +x .githooks/lib/check-*
+          chmod +x .githooks/lib/* 2>/dev/null || true
           # -z (NUL-delimited) so a filename containing a newline, tab, or
           # quote can't split the list and slip a file past the scan. The
           # check scripts read each file's committed blob (git show ":0:<path>"),

--- a/.scaffold.toml.template
+++ b/.scaffold.toml.template
@@ -1,0 +1,63 @@
+# .scaffold.toml — per-project rule overrides for the ai-coding-rules-scaffold
+# guardrails. EVERYTHING here is committed and auditable: it is the single place
+# a team records a deliberate, signed-off deviation from the scaffold defaults.
+# Run `.githooks/lib/scaffold-audit` to list every active override at a glance.
+#
+# This file is OPTIONAL and ships empty (all examples commented out) — with no
+# uncommented entries it changes nothing. Uncomment and edit only what you mean
+# to override, and leave a `reason` + `by` so the next person knows why.
+#
+# Format is a strict TOML subset (see .githooks/lib/scaffold-config for the
+# exact grammar): [section] headers, bare or "quoted" keys, and integer /
+# true,false / "string" values. No arrays, inline tables, or trailing comments.
+#
+# SECURITY BOUNDARY — what you CANNOT override here:
+#   The secret scanner (check-secrets) and the credential-filename check
+#   (check-filenames) ignore this file entirely. Secret and key-file blocking is
+#   non-negotiable and cannot be disabled or downgraded per-project. Overrides
+#   below apply ONLY to forbidden-pattern rules, the file-size cap, and the
+#   repo-hygiene rules. A `severity = "warn"` downgrade still EMITS the finding
+#   (as a CI ::warning::), so a relaxed rule stays visible — it just stops
+#   failing the build.
+
+# ── File-size cap ───────────────────────────────────────────────────────────
+# The default cap is 500 lines (or whatever MAX_LINES is set to). Override it
+# globally or per glob. The most-specific matching glob wins (longest pattern).
+# Globs use shell `[[ == ]]` matching, where `*` also spans `/`.
+#
+# [size]
+# default            = 800        # raise the project-wide cap
+# "legacy/**"        = 2000       # generated/legacy trees you can't split yet
+# "db/migrations/*"  = 5000
+
+# ── Per-rule overrides ────────────────────────────────────────────────────────
+# Key a forbidden-pattern rule by "<patternfile-stem>/<description>", where the
+# description is the text after the TAB in the .forbidden-patterns/<lang>.txt
+# rule. Hygiene rules use the bare ids `conflict-marker` and `case-collision`.
+# The size cap as a whole uses the id `size`.
+#
+# Each [rules."..."] table accepts:
+#   disabled = true            # turn the rule off entirely (still auditable)
+#   severity = "warn"          # error (default) -> warn: emit but don't fail
+#   reason   = "..."           # why — surfaced by scaffold-audit
+#   by       = "name + date"   # who signed off
+#
+# To MODIFY a forbidden-pattern's regex or description, edit the rule directly in
+# .forbidden-patterns/<lang>.txt (you own that file after install); git history
+# is the audit trail for those edits. This file owns disable + severity only, so
+# a regex never has to live in two places.
+#
+# [rules."php/var_dump( or print_r( left in code"]
+# disabled = true
+# reason   = "legacy reporting module, tracked in JIRA-1234"
+# by       = "alex 2026-06-11"
+#
+# [rules."frontend/console.log left in code"]
+# severity = "warn"
+# reason   = "debug logging allowed in the spike branch"
+# by       = "sam 2026-06-11"
+#
+# [rules.case-collision]
+# severity = "warn"
+# reason   = "monorepo intentionally ships Readme.md beside README.md"
+# by       = "jo 2026-06-11"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ versioning follows [SemVer](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- **Per-project rule overrides (`.scaffold.toml`).** A first-class, committed,
+  auditable config layer the `check-*` scripts consume via a new pure-bash/awk
+  reader (`lib/scaffold-config`, no python/jq dependency). A team can: raise the
+  size cap globally or per glob (`[size]`), disable a forbidden-pattern or
+  hygiene rule entirely, or downgrade any of them `error → warn` (still emitted
+  as a CI `::warning::`, never silent). Rules are keyed
+  `"<patternfile-stem>/<description>"`, plus `conflict-marker` / `case-collision`
+  / `size`. Modifying a pattern's regex stays an edit to the `.forbidden-patterns`
+  file you own (no duplicated regexes). A malformed config **fails safe** —
+  rules stay fully enforced. **Security boundary:** `check-secrets` and
+  `check-filenames` ignore `.scaffold.toml` by design, so secret/credential-file
+  blocking cannot be disabled per-project. `lib/scaffold-audit` lists every
+  active override and the CI guardrails job echoes it into the build log;
+  `install.sh` ships an empty, fully-commented `.scaffold.toml`.
 - **TypeScript enforcement, broadened (P0).** The shipped `eslint.config.js`
   now extends typescript-eslint's **`strictTypeChecked`** tier with
   `projectService` auto-discovery, so type-aware rules actually fire. Pinned

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,21 @@ versioning follows [SemVer](https://semver.org/).
   default). Weekly grouped bumps of the SHA-pinned GitHub Actions so the pins
   don't rot.
 
+- **Multi-language forbidden patterns (config-driven).** `check-patterns` now
+  auto-discovers every `.forbidden-patterns/*.txt` and reads a
+  `# scaffold-extensions:` header from each, so adding a language is just
+  dropping a file — no script edit. Ships tuned, adversarially FP-reviewed
+  pattern files for **PHP, Go, Rust, Java, Kotlin, Ruby** (plus `*.vue` + Vue
+  `v-html` on the frontend set); FP-prone rules (Rust `.unwrap()`, Ruby `puts`,
+  PHP `die/exit`, …) ship commented as opt-in. `install.sh` auto-installs a
+  language's file when it detects the manifest (`go.mod`, `Cargo.toml`,
+  `composer.json`, `pom.xml`/`build.gradle`, `Gemfile`), or all of them with
+  `--all-langs`. backend/frontend/shell keep a built-in fallback mapping.
+- **PHP linting.** `php -l` (syntax) + `phpcs` (when configured) wired into the
+  pre-commit hook and a new `php` CI job (`setup-php` SHA-pinned). Ready-to-
+  uncomment, SHA-pinned CI job stubs added for Go/Rust/Java/Kotlin/Ruby linters.
+  +13 harness fixtures (a reject + a look-alike negative per language).
+
 ### Changed
 - **CI uses a frozen-lockfile install.** The frontend job runs `npm ci` when a
   lockfile is present (hard-failing on lockfile drift instead of silently

--- a/README.md
+++ b/README.md
@@ -108,8 +108,11 @@ Either way, the four `lib/check-*` scripts in `.githooks/lib/` are also runnable
 | `operational-rules.md` | `operational-rules.md` | Process and collaboration rules — failure modes that no linter can catch |
 | `ruff.toml.template` | `ruff.toml` | Python lint config |
 | `eslint.config.js.template` | `eslint.config.js` | TS/JS lint config (flat config, ESLint 9+) |
-| `githooks/pre-commit.template` | `.githooks/pre-commit` | Hook orchestrator — invokes the four `lib/check-*` scripts |
-| `githooks/lib/check-{size,patterns,filenames,secrets}.template` | `.githooks/lib/check-{size,patterns,filenames,secrets}` | Reusable check scripts; the same scripts run from CI so hook and CI can't drift |
+| `githooks/pre-commit.template` | `.githooks/pre-commit` | Hook orchestrator — invokes the five `lib/check-*` scripts |
+| `githooks/lib/check-{size,patterns,filenames,secrets,hygiene}.template` | `.githooks/lib/check-{size,patterns,filenames,secrets,hygiene}` | Reusable check scripts; the same scripts run from CI so hook and CI can't drift |
+| `githooks/lib/scaffold-config.template` | `.githooks/lib/scaffold-config` | Reads per-project rule overrides from `.scaffold.toml` (per-path size caps, per-rule disable / severity) |
+| `githooks/lib/scaffold-audit.template` | `.githooks/lib/scaffold-audit` | Lists every active override in `.scaffold.toml`; run locally and echoed by CI |
+| `.scaffold.toml.template` | `.scaffold.toml` | Per-project rule overrides — ships empty (commented), enforces nothing until edited |
 | `.github/workflows/lint.yml.template` | `.github/workflows/lint.yml` | CI mirror — invokes the same `lib/check-*` scripts as the hook |
 | `forbidden-patterns/backend.txt.template` | `.forbidden-patterns/backend.txt` | Python patterns consumed by hook + CI |
 | `forbidden-patterns/frontend.txt.template` | `.forbidden-patterns/frontend.txt` | TS/JS patterns consumed by hook + CI |
@@ -222,6 +225,48 @@ unaffected. See `forbidden-patterns/README.md` for examples.
 suppressing a guardrail.** Treat new markers like new `# noqa`s — confirm
 the suppression is justified before approving. Audit the full set with
 `git grep -i scaffold-allow`.
+
+### Per-project rule overrides (`.scaffold.toml`)
+
+`scaffold-allow` exempts a single *line*. When a team disagrees with a rule
+*as a whole* — or needs a bigger size budget for a legacy tree — record that
+decision once, durably and auditably, in a repo-root `.scaffold.toml`. It
+ships empty (all examples commented), so it changes nothing until you edit it.
+
+```toml
+[size]
+default     = 800          # raise the project-wide line cap (default 500)
+"legacy/**" = 2000         # most-specific matching glob wins
+
+[rules."php/var_dump( or print_r( left in code"]
+disabled = true            # turn a forbidden-pattern rule off entirely
+reason   = "legacy reporting module, JIRA-1234"
+by       = "alex 2026-06-11"
+
+[rules."frontend/console.log left in code"]
+severity = "warn"          # error (default) → warn: still reported, doesn't fail
+
+[rules.case-collision]     # hygiene ids: conflict-marker, case-collision
+severity = "warn"
+```
+
+- **Rule ids.** Forbidden-pattern rules are keyed `"<patternfile-stem>/<description>"`
+  (the text after the TAB in `.forbidden-patterns/<lang>.txt`). Hygiene rules
+  use `conflict-marker` / `case-collision`; the size cap uses `size`.
+- **Disable vs downgrade.** `disabled = true` turns the rule off; `severity =
+  "warn"` keeps emitting the finding (a CI `::warning::`) without failing the
+  build — a relaxed rule stays visible, never silent.
+- **Modifying a pattern's regex/description** is just editing the
+  `.forbidden-patterns/<lang>.txt` you already own; git history is the audit
+  trail. `.scaffold.toml` owns disable + severity, so a regex never lives in two
+  places.
+- **What you cannot override.** The secret scanner and the credential-filename
+  check (`check-secrets` / `check-filenames`) ignore `.scaffold.toml` entirely
+  — secret/key-file blocking is non-negotiable and can't be turned off
+  per-project.
+- **Audit.** `.githooks/lib/scaffold-audit` lists every active override; the CI
+  guardrails job prints it into the build log. Treat changes to `.scaffold.toml`
+  as security-relevant in review, the same as edits to `.githooks/**`.
 
 ## Opt-in layers
 

--- a/README.md
+++ b/README.md
@@ -67,10 +67,14 @@ The script auto-detects Python (`pyproject.toml` / `requirements.txt` / `setup.p
 ./install.sh --no-verify    # skip the post-install linter check
 ./install.sh --claude       # also install opt-in Claude Code agent guardrails
 ./install.sh --commit-msg   # also install the Conventional-Commits commit-msg hook
+./install.sh --all-langs    # install every language's forbidden-pattern file
 ./install.sh --help         # show usage
 ```
 
-See [Opt-in layers](#opt-in-layers) for what `--claude` and `--commit-msg` add.
+Language pattern files are auto-installed when their manifest is detected
+(`go.mod`, `Cargo.toml`, `composer.json`, `pom.xml`/`build.gradle`, `Gemfile`,
+…); `--all-langs` installs them all. See [Opt-in layers](#opt-in-layers) for
+what `--claude` and `--commit-msg` add.
 
 At the end, `install.sh` verifies that `ruff` and/or `eslint` are installed and that their configs load. If either is missing, it prints the install command.
 

--- a/coding-rules.md
+++ b/coding-rules.md
@@ -16,7 +16,7 @@ Short rule set. Most discipline is enforced by the linter (`ruff` / `eslint`) an
 
 ## Pattern files
 
-Stack-specific deny patterns live in `.forbidden-patterns/{backend,frontend,secrets}.txt`. Add deprecated import paths, old service names, banned API keys, etc. — the hook scans them on every commit and so does CI. Format is `<regex><TAB><description>` per line; see `forbidden-patterns/README.md` for the full reference.
+Stack-specific deny patterns live in `.forbidden-patterns/*.txt` (one per language — `backend.txt`, `frontend.txt`, `php.txt`, `go.txt`, `rust.txt`, `java.txt`, `kotlin.txt`, `ruby.txt`, `shell.txt` — plus the language-agnostic `secrets.txt`). Add deprecated import paths, old service names, banned API keys, etc. — the hook scans them on every commit and so does CI. Format is `<regex><TAB><description>` per line; each file declares the extensions it scans with a `# scaffold-extensions:` header, so adding a language is just dropping a file. See `forbidden-patterns/README.md` for the full reference.
 
 ## Communication
 

--- a/forbidden-patterns/README.md
+++ b/forbidden-patterns/README.md
@@ -1,14 +1,35 @@
 # forbidden-patterns/
 
 Pattern files consumed by `.githooks/lib/check-patterns` and
-`.githooks/lib/check-secrets`. Three files, same format, different scope:
+`.githooks/lib/check-secrets`. Same format, different scope:
 
 | File           | Scans                                              | Case-sensitive |
 |----------------|----------------------------------------------------|----------------|
 | `backend.txt`  | `*.py`                                             | yes            |
-| `frontend.txt` | `*.ts`, `*.tsx`, `*.js`, `*.jsx`                   | yes            |
+| `frontend.txt` | `*.ts`, `*.tsx`, `*.js`, `*.jsx`, `*.vue`         | yes            |
 | `shell.txt`    | `*.sh`, `*.bash`                                   | yes            |
+| `php.txt`      | `*.php`, `*.phtml`, …                              | yes            |
+| `go.txt`       | `*.go`                                             | yes            |
+| `rust.txt`     | `*.rs`                                             | yes            |
+| `java.txt`     | `*.java`                                           | yes            |
+| `kotlin.txt`   | `*.kt`, `*.kts`                                    | yes            |
+| `ruby.txt`     | `*.rb`, `*.rake`                                   | yes            |
 | `secrets.txt`  | all tracked text files (binaries / lockfiles excluded) | no         |
+
+`check-patterns` **auto-discovers** every `*.txt` here (except `secrets.txt`,
+which is `check-secrets`' domain). Each file declares which extensions it
+applies to with a header line:
+
+```
+# scaffold-extensions: go
+```
+
+so the table above isn't wired into any script — a file's own header is the
+source of truth. `backend.txt` / `frontend.txt` / `shell.txt` also have a
+built-in fallback mapping, so an older copy without the header still works.
+`install.sh` copies a language's file when it detects that language's manifest
+(`go.mod`, `Cargo.toml`, `composer.json`, `pom.xml`/`build.gradle`, `Gemfile`,
+…), or all of them with `--all-langs`.
 
 ## Format
 
@@ -79,14 +100,28 @@ marker — those rules are file-level, not line-level. Audit usage with
 
 ## Adding a pattern
 
-1. Pick the right file (backend / frontend / secrets).
+1. Pick the right file for the language.
 2. Test the regex first: `echo 'sample' | grep -E 'your-pattern'` (add
    `-i` for the secrets file).
 3. Insert a single TAB between regex and description.
 4. Run `./tests/run.sh` from the scaffold root — the harness exercises
    each pattern type.
 
-## Why three files
+## Adding a language
+
+No script edit required — that's the point of the `scaffold-extensions` header:
+
+1. Create `.forbidden-patterns/<lang>.txt`.
+2. First non-pattern line: `# scaffold-extensions: ext1 ext2` (the file
+   extensions to scan, space-separated, no dots).
+3. Add `<regex><TAB><description>` lines. Keep active patterns low-false-
+   positive — a blocked legitimate commit erodes trust fast. Ship FP-prone
+   ones (e.g. Rust `.unwrap()`, Ruby `puts`) commented as opt-in.
+4. `check-patterns` picks it up automatically on the next run. Add a fixture
+   to `tests/run.sh` and, optionally, a CI linter job (see the commented
+   stubs in `.github/workflows/lint.yml`).
+
+## Why split by language
 
 Splitting by language keeps regexes precise: a pattern targeting Python
 function calls (`(^|[^A-Za-z_])print[[:space:]]*\(`) shouldn't run against

--- a/forbidden-patterns/backend.txt.template
+++ b/forbidden-patterns/backend.txt.template
@@ -1,7 +1,11 @@
 # Forbidden patterns for Python files (*.py). Applied by .githooks/pre-commit.
+# scaffold-extensions: py
 # Format: <regex><TAB><description>   (one per line; # comments ignored)
 # Separator is TAB — patterns can contain literal `|` for ERE alternation
 # (e.g. `(TODO|FIXME|XXX)`). Patterns cannot contain a literal TAB.
+# The `scaffold-extensions:` header above tells check-patterns which file
+# extensions these rules scan — drop a new <lang>.txt with its own header to
+# add a language; see forbidden-patterns/README.md.
 # Copy to your project as `.forbidden-patterns/backend.txt`.
 
 (^|[^A-Za-z_])print[[:space:]]*\(	Use structlog (or the project's logger), not print()

--- a/forbidden-patterns/frontend.txt.template
+++ b/forbidden-patterns/frontend.txt.template
@@ -1,4 +1,5 @@
-# Forbidden patterns for TS/JS files (*.ts, *.tsx, *.js, *.jsx). Applied by .githooks/pre-commit.
+# Forbidden patterns for TS/JS/Vue files. Applied by .githooks/pre-commit.
+# scaffold-extensions: ts tsx js jsx vue
 # Format: <regex><TAB><description>   (one per line; # comments ignored)
 # Separator is TAB — patterns can contain literal `|` for ERE alternation.
 # Patterns are case-SENSITIVE, scanned against the staged blob. Copy to your
@@ -20,6 +21,7 @@
 
 # --- Security ---
 dangerouslySetInnerHTML	dangerouslySetInnerHTML is an XSS vector — sanitize or render as text
+(^|[^A-Za-z-])v-html[[:space:]]*=	Vue v-html is an XSS vector — sanitize or render with {{ }}/text
 https?://(localhost|127\.0\.0\.1)	No hardcoded localhost/127.0.0.1 URLs — read from config/env
 
 # Optional: forbid TODO/FIXME/XXX in one line via regex alternation.

--- a/forbidden-patterns/go.txt.template
+++ b/forbidden-patterns/go.txt.template
@@ -1,0 +1,15 @@
+# Forbidden patterns for Go files (*.go). Applied by .githooks/pre-commit.
+# scaffold-extensions: go
+# Format: <regex><TAB><description>   (one per line; # comments ignored)
+# Separator is TAB - patterns can contain literal `|` for ERE alternation.
+# Case-sensitive ERE (grep -anE). Copy to your project as `.forbidden-patterns/go.txt`.
+# Active rules flag leftover debug output; panic/log.Fatal live in optional below.
+
+(^|[^A-Za-z_.])fmt\.Print(ln|f)?[[:space:]]*\(	Remove fmt.Print/Println/Printf debug output - use the project logger
+(^|[^A-Za-z_.])println[[:space:]]*\(	Remove the builtin println() before committing
+(^|[^A-Za-z_.])spew\.Dump[[:space:]]*\(	Remove spew.Dump() debug dump before committing
+
+# Optional (opt-in) — uncomment a line to enable it:
+# (^|[^A-Za-z_.])print[[:space:]]*\(	Remove the builtin print() before committing (off by default: 'print' is a plausible method/field name)
+# (^|[^A-Za-z_])panic[[:space:]]*\(	Avoid panic() in library code - return an error (off by default: legitimate in main/init and tests)
+# (^|[^A-Za-z_])log\.(Fatal|Panic)(f|ln)?[[:space:]]*\(	Avoid log.Fatal/log.Panic in library code - return an error (off by default: legitimate in main)

--- a/forbidden-patterns/java.txt.template
+++ b/forbidden-patterns/java.txt.template
@@ -1,0 +1,16 @@
+# Forbidden patterns for Java files (*.java). Applied by .githooks/pre-commit.
+# scaffold-extensions: java
+# Format: <regex><TAB><description>   (one per line; # comments ignored)
+# Separator is TAB - patterns can contain literal `|` for ERE alternation.
+# Patterns are POSIX ERE, matched case-sensitively with `grep -anE`.
+# Bans console debug output; keeps logger.info/warn/error intact.
+# printStackTrace ban is no-arg only; printStackTrace(writer) is allowed (logging idiom).
+# Copy to your project as `.forbidden-patterns/java.txt`.
+
+(^|[^A-Za-z_])System\.out\.print(ln)?[[:space:]]*\(	Use a logger (slf4j/Log4j), not System.out.print/println
+(^|[^A-Za-z_])System\.err\.print(ln|f)?[[:space:]]*\(	Use logger.error(), not System.err.print/println/printf
+\.printStackTrace[[:space:]]*\([[:space:]]*\)	Log the exception via the logger, not e.printStackTrace(); pass a PrintWriter to capture it instead
+
+# Optional (opt-in) — uncomment a line to enable it:
+# (^|[^A-Za-z_])(TODO|FIXME|XXX)($|[^A-Za-z0-9_])	TODO/FIXME/XXX not allowed - open a ticket instead
+# (^|[^A-Za-z_])System\.out\.printf[[:space:]]*\(	Use a logger, not System.out.printf (FP-prone in CLI tools)

--- a/forbidden-patterns/kotlin.txt.template
+++ b/forbidden-patterns/kotlin.txt.template
@@ -1,0 +1,22 @@
+# Forbidden patterns for Kotlin files (*.kt, *.kts). Applied by .githooks/pre-commit.
+# scaffold-extensions: kt kts
+# Format: <regex><TAB><description>   (one per line; # comments ignored)
+# Separator is TAB - patterns can contain literal `|` for ERE alternation; no literal TAB.
+# Copy to your project as `.forbidden-patterns/kotlin.txt`.
+# Note: *.kts are Gradle/script files where println() is idiomatic; flagging it there
+# still catches stray debug output, but expect to scaffold-allow legitimate cases.
+# print/println/TODO anchors exclude a preceding `.` so member calls like writer.println(),
+# document.print(), and obj.TODO() do NOT match - only the unqualified kotlin.io builtins do.
+
+(^|[^A-Za-z0-9_.])println[[:space:]]*\(	Use the project's logger (e.g. slf4j/kotlin-logging), not println()
+(^|[^A-Za-z0-9_.])print[[:space:]]*\(	Use the project's logger, not print()
+System\.(out|err)\.print(ln)?[[:space:]]*\(	Use the project's logger, not System.out/System.err.print(ln)
+(^|[^A-Za-z0-9_])printStackTrace[[:space:]]*\(	Log the exception via the project's logger, not printStackTrace()
+(^|[^A-Za-z0-9_.])TODO[[:space:]]*\(	kotlin.TODO() throws NotImplementedError at runtime - finish the impl or open a ticket
+
+# Optional (opt-in) — uncomment a line to enable it:
+# (^|[^A-Za-z_])(TODO|FIXME|XXX)($|[^A-Za-z0-9_])	TODO/FIXME/XXX comment not allowed - open a ticket instead (FP-prone in comments/strings)
+# @Disabled($|[^A-Za-z0-9_])	Disabled JUnit5 test committed - re-enable or delete (may be intentional)
+# (^|[^A-Za-z_])(it|i)gnore[[:space:]]*=[[:space:]]*true	Ignored test annotation - re-enable or delete (FP-prone; matches config flags)
+# !![[:space:]]*($|[^=])	Avoid the !! not-null assertion - use safe calls or requireNotNull (very FP-prone)
+# GlobalScope\.	Avoid GlobalScope - use a structured-concurrency CoroutineScope (some scripts legitimately use it)

--- a/forbidden-patterns/php.txt.template
+++ b/forbidden-patterns/php.txt.template
@@ -1,0 +1,20 @@
+# Forbidden patterns for PHP files. Applied by .githooks/pre-commit.
+# scaffold-extensions: php phtml php3 php4 php5 php7 php8
+# Format: <regex><TAB><description>   (one per line; # comments ignored)
+# Separator is TAB; patterns can contain literal | for ERE alternation.
+# Patterns are case-SENSITIVE, scanned against the staged blob. Copy to
+# your project as `.forbidden-patterns/php.txt`.
+# error_log() is intentionally NOT banned - it is legitimate logging.
+# die()/exit() are common control flow and live in optionalPatterns.
+
+(^|[^A-Za-z_])var_dump[[:space:]]*\(	Remove var_dump() before committing - dumps to stdout
+(^|[^A-Za-z_>])dd[[:space:]]*\(	Remove dd() (dump-and-die) before committing - it is a debug call
+(^|[^A-Za-z_>])dump[[:space:]]*\(	Remove dump() (var-dumper/Laravel/Symfony) before committing
+(^|[^A-Za-z_])xdebug_break[[:space:]]*\(	Remove xdebug_break() before committing
+
+# Optional (opt-in) — uncomment a line to enable it:
+# (^|[^A-Za-z_])print_r[[:space:]]*\(	print_r() leaks to stdout unless 2nd arg is true - opt in if your app never returns its output
+# (^|[^A-Za-z_])var_export[[:space:]]*\(	var_export() leaks to stdout unless 2nd arg is true - opt in if your app never returns its output
+# (^|[^A-Za-z_])(die|exit)[[:space:]]*\(	die()/exit() - often legitimate control flow; opt in if your codebase forbids it
+# (^|[^A-Za-z_])(TODO|FIXME|XXX)($|[^A-Za-z0-9_])	TODO/FIXME/XXX not allowed - open a ticket instead
+# (^|[^A-Za-z_.>:])(eval|assert)[[:space:]]*\(	Avoid eval()/assert(string) - arbitrary-code-execution risk; excludes ->assert and ::assert test calls

--- a/forbidden-patterns/ruby.txt.template
+++ b/forbidden-patterns/ruby.txt.template
@@ -1,0 +1,25 @@
+# Forbidden patterns for Ruby files (*.rb, *.rake). Applied by .githooks/pre-commit.
+# scaffold-extensions: rb rake
+# Format: <regex><TAB><description>   (one per line; # comments ignored)
+# Separator is TAB - patterns can contain literal `|` for ERE alternation.
+# Patterns are case-SENSITIVE, scanned against the staged blob. Copy to your
+# project as `.forbidden-patterns/ruby.txt`.
+# Targets debugger breakpoints (binding.pry/irb, byebug, debugger) and pp.
+# Rails.logger and raise are intentionally NOT banned. puts/p are FP-prone
+# for CLI tools and ship commented below.
+# The `debugger` pattern excludes a trailing `:` so the `debugger:` keyword/hash
+# key is allowed; only the bare breakpoint statement is caught.
+
+(^|[^A-Za-z_])binding\.pry($|[^A-Za-z0-9_])	Remove binding.pry breakpoint before committing
+(^|[^A-Za-z_])binding\.irb($|[^A-Za-z0-9_])	Remove binding.irb breakpoint before committing
+(^|[^A-Za-z_])byebug($|[^A-Za-z0-9_])	Remove byebug breakpoint before committing
+(^|[^A-Za-z_])debugger($|[^A-Za-z0-9_:])	Remove debugger breakpoint before committing
+(^|[^A-Za-z_])require[[:space:]]+.(pry-byebug|byebug|pry|debug)('|")	Don't commit a require of a debug gem (pry/byebug/debug)
+(^|[^A-Za-z_])save_and_open_(page|screenshot)($|[^A-Za-z0-9_])	Remove Capybara save_and_open_page/screenshot debug call before committing
+(^|[^A-Za-z_.])pp([[:space:]]+[^[:space:]=]|[[:space:]]*\()	Remove pp() pretty-print debug call; use the logger instead
+
+# Optional (opt-in) — uncomment a line to enable it:
+# (^|[^A-Za-z_.])puts[[:space:]]*[\( ]	puts is common legitimate CLI output - enable only if your app uses a logger exclusively
+# (^|[^A-Za-z_.])p[[:space:]]+[^[:space:]=]	p is FP-prone (single-letter, also a common local var) - opt in with care
+# (^|[^A-Za-z_])(TODO|FIXME|XXX)($|[^A-Za-z0-9_])	TODO/FIXME/XXX not allowed - open a ticket instead
+# (^|[^A-Za-z_])(binding\.remote_pry|PryRemote)($|[^A-Za-z0-9_])	Remove remote-pry breakpoint before committing

--- a/forbidden-patterns/rust.txt.template
+++ b/forbidden-patterns/rust.txt.template
@@ -1,0 +1,26 @@
+# Forbidden patterns for Rust files (*.rs). Applied by .githooks/pre-commit.
+# scaffold-extensions: rs
+# Format: <regex><TAB><description>   (one per line; # comments ignored)
+# Separator is TAB - patterns can contain literal `|` for ERE alternation.
+# Patterns are case-SENSITIVE, scanned against the staged blob. Copy to your
+# project as `.forbidden-patterns/rust.txt`.
+# Each macro pattern requires an opening delimiter ( [ { after the `!` so it
+# only fires on a real invocation, not an identifier or a comment mention, and
+# to stay portable across GNU grep and ugrep.
+# Delimiter class is [([{] - bracket expressions take literal chars, no backslashes.
+
+(^|[^A-Za-z_])dbg![[:space:]]*[([{]	Remove dbg!() debug macro before committing
+(^|[^A-Za-z_])println![[:space:]]*[([{]	Use the project logger (log/tracing), not println!()
+(^|[^A-Za-z_])print![[:space:]]*[([{]	Use the project logger (log/tracing), not print!()
+(^|[^A-Za-z_])eprintln![[:space:]]*[([{]	Use the project logger (log/tracing), not eprintln!()
+(^|[^A-Za-z_])eprint![[:space:]]*[([{]	Use the project logger (log/tracing), not eprint!()
+(^|[^A-Za-z_])todo![[:space:]]*[([{]	Unfinished code: todo!() left in - implement or open a ticket
+(^|[^A-Za-z_])unimplemented![[:space:]]*[([{]	Unfinished code: unimplemented!() left in - implement before committing
+(^|[^A-Za-z_])unreachable![[:space:]]*[([{]	unreachable!() panics in prod if hit - prove it or return a Result
+
+# Optional (opt-in) — uncomment a line to enable it:
+# (^|[^A-Za-z_])panic![[:space:]]*[([{]	panic!() aborts the thread - prefer returning a Result (opt-in: noisy)
+# \.unwrap[[:space:]]*\(	.unwrap() panics on None/Err - prefer ? or expect() (opt-in: very FP-heavy)
+# \.expect[[:space:]]*\(	.expect() panics on None/Err - prefer ? or proper handling (opt-in: very FP-heavy)
+# (^|[^A-Za-z_])(TODO|FIXME|XXX)($|[^A-Za-z0-9_])	TODO/FIXME/XXX not allowed - open a ticket instead (opt-in)
+# #\[allow\(	An #[allow(...)] suppresses a lint - justify in review, not silently (opt-in: common)

--- a/forbidden-patterns/shell.txt.template
+++ b/forbidden-patterns/shell.txt.template
@@ -1,4 +1,5 @@
 # Forbidden patterns for shell scripts (*.sh, *.bash). See forbidden-patterns/README.md.
+# scaffold-extensions: sh bash
 # Copy to your project as `.forbidden-patterns/shell.txt`.
 
 (^|[^A-Za-z_])(curl|wget)([[:space:]]+[^|]*)?\|[[:space:]]*(sudo[[:space:]]+)?(bash|sh|zsh)([[:space:]]|$)	Piping remote download to a shell — review the script and run it as a separate step

--- a/githooks/lib/check-hygiene.template
+++ b/githooks/lib/check-hygiene.template
@@ -21,6 +21,10 @@
 # A `scaffold-allow` marker (after a comment leader) exempts a conflict-marker
 # line, for the rare doc that shows one on purpose.
 #
+# Per-project overrides (lib/scaffold-config, .scaffold.toml): the rule ids
+# `conflict-marker` and `case-collision` can each be disabled or downgraded to a
+# non-failing warning. Absent/unparseable config → both fully enforced (safe).
+#
 # Output: human-readable on tty; ::error file=...:: when --ci is passed.
 # Exit:   0 if all OK, 1 if any violation.
 
@@ -37,12 +41,30 @@ ghesc() {
   printf '%s' "$s"
 }
 
+# Per-project overrides (.scaffold.toml via the sibling scaffold-config helper).
+# Fails open to empty output when the helper is missing (older install), so the
+# caller treats the rule as fully enforced.
+SELF_DIR="$(cd "$(dirname "$0")" && pwd)"
+CONFIG_BIN="$SELF_DIR/scaffold-config"
+cfg() { [ -x "$CONFIG_BIN" ] || return 0; "$CONFIG_BIN" "$@" 2>/dev/null || true; }
+
+# Emit a finding at the resolved severity. `warn` reports without failing the
+# build; `error` sets FAILED. (Callers skip the check entirely when `disabled`.)
 emit() {
-  local file=$1 message=$2
-  if [ "$CI_MODE" -eq 1 ]; then
-    echo "::error file=$(ghesc prop "$file")::$(ghesc data "$message")"
+  local state=$1 file=$2 message=$3
+  if [ "$state" = warn ]; then
+    if [ "$CI_MODE" -eq 1 ]; then
+      echo "::warning file=$(ghesc prop "$file")::$(ghesc data "$message")"
+    else
+      echo "! $file: $message (warn — .scaffold.toml override)"
+    fi
   else
-    echo "✗ $file: $message"
+    if [ "$CI_MODE" -eq 1 ]; then
+      echo "::error file=$(ghesc prop "$file")::$(ghesc data "$message")"
+    else
+      echo "✗ $file: $message"
+    fi
+    FAILED=1
   fi
 }
 
@@ -65,38 +87,42 @@ done
 FAILED=0
 
 # --- 1. merge-conflict markers ---------------------------------------------
-CONFLICT_RE='^(<{7}|>{7}|\|{7})( |$)'
-for file in "${FILES[@]}"; do
-  cap_rc=0
-  content=$(git show ":0:$file" 2>/dev/null | awk -v n="$MAX_LINE_LENGTH" 'length > n { next } { print }') || cap_rc=$?
-  [ "$cap_rc" -eq 0 ] || true
-  [ -n "$content" ] || continue
-  m=$(grep -anE -- "$CONFLICT_RE" <<<"$content" | grep -ivE '(#|//|/\*|<!--|--)[[:space:]]*scaffold-allow' || true)
-  if [ -n "$m" ]; then
-    emit "$file" "merge-conflict marker — resolve the conflict before committing"
-    printf '%s\n' "$m" | head -3 | sed 's/^/    /' >&2 || true
-    FAILED=1
-  fi
-done
+CONFLICT_STATE=$(cfg rule-state conflict-marker); [ -n "$CONFLICT_STATE" ] || CONFLICT_STATE=error
+if [ "$CONFLICT_STATE" != disabled ]; then
+  CONFLICT_RE='^(<{7}|>{7}|\|{7})( |$)'
+  for file in "${FILES[@]}"; do
+    cap_rc=0
+    content=$(git show ":0:$file" 2>/dev/null | awk -v n="$MAX_LINE_LENGTH" 'length > n { next } { print }') || cap_rc=$?
+    [ "$cap_rc" -eq 0 ] || true
+    [ -n "$content" ] || continue
+    m=$(grep -anE -- "$CONFLICT_RE" <<<"$content" | grep -ivE '(#|//|/\*|<!--|--)[[:space:]]*scaffold-allow' || true)
+    if [ -n "$m" ]; then
+      emit "$CONFLICT_STATE" "$file" "merge-conflict marker — resolve the conflict before committing"
+      printf '%s\n' "$m" | head -3 | sed 's/^/    /' >&2 || true
+    fi
+  done
+fi
 
 # --- 2. case-only filename collisions --------------------------------------
 # bash 3.2 (macOS) has no associative arrays and no ${var,,}, so lowercase each
 # path once with tr into a parallel array, then compare pairwise (O(n^2) string
 # compares, no subprocess in the inner loop). NUL-delimited input means a path
 # may legitimately contain a newline, so we never split on newlines here.
-LOWER=()
-for f in "${FILES[@]}"; do
-  LOWER+=("$(printf '%s' "$f" | tr '[:upper:]' '[:lower:]')")
-done
-
-n=${#FILES[@]}
-for ((i = 0; i < n; i++)); do
-  for ((j = i + 1; j < n; j++)); do
-    if [ "${LOWER[$i]}" = "${LOWER[$j]}" ] && [ "${FILES[$i]}" != "${FILES[$j]}" ]; then
-      emit "${FILES[$j]}" "case-only filename collision with '${FILES[$i]}' — breaks case-insensitive checkouts (macOS/Windows)"
-      FAILED=1
-    fi
+CASE_STATE=$(cfg rule-state case-collision); [ -n "$CASE_STATE" ] || CASE_STATE=error
+if [ "$CASE_STATE" != disabled ]; then
+  LOWER=()
+  for f in "${FILES[@]}"; do
+    LOWER+=("$(printf '%s' "$f" | tr '[:upper:]' '[:lower:]')")
   done
-done
+
+  n=${#FILES[@]}
+  for ((i = 0; i < n; i++)); do
+    for ((j = i + 1; j < n; j++)); do
+      if [ "${LOWER[$i]}" = "${LOWER[$j]}" ] && [ "${FILES[$i]}" != "${FILES[$j]}" ]; then
+        emit "$CASE_STATE" "${FILES[$j]}" "case-only filename collision with '${FILES[$i]}' — breaks case-insensitive checkouts (macOS/Windows)"
+      fi
+    done
+  done
+fi
 
 exit $FAILED

--- a/githooks/lib/check-patterns.template
+++ b/githooks/lib/check-patterns.template
@@ -1,7 +1,14 @@
 #!/usr/bin/env bash
 # .githooks/lib/check-patterns — forbidden-pattern scan for source files.
-# Reads NUL-separated file paths on stdin (produced by `git ... -z`). Scans .py
-# against backend.txt, TS/JS against frontend.txt, and shell against shell.txt.
+# Reads NUL-separated file paths on stdin (produced by `git ... -z`). Auto-
+# discovers every `.forbidden-patterns/*.txt` (except secrets.txt, which is
+# check-secrets' domain) and scans the files whose extension the pattern file
+# claims. A pattern file declares its extensions with a header line:
+#   # scaffold-extensions: py
+#   # scaffold-extensions: ts tsx js jsx vue
+# so a new language is added by dropping `<lang>.txt` with that header — no edit
+# to this script. backend.txt / frontend.txt / shell.txt have a built-in
+# fallback mapping for backward compatibility.
 # Pattern format: <regex><TAB><description>
 # (TAB is the field separator so regex can use literal `|` alternation.)
 #
@@ -156,9 +163,38 @@ scan() {
   done
 }
 
+# Resolve which file extensions a pattern file applies to. An explicit
+#   # scaffold-extensions: ext1 ext2 ...
+# header (first matching comment line) wins, so a new language is added by just
+# dropping a `<lang>.txt` with that header — no edit to this script. The three
+# original files have a built-in fallback so an older copy without the header
+# keeps working.
+exts_for() {
+  local cfg=$1 hdr
+  hdr=$(grep -m1 -E '^#[[:space:]]*scaffold-extensions:' "$cfg" 2>/dev/null \
+          | sed -E 's/^#[[:space:]]*scaffold-extensions:[[:space:]]*//; s/[[:space:]]+$//')
+  if [ -n "$hdr" ]; then printf '%s' "$hdr"; return; fi
+  case "$(basename "$cfg")" in
+    backend.txt)  printf 'py' ;;
+    frontend.txt) printf 'ts tsx js jsx vue' ;;
+    shell.txt)    printf 'sh bash' ;;
+    *)            printf '' ;;
+  esac
+}
+
 FAILED=0
-scan ".forbidden-patterns/backend.txt" py
-scan ".forbidden-patterns/frontend.txt" ts tsx js jsx
-scan ".forbidden-patterns/shell.txt" sh bash
+# Auto-discover every pattern file. secrets.txt is check-secrets' domain (it
+# scans all files, not by extension), so skip it here.
+for cfg in .forbidden-patterns/*.txt; do
+  [ -e "$cfg" ] || continue   # no glob match → literal string; skip
+  case "$(basename "$cfg")" in secrets.txt) continue ;; esac
+  cfg_exts=$(exts_for "$cfg")
+  if [ -z "$cfg_exts" ]; then
+    echo "warning: $cfg: no '# scaffold-extensions:' header and no built-in mapping — skipped" >&2
+    continue
+  fi
+  # shellcheck disable=SC2086  # word-splitting $cfg_exts into separate args is intentional
+  scan "$cfg" $cfg_exts
+done
 
 exit $FAILED

--- a/githooks/lib/check-patterns.template
+++ b/githooks/lib/check-patterns.template
@@ -38,6 +38,36 @@ ghesc() {
   printf '%s' "$s"
 }
 
+# Per-project overrides (.scaffold.toml via the sibling scaffold-config helper).
+# `cfg` fails open to empty output when the helper is missing (older install);
+# the caller then treats every rule as fully enforced (fail safe).
+SELF_DIR="$(cd "$(dirname "$0")" && pwd)"
+CONFIG_BIN="$SELF_DIR/scaffold-config"
+cfg() { [ -x "$CONFIG_BIN" ] || return 0; "$CONFIG_BIN" "$@" 2>/dev/null || true; }
+
+# Emit one finding at the resolved severity. `warn` reports without failing the
+# build (a deliberate, audited downgrade); `error` fails. FAILED is the global
+# set below; this is only ever called after it exists.
+report() {
+  local state=$1 file=$2 desc=$3 matches=$4
+  if [ "$state" = warn ]; then
+    if [ "$CI_MODE" -eq 1 ]; then
+      echo "::warning file=$(ghesc prop "$file")::$(ghesc data "$desc")"
+    else
+      echo "! $file: $desc (warn — .scaffold.toml override)"
+      printf '%s\n' "$matches" | head -3 | sed 's/^/    /' || true
+    fi
+  else
+    if [ "$CI_MODE" -eq 1 ]; then
+      echo "::error file=$(ghesc prop "$file")::$(ghesc data "$desc")"
+    else
+      echo "✗ $file: $desc"
+      printf '%s\n' "$matches" | head -3 | sed 's/^/    /' || true
+    fi
+    FAILED=1
+  fi
+}
+
 # Cap the maximum scanned LINE length (see check-secrets): one very long line
 # can make the combined ERE hang the hook/CI. Over-long lines are dropped with
 # a warning. Linear awk length check; the ERE on a long line is not linear.
@@ -58,6 +88,11 @@ scan() {
   local exts=("$@")
   [ -f "$config" ] || return 0
   [ ${#FILES[@]} -eq 0 ] && return 0
+
+  # Rule-id prefix for .scaffold.toml lookups: the pattern file's stem, e.g.
+  # `php` for php.txt. A rule's full id is "<stem>/<description>".
+  local stem
+  stem=$(basename "$config" .txt)
 
   local raw_patterns=() raw_descs=()
   local line pattern description
@@ -152,13 +187,12 @@ scan() {
       # Exempt only a comment-anchored marker (see check-secrets).
       m=$(grep -anE -- "$pat" <<<"$content" | grep -ivE '(#|//|/\*|<!--|--)[[:space:]]*scaffold-allow' || true)
       [ -n "$m" ] || continue
-      if [ "$CI_MODE" -eq 1 ]; then
-        echo "::error file=$(ghesc prop "$file")::$(ghesc data "$desc")"
-      else
-        echo "✗ $file: $desc"
-        printf '%s\n' "$m" | head -3 | sed 's/^/    /' || true
-      fi
-      FAILED=1
+      # Per-rule override: `disabled` skips the rule, `warn` reports without
+      # failing, anything else (incl. missing config) enforces as `error`.
+      local state
+      state=$(cfg rule-state "$stem/$desc"); [ -n "$state" ] || state=error
+      [ "$state" = disabled ] && continue
+      report "$state" "$file" "$desc" "$m"
     done
   done
 }

--- a/githooks/lib/check-size.template
+++ b/githooks/lib/check-size.template
@@ -6,6 +6,11 @@
 # the count reflects exactly what will be committed. Skips docs, data, and
 # binary types.
 #
+# Per-project overrides (lib/scaffold-config, .scaffold.toml): a per-path
+# `[size]` glob raises the cap for matching files, and `[rules.size]` can
+# disable the whole check or downgrade it to a non-failing warning. Absent or
+# unparseable config → the MAX_LINES default, fully enforced (fail safe).
+#
 # Output: human-readable on tty; ::error file=...:: when --ci is passed.
 # Exit:   0 if all OK, 1 if any violation.
 
@@ -34,24 +39,49 @@ ghesc() {
   printf '%s' "$s"
 }
 
+# Per-project overrides live in .scaffold.toml, read via the sibling
+# scaffold-config helper. `cfg` fails open to empty output if the helper is
+# missing (older install) — callers then fall back to the built-in defaults.
+SELF_DIR="$(cd "$(dirname "$0")" && pwd)"
+CONFIG_BIN="$SELF_DIR/scaffold-config"
+cfg() { [ -x "$CONFIG_BIN" ] || return 0; "$CONFIG_BIN" "$@" 2>/dev/null || true; }
+
+# Whole-check state: `disabled` skips the size cap, `warn` reports without
+# failing. Default `error`.
+SIZE_STATE=$(cfg rule-state size); [ -n "$SIZE_STATE" ] || SIZE_STATE=error
+[ "$SIZE_STATE" = disabled ] && exit 0
+
+# Emit a finding at the resolved severity. `warn` prints but does not fail the
+# build (a deliberate, audited downgrade); `error` fails as usual.
 FAILED=0
+emit() {
+  local file=$1 message=$2
+  if [ "$SIZE_STATE" = warn ]; then
+    if [ "$CI_MODE" -eq 1 ]; then echo "::warning file=$(ghesc prop "$file")::$(ghesc data "$message")"
+    else echo "! $file: $message (warn — .scaffold.toml override)"; fi
+  else
+    if [ "$CI_MODE" -eq 1 ]; then echo "::error file=$(ghesc prop "$file")::$(ghesc data "$message")"
+    else echo "✗ $file: $message"; fi
+    FAILED=1
+  fi
+}
+
 while IFS= read -r -d '' file; do
   [ -z "$file" ] && continue
   case "$file" in
     *.md|*.json|*.toml|*.yaml|*.yml|*.lock|*.txt|*.csv|*.sql) continue ;;
     *.svg|*.png|*.jpg|*.jpeg|*.gif|*.ico|*.pdf) continue ;;
   esac
+  # Per-path cap from .scaffold.toml [size], else the global MAX_LINES. A junk
+  # value can't slip through: scaffold-config only emits an integer.
+  cap=$(cfg size-cap "$file")
+  case "$cap" in ''|*[!0-9]*) cap=$MAX_LINES ;; esac
   # `grep -c ''` counts every line, including a trailing line without a
   # final newline (which `wc -l` would silently miss). -a keeps grep in text
   # mode so an embedded NUL byte can't abort the count.
   lines=$(git show ":0:$file" 2>/dev/null | grep -ac '' || true)
-  if [ "$lines" -gt "$MAX_LINES" ]; then
-    if [ "$CI_MODE" -eq 1 ]; then
-      echo "::error file=$(ghesc prop "$file")::$lines lines (max $MAX_LINES) — extract a module"
-    else
-      echo "✗ $file: $lines lines (max $MAX_LINES) — extract a module"
-    fi
-    FAILED=1
+  if [ "$lines" -gt "$cap" ]; then
+    emit "$file" "$lines lines (max $cap) — extract a module"
   fi
 done
 

--- a/githooks/lib/scaffold-audit.template
+++ b/githooks/lib/scaffold-audit.template
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# .githooks/lib/scaffold-audit — list every active rule override recorded in the
+# repo-root `.scaffold.toml`, in one readable block. Run it locally to review a
+# project's deviations; the CI guardrails job runs it too, so every relaxed or
+# disabled rule is visible in the build log (a `severity = "warn"` downgrade is
+# never silent).
+#
+# Informational only: always exits 0. Pure bash + awk, same TOML subset as
+# lib/scaffold-config (the parser of record — this is a reporting view of it).
+#
+# Output: a heading plus one stanza per [size] cap and per [rules."..."] entry.
+
+set -euo pipefail
+
+CONFIG=".scaffold.toml"
+
+if [ ! -f "$CONFIG" ]; then
+  echo "scaffold-audit: no .scaffold.toml — all rules at scaffold defaults."
+  exit 0
+fi
+
+# awk walks the same subset scaffold-config parses and renders each override.
+# It counts emitted stanzas so an empty/all-comments config reports cleanly.
+out=$(awk '
+  function trim(s){ sub(/^[ \t]+/,"",s); sub(/[ \t]+$/,"",s); return s }
+  function unq(s){ if (s ~ /^".*"$/) s=substr(s,2,length(s)-2); return s }
+  function flush(){
+    if (cur=="") return
+    if (cur=="size") return            # [size] entries print inline as parsed
+    line="  rule \"" rid "\""
+    if (disabled) line=line "  — DISABLED"
+    else if (sev!="") line=line "  — severity=" sev
+    else line=line "  — (recorded, no enforcement change)"
+    print line
+    if (reason!="") print "      reason: " reason
+    if (by!="")     print "      by:     " by
+    count++
+  }
+  BEGIN { cur=""; rid=""; disabled=0; sev=""; reason=""; by=""; sizehdr=0; count=0 }
+  {
+    t=$0; sub(/\r$/,"",t); t=trim(t)
+    if (t=="" || t ~ /^#/) next
+    if (t ~ /^\[/) {
+      flush()
+      disabled=0; sev=""; reason=""; by=""
+      sec=t; sub(/^\[/,"",sec); sub(/\]$/,"",sec)
+      if (sec=="size") { cur="size"; rid="" }
+      else if (sec ~ /^rules\./) { cur="rule"; rid=unq(substr(sec,7)) }
+      else { cur="" }            # unknown section — ignored, like the reader
+      next
+    }
+    if (cur=="") next
+    eq=index(t,"="); if (eq==0) next
+    key=unq(trim(substr(t,1,eq-1))); val=unq(trim(substr(t,eq+1)))
+    if (cur=="size") {
+      if (!sizehdr) { print "  [size] caps:"; sizehdr=1 }
+      print "      " key " = " val
+      count++
+      next
+    }
+    if (key=="disabled" && val=="true") disabled=1
+    else if (key=="severity") sev=val
+    else if (key=="reason") reason=val
+    else if (key=="by") by=val
+  }
+  END { flush(); if (count==0) print "  (no overrides — empty or comments only)" }
+' "$CONFIG")
+
+echo "scaffold-audit: active rule overrides in $CONFIG"
+printf '%s\n' "$out"

--- a/githooks/lib/scaffold-config.template
+++ b/githooks/lib/scaffold-config.template
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# .githooks/lib/scaffold-config — read per-project rule overrides from the
+# repo-root `.scaffold.toml`. This is the single place every guardrail consults
+# for "the dev overrode this rule" decisions, so the override state lives in one
+# committed, greppable, auditable file (see lib/scaffold-audit).
+#
+# It parses a strict TOML *subset*, in pure bash + awk (NO python/jq), so the
+# core guardrails keep working on a bare machine:
+#   - `[section]` headers, including dotted/quoted ones: [rules."php/foo bar"]
+#   - bare or "quoted" keys:  default = 800   "src/**" = 1200   disabled = true
+#   - values: integers, true/false, and "double-quoted strings"
+#   - `#` comments on their own line, and blank lines
+# Arrays, inline tables, multiline strings, and trailing comments are NOT
+# supported. Anything it cannot parse is simply ignored — so a malformed config
+# FAILS SAFE: an entry only ever takes effect when it parses cleanly, and the
+# scanners stay fully enforced otherwise. A config can only make checks weaker
+# through an explicit, well-formed entry that a reviewer can see in the diff.
+#
+# SECURITY BOUNDARY: check-secrets and check-filenames deliberately never call
+# this. Secret/credential-file blocking is non-negotiable and cannot be disabled
+# or downgraded per-project — a malicious PR cannot add a `.scaffold.toml` that
+# neuters them. Overrides apply only to: forbidden-pattern rules, the size cap,
+# and the hygiene rules.
+#
+# Subcommands:
+#   size-cap <path>   Print the effective max-lines for <path>: the most-specific
+#                     matching [size] glob (longest pattern wins), else
+#                     [size].default, else nothing (caller keeps its own default).
+#                     Globs use bash `[[ == ]]` semantics, where `*` also spans `/`.
+#   rule-state <id>   Print exactly one of: disabled | warn | error (default
+#                     error). `disabled` wins over `severity`.
+#
+# Rule ids:
+#   "<patternfile-stem>/<description>"  forbidden-pattern rules (quote in TOML)
+#   conflict-marker | case-collision    hygiene rules
+#   size                                 the file-size cap (whole check)
+#
+# Exit: 0 always for the two queries (prints the answer to stdout); 2 on misuse.
+
+set -euo pipefail
+
+CONFIG=".scaffold.toml"
+cmd=${1:-}
+
+# No config → defaults everywhere. size-cap prints nothing; rule-state is error.
+if [ ! -f "$CONFIG" ]; then
+  case "$cmd" in
+    size-cap)   exit 0 ;;
+    rule-state) echo "error"; exit 0 ;;
+    *)          echo "usage: scaffold-config {size-cap <path>|rule-state <id>}" >&2; exit 2 ;;
+  esac
+fi
+
+case "$cmd" in
+  size-cap)
+    path=${2:-}
+    [ -n "$path" ] || exit 0
+    # awk emits the [size] table: "D<TAB>val" for default, "G<TAB>glob<TAB>val"
+    # per glob. Glob-matching needs shell semantics, so it's done in bash below.
+    dump=$(awk '
+      function trim(s){ sub(/^[ \t]+/,"",s); sub(/[ \t]+$/,"",s); return s }
+      function unq(s){ if (s ~ /^".*"$/) s=substr(s,2,length(s)-2); return s }
+      {
+        line=$0; sub(/\r$/,"",line); t=trim(line)
+        if (t=="" || t ~ /^#/) next
+        if (t ~ /^\[/) { sec=t; sub(/^\[/,"",sec); sub(/\]$/,"",sec); insize=(sec=="size"); next }
+        if (!insize) next
+        eq=index(t,"="); if (eq==0) next
+        key=unq(trim(substr(t,1,eq-1))); val=unq(trim(substr(t,eq+1)))
+        if (key=="default") print "D\t" val
+        else print "G\t" key "\t" val
+      }
+    ' "$CONFIG")
+
+    best=""; bestlen=-1; default=""
+    while IFS=$'\t' read -r tag a b; do
+      case "$tag" in
+        D) default=$a ;;
+        G)
+          # Only an integer cap is honoured; a junk value fails safe (ignored).
+          case "$b" in ''|*[!0-9]*) continue ;; esac
+          # shellcheck disable=SC2053  # intentional glob match of $path against $a
+          if [[ "$path" == $a ]] && [ "${#a}" -gt "$bestlen" ]; then
+            best=$b; bestlen=${#a}
+          fi
+          ;;
+      esac
+    done <<<"$dump"
+
+    if [ -n "$best" ]; then
+      printf '%s\n' "$best"
+    else
+      case "$default" in ''|*[!0-9]*) : ;; *) printf '%s\n' "$default" ;; esac
+    fi
+    ;;
+
+  rule-state)
+    id=${2:-}
+    [ -n "$id" ] || { echo "error"; exit 0; }
+    awk -v target="$id" '
+      function trim(s){ sub(/^[ \t]+/,"",s); sub(/[ \t]+$/,"",s); return s }
+      function unq(s){ if (s ~ /^".*"$/) s=substr(s,2,length(s)-2); return s }
+      BEGIN { match_=0; disabled=0; sev="error" }
+      {
+        line=$0; sub(/\r$/,"",line); t=trim(line)
+        if (t=="" || t ~ /^#/) next
+        if (t ~ /^\[/) {
+          sec=t; sub(/^\[/,"",sec); sub(/\]$/,"",sec)
+          if (sec ~ /^rules\./) { match_ = (unq(substr(sec,7))==target) }
+          else { match_=0 }
+          next
+        }
+        if (!match_) next
+        eq=index(t,"="); if (eq==0) next
+        key=unq(trim(substr(t,1,eq-1))); val=unq(trim(substr(t,eq+1)))
+        if (key=="disabled" && val=="true") disabled=1
+        else if (key=="severity") sev=val
+      }
+      END {
+        if (disabled) print "disabled"
+        else if (sev=="warn") print "warn"
+        else print "error"
+      }
+    ' "$CONFIG"
+    ;;
+
+  *)
+    echo "usage: scaffold-config {size-cap <path>|rule-state <id>}" >&2
+    exit 2
+    ;;
+esac

--- a/githooks/pre-commit.template
+++ b/githooks/pre-commit.template
@@ -101,11 +101,13 @@ FAILED=0
 # stays usable on machines that haven't run `pip install ruff` yet.
 STAGED_PY=()
 STAGED_JS=()
+STAGED_PHP=()
 while IFS= read -r -d '' f; do
   [ -z "$f" ] && continue
   case "$f" in
     *.py)                  STAGED_PY+=("$f") ;;
-    *.ts|*.tsx|*.js|*.jsx) STAGED_JS+=("$f") ;;
+    *.ts|*.tsx|*.js|*.jsx|*.vue) STAGED_JS+=("$f") ;;
+    *.php|*.phtml)         STAGED_PHP+=("$f") ;;
   esac
 done <"$STAGED_LIST"
 
@@ -133,6 +135,20 @@ if [ ${#STAGED_JS[@]} -gt 0 ] \
    && command -v npx >/dev/null 2>&1 \
    && npx --no-install tsc --version >/dev/null 2>&1; then
   npx --no-install tsc --noEmit || FAILED=1
+fi
+
+# PHP: zero-config syntax check (`php -l`) on each staged file when php is on
+# PATH, plus phpcs when a ruleset/composer project is present and phpcs is
+# installed. Silently skipped otherwise, like the linters above.
+if [ ${#STAGED_PHP[@]} -gt 0 ] && command -v php >/dev/null 2>&1; then
+  for f in "${STAGED_PHP[@]}"; do
+    php -l "$f" >/dev/null 2>&1 || { echo "✗ $f: PHP syntax error (php -l)"; FAILED=1; }
+  done
+fi
+if [ ${#STAGED_PHP[@]} -gt 0 ] \
+   && { [ -f phpcs.xml ] || [ -f phpcs.xml.dist ] || [ -f composer.json ]; } \
+   && command -v phpcs >/dev/null 2>&1; then
+  phpcs -- "${STAGED_PHP[@]}" || FAILED=1
 fi
 
 if [ "$FAILED" -ne 0 ]; then

--- a/install.sh
+++ b/install.sh
@@ -81,7 +81,10 @@ cp_safe "$SCAFFOLD_DIR/AGENTS.md.template" "AGENTS.md"
 cp_safe "$SCAFFOLD_DIR/CLAUDE.md.pointer" "CLAUDE.md"
 cp_safe "$SCAFFOLD_DIR/githooks/pre-commit.template" ".githooks/pre-commit"
 chmod +x .githooks/pre-commit
-for check in check-size check-patterns check-filenames check-secrets check-hygiene; do
+# scaffold-config + scaffold-audit are the per-project override layer
+# (.scaffold.toml): the check-* scripts source the former for per-rule
+# disable / severity / per-path size caps; the latter lists active overrides.
+for check in check-size check-patterns check-filenames check-secrets check-hygiene scaffold-config scaffold-audit; do
   cp_safe "$SCAFFOLD_DIR/githooks/lib/${check}.template" ".githooks/lib/${check}"
   chmod +x ".githooks/lib/${check}"
 done
@@ -89,6 +92,9 @@ cp_safe "$SCAFFOLD_DIR/.github/workflows/lint.yml.template" ".github/workflows/l
 cp_safe "$SCAFFOLD_DIR/.github/dependabot.yml.template" ".github/dependabot.yml"
 cp_safe "$SCAFFOLD_DIR/forbidden-patterns/secrets.txt.template" ".forbidden-patterns/secrets.txt"
 cp_safe "$SCAFFOLD_DIR/forbidden-patterns/shell.txt.template" ".forbidden-patterns/shell.txt"
+# Per-project override file — ships empty (all examples commented), so it
+# enforces nothing until a team uncomments an entry. See scaffold-config.
+cp_safe "$SCAFFOLD_DIR/.scaffold.toml.template" ".scaffold.toml"
 
 # Python
 if [ "$MODE" = "python" ] || [ "$MODE" = "both" ]; then

--- a/install.sh
+++ b/install.sh
@@ -10,6 +10,7 @@
 #   install.sh --no-verify  # skip the post-install linter smoke test
 #   install.sh --claude     # also install opt-in Claude Code agent guardrails
 #   install.sh --commit-msg # also install the Conventional-Commits commit-msg hook
+#   install.sh --all-langs  # install every language's forbidden-pattern file
 #   install.sh --help       # show this help
 
 set -euo pipefail
@@ -20,6 +21,7 @@ FORCE=0
 VERIFY=1
 CLAUDE=0
 COMMIT_MSG=0
+ALL_LANGS=0
 
 for arg in "$@"; do
   case "$arg" in
@@ -30,7 +32,8 @@ for arg in "$@"; do
     --no-verify)  VERIFY=0 ;;
     --claude)     CLAUDE=1 ;;
     --commit-msg) COMMIT_MSG=1 ;;
-    --help|-h)    sed -n '2,13p' "$0"; exit 0 ;;
+    --all-langs)  ALL_LANGS=1 ;;
+    --help|-h)    sed -n '2,14p' "$0"; exit 0 ;;
     *) echo "error: unknown argument: $arg" >&2; exit 1 ;;
   esac
 done
@@ -98,6 +101,26 @@ if [ "$MODE" = "frontend" ] || [ "$MODE" = "both" ]; then
   cp_safe "$SCAFFOLD_DIR/eslint.config.js.template" "eslint.config.js"
   cp_safe "$SCAFFOLD_DIR/forbidden-patterns/frontend.txt.template" ".forbidden-patterns/frontend.txt"
 fi
+
+# Additional language pattern files (config-driven check-patterns). Each ships a
+# `<lang>.txt` with a `# scaffold-extensions:` header that check-patterns auto-
+# discovers — so adding a language is just dropping a file. Installed when the
+# language's manifest is detected, or all of them with --all-langs.
+LANGS=""
+add_lang() { case " $LANGS " in *" $1 "*) ;; *) LANGS="$LANGS $1" ;; esac; }
+if [ "$ALL_LANGS" -eq 1 ]; then
+  for L in php go rust java kotlin ruby; do add_lang "$L"; done
+else
+  if [ -f composer.json ]; then add_lang php; fi
+  if [ -f go.mod ]; then add_lang go; fi
+  if [ -f Cargo.toml ]; then add_lang rust; fi
+  if [ -f pom.xml ] || [ -f build.gradle ]; then add_lang java; fi
+  if [ -f build.gradle.kts ] || ls -1 ./*.kt >/dev/null 2>&1; then add_lang kotlin; fi
+  if [ -f Gemfile ] || ls -1 ./*.gemspec >/dev/null 2>&1; then add_lang ruby; fi
+fi
+for L in $LANGS; do
+  cp_safe "$SCAFFOLD_DIR/forbidden-patterns/${L}.txt.template" ".forbidden-patterns/${L}.txt"
+done
 
 # Claude Code agent-runtime guardrails (opt-in: --claude). Installs a PreToolUse
 # precheck hook (reuses .forbidden-patterns/secrets.txt) plus a settings.json

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -67,7 +67,7 @@ echo '{"name":"test"}' >package.json
 echo 'name = "test"' >pyproject.toml
 git add . && git commit --quiet -m "fixture" --no-verify
 
-"$SCAFFOLD_DIR/install.sh" --both --no-verify >/dev/null
+"$SCAFFOLD_DIR/install.sh" --both --all-langs --no-verify >/dev/null
 git add . && git commit --quiet -m "install scaffold" --no-verify
 
 echo "Hook test cases:"
@@ -511,6 +511,62 @@ else
   sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
 fi
 reset_repo
+
+# --- Multi-language forbidden patterns (config-driven check-patterns) -------
+# Each language file declares its extensions via a `# scaffold-extensions:`
+# header and is auto-discovered by check-patterns. Samples come from the
+# adversarially-FP-reviewed pattern set; each pair proves an active pattern
+# rejects and a look-alike legitimate construct passes.
+
+# PHP — dd() debug call vs ->dd() method call ($-vars are literal PHP source)
+# shellcheck disable=SC2016
+echo '<?php dd($user, $order);' >leak.php
+git add leak.php
+assert_rejects "PHP dd() debug call rejected" "dump-and-die"
+# shellcheck disable=SC2016
+echo '<?php $q = $builder->dd()->paginate();' >ok.php
+git add ok.php
+assert_passes "PHP ->dd() method call is not flagged"
+
+# Go — fmt.Println debug vs fmt.Errorf
+echo 'fmt.Println("user:", u)' >leak.go
+git add leak.go
+assert_rejects "Go fmt.Println debug rejected" "fmt.Print"
+echo 'return fmt.Errorf("load config: %w", err)' >ok.go
+git add ok.go
+assert_passes "Go fmt.Errorf is not flagged"
+
+# Rust — dbg!() macro vs format!()
+echo 'dbg!(payload);' >leak.rs
+git add leak.rs
+assert_rejects "Rust dbg!() macro rejected" "dbg!"
+echo 'let n = format!("{}-{}", a, b);' >ok.rs
+git add ok.rs
+assert_passes "Rust format!() is not flagged"
+
+# Java — System.out.println vs logger
+echo 'System.out.println("debug");' >Leak.java
+git add Leak.java
+assert_rejects "Java System.out.println rejected" "System.out"
+echo 'logger.info("started");' >Ok.java
+git add Ok.java
+assert_passes "Java logger.info is not flagged"
+
+# Kotlin — println vs logger
+echo 'println("debug")' >Leak.kt
+git add Leak.kt
+assert_rejects "Kotlin println rejected" "println"
+echo 'logger.info("started")' >Ok.kt
+git add Ok.kt
+assert_passes "Kotlin logger.info is not flagged"
+
+# Ruby — binding.pry debug vs puts (puts is opt-in, off by default)
+echo 'binding.pry' >leak.rb
+git add leak.rb
+assert_rejects "Ruby binding.pry rejected" "binding.pry"
+echo 'puts "ok"' >ok.rb
+git add ok.rb
+assert_passes "Ruby puts is opt-in (not flagged by default)"
 
 # 46-48. agent-precheck — the opt-in Claude Code PreToolUse hook. Invoked
 #     directly (it's not a git hook) with CLAUDE_PROJECT_DIR pointed at this

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -633,6 +633,104 @@ fi
 rm -f "$mf"
 reset_repo
 
+# --- .scaffold.toml per-project overrides (lib/scaffold-config) -------------
+# A STAGED .scaffold.toml is what the checks read: the hook stashes unstaged
+# changes (--keep-index), so only the indexed copy is on disk during the scan —
+# matching how overrides ship (committed). Fixtures use ruff-clean comment
+# bodies / bare `print` so the linters don't independently fail an assert_passes
+# case (ruff doesn't enable T20; eslint's no-console is why these avoid .ts).
+
+# 52. [size] per-glob cap raises the limit: a 501-line file under the matching
+#     glob passes where the default 500 would reject.
+printf '[size]\n"legacy/**" = 700\n' >.scaffold.toml
+mkdir -p legacy
+seq 1 501 | sed 's/^/# /' >legacy/big.py
+git add .scaffold.toml legacy/big.py
+assert_passes "override: [size] per-glob cap raises the limit"
+
+# 53. [rules.size] disabled turns the size cap off entirely.
+printf '[rules.size]\ndisabled = true\n' >.scaffold.toml
+seq 1 501 | sed 's/^/# /' >big2.py
+git add .scaffold.toml big2.py
+assert_passes "override: [rules.size] disabled skips the size cap"
+
+# 54. A disabled forbidden-pattern rule lets its match through.
+cat >.scaffold.toml <<'EOF'
+[rules."backend/Use structlog (or the project's logger), not print()"]
+disabled = true
+reason   = "test"
+by       = "test"
+EOF
+echo 'print("debug")' >app.py
+git add .scaffold.toml app.py
+assert_passes "override: disabled pattern rule lets the match through"
+
+# 55. severity = "warn" reports the match but does NOT fail the build.
+cat >.scaffold.toml <<'EOF'
+[rules."backend/Use structlog (or the project's logger), not print()"]
+severity = "warn"
+EOF
+echo 'print("debug")' >app.py
+git add .scaffold.toml app.py
+if .githooks/pre-commit >"$HOOK_OUT" 2>&1; then
+  if grep -qF "(warn — .scaffold.toml override)" "$HOOK_OUT"; then
+    echo "  ✓ override: severity=warn reports without failing"; PASS=$((PASS + 1))
+  else
+    echo "  ✗ override: severity=warn passed but emitted no warn notice"
+    sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+  fi
+else
+  echo "  ✗ override: severity=warn — hook failed, expected pass-with-warning"
+  sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+reset_repo
+
+# 56. Hygiene rule downgrade: case-collision as a warning still passes. Feed the
+#     NUL-delimited path list to check-hygiene directly (a real case-variant pair
+#     can't coexist on a case-insensitive FS), with the override on disk.
+printf '[rules.case-collision]\nseverity = "warn"\n' >.scaffold.toml
+if printf '%s\0' 'Collide.txt' 'collide.txt' | .githooks/lib/check-hygiene >"$HOOK_OUT" 2>&1; then
+  if grep -qF "(warn — .scaffold.toml override)" "$HOOK_OUT"; then
+    echo "  ✓ override: case-collision severity=warn passes with a notice"; PASS=$((PASS + 1))
+  else
+    echo "  ✗ override: case-collision warn passed but emitted no notice"
+    sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+  fi
+else
+  echo "  ✗ override: case-collision severity=warn — failed, expected pass"
+  sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+reset_repo
+
+# 57. FAIL SAFE: an unparseable .scaffold.toml disables nothing — print() is
+#     still rejected (a config can only weaken via a clean, explicit entry).
+printf 'this is { not ] valid toml at all\n' >.scaffold.toml
+echo 'print("debug")' >app.py
+git add .scaffold.toml app.py
+assert_rejects "override: malformed config fails safe (rule still enforced)" "structlog"
+
+# 58. SECURITY BOUNDARY: .scaffold.toml cannot disable the secret scanner —
+#     check-secrets never consults it, so the AKIA key is still caught.
+cat >.scaffold.toml <<'EOF'
+[rules."secrets/AWS access key ID (AKIA) or temporary session key (ASIA) — rotate immediately"]
+disabled = true
+EOF
+echo "AKIA""IOSFODNN7EXAMPLE" >creds.txt
+git add .scaffold.toml creds.txt
+assert_rejects "override: secret scanner is NOT disablable via .scaffold.toml" "AWS access key"
+
+# 59. scaffold-audit (installed by install.sh) lists active overrides. The CI
+#     guardrails job runs this so a disabled rule is visible in the build log.
+printf '[rules."backend/Use structlog (or the project'\''s logger), not print()"]\ndisabled = true\n' >.scaffold.toml
+if .githooks/lib/scaffold-audit >"$HOOK_OUT" 2>&1 \
+   && grep -qF "DISABLED" "$HOOK_OUT" && grep -qF "backend/Use structlog" "$HOOK_OUT"; then
+  echo "  ✓ scaffold-audit lists active overrides"; PASS=$((PASS + 1))
+else
+  echo "  ✗ scaffold-audit — did not list the disabled rule"
+  sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+reset_repo
+
 echo ""
 echo "Result: $PASS passed, $FAIL failed"
 exit $FAIL

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -67,9 +67,12 @@ force_remove() {
 remove_if_unmodified "ruff.toml"                     "$SCAFFOLD_DIR/ruff.toml.template"
 remove_if_unmodified "eslint.config.js"              "$SCAFFOLD_DIR/eslint.config.js.template"
 remove_if_unmodified ".githooks/pre-commit"          "$SCAFFOLD_DIR/githooks/pre-commit.template"
-for check in check-size check-patterns check-filenames check-secrets check-hygiene; do
+for check in check-size check-patterns check-filenames check-secrets check-hygiene scaffold-config scaffold-audit; do
   remove_if_unmodified ".githooks/lib/${check}" "$SCAFFOLD_DIR/githooks/lib/${check}.template"
 done
+# Per-project override file — removed only if still byte-identical to the
+# shipped (empty) template; a team that has recorded overrides keeps it.
+remove_if_unmodified ".scaffold.toml"                "$SCAFFOLD_DIR/.scaffold.toml.template"
 remove_if_unmodified ".github/workflows/lint.yml"    "$SCAFFOLD_DIR/.github/workflows/lint.yml.template"
 remove_if_unmodified ".github/dependabot.yml"        "$SCAFFOLD_DIR/.github/dependabot.yml.template"
 remove_if_unmodified "CLAUDE.md"                     "$SCAFFOLD_DIR/CLAUDE.md.pointer"


### PR DESCRIPTION
Stacked on the now-merged #12; rebased onto `main`. Two commits.

## 1. Config-driven multi-language forbidden patterns (`1f9338f`)
`check-patterns` auto-discovers every `.forbidden-patterns/*.txt` via a
`# scaffold-extensions:` header, so adding a language is just dropping a file.
Ships adversarially-FP-reviewed pattern sets for **PHP / Go / Rust / Java /
Kotlin / Ruby** (+ `*.vue`/`v-html`), a PHP linter (hook + CI), and commented
SHA-pinned CI stubs for the other five toolchains. `install.sh --all-langs`.

## 2. Per-project rule overrides — `.scaffold.toml` (`47c240c`)
A first-class, committed, auditable config layer the `check-*` scripts consume
via a new **pure-bash/awk** reader (no python/jq dependency):

- **`lib/scaffold-config`** — `size-cap <path>` (most-specific `[size]` glob
  wins) and `rule-state <id>` → `disabled|warn|error`. Malformed/absent config
  **fails safe** (rules stay fully enforced).
- **`lib/scaffold-audit`** — lists every active override; echoed by the CI
  guardrails job so a relaxed rule is visible in the build log.
- **Wiring** — `check-size` / `check-patterns` / `check-hygiene` honor per-path
  size caps, per-rule disable, and `error → warn` downgrade (warn still emits as
  a CI `::warning::`, never silent). Rules keyed `"<patternfile-stem>/<description>"`,
  plus `conflict-marker` / `case-collision` / `size`.

### Security boundary
`check-secrets` and `check-filenames` **deliberately ignore** `.scaffold.toml`,
so secret/credential-file blocking cannot be disabled per-project — a malicious
PR can't add a config that neuters them. Modifying a pattern's regex stays an
edit to the `.forbidden-patterns` file you own (git history is the audit trail;
no regex lives in two places).

### Plumbing & docs
`install.sh` ships an empty (commented) `.scaffold.toml` + both libs;
`uninstall.sh` removes them when unmodified; `lint.yml` gained a "show active
overrides" step and an extended trust note. README (new "Per-project rule
overrides" section) + CHANGELOG updated.

## Verification
- `tests/run.sh`: **75 passed, 0 failed** (+8 override cases incl. *secret
  scanner is NOT disablable via `.scaffold.toml`* and *malformed config fails
  safe*).
- `shellcheck -S info` clean across all scripts; `actionlint` validates the
  rendered `lint.yml`.