### PR TITLE
feat(toolchain): ship tool configs, detect/offer install, prettier + patch-coverage gate

### DIFF
--- a/.coveragerc.template
+++ b/.coveragerc.template
@@ -1,0 +1,17 @@
+# Copy to project root as `.coveragerc` (install.sh does this for Python
+# stacks). Configures coverage.py for the patch-coverage gate; pair with
+# `pytest --cov --cov-report=xml` (the coverage.yml CI job runs exactly that).
+[run]
+branch = True
+# Adjust to your package layout (e.g. `src`). The gate measures CHANGED lines,
+# so this just scopes what counts as "your code".
+source = .
+omit =
+    */tests/*
+    */test_*.py
+    */.venv/*
+    */venv/*
+
+[report]
+# Surface partially-covered branches in the local report.
+show_missing = True

--- a/.github/workflows/coverage.yml.template
+++ b/.github/workflows/coverage.yml.template
@@ -1,0 +1,99 @@
+name: coverage
+
+# OPT-IN patch-coverage gate. Copy to your project as
+# `.github/workflows/coverage.yml` (or `install.sh --coverage-gate`).
+#
+# WHAT THIS DOES — and what it cannot do.
+# It fails the PR when lines you ADDED OR CHANGED in this PR are not executed by
+# any test (diff-cover, default threshold 100% of changed lines). It deliberately
+# does NOT gate on whole-repo coverage %, which lets old untested code mask new
+# gaps. The honest ceiling: this forces changed lines to be EXECUTED by a test,
+# never VERIFIED by one — an assertion-free test still "covers" a line. Pair it
+# with required human review and, for real test-quality signal, mutation testing
+# (see RECOMMENDATIONS.md, "forcing tests"). A green check here is necessary, not
+# sufficient.
+#
+# Runs on pull_request only — patch coverage is defined relative to the PR base.
+# Actions are pinned to a commit SHA (trailing comment = version); the SHAs match
+# lint.yml so Dependabot bumps them together. Tune DIFF_COVER_FAIL_UNDER below.
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+env:
+  # Percent of changed lines that must be covered. 100 = every line you touched
+  # needs a test exercising it. Lower it (e.g. 80) to ease adoption on an
+  # existing codebase, then ratchet up.
+  DIFF_COVER_FAIL_UNDER: "100"
+
+jobs:
+  patch-coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          # diff-cover compares against the PR base, so it needs full history.
+          fetch-depth: 0
+          persist-credentials: false  # don't leave GITHUB_TOKEN in .git/config
+
+      # ── Detect stacks (step output, not job-level if: — see lint.yml) ──────
+      - id: detect
+        run: |
+          if [ -f pyproject.toml ] || [ -f pytest.ini ] || [ -f setup.py ]; then
+            echo "python=true" >> "$GITHUB_OUTPUT"
+          fi
+          if [ -f package.json ]; then
+            echo "frontend=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # ── Python: pytest + coverage → coverage.xml (Cobertura) ──────────────
+      - if: steps.detect.outputs.python == 'true'
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+      - name: Run Python tests with coverage
+        if: steps.detect.outputs.python == 'true'
+        # `|| true` so a no-tests-collected exit doesn't mask the diff-cover
+        # verdict below; diff-cover reads coverage.xml and is the gate.
+        run: |
+          pip install pytest pytest-cov
+          pytest --cov --cov-report=xml || true
+
+      # ── Frontend: vitest V8 coverage → coverage/cobertura-coverage.xml ────
+      - if: steps.detect.outputs.frontend == 'true'
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: "20"
+      - name: Run frontend tests with coverage
+        if: steps.detect.outputs.frontend == 'true'
+        # --ignore-scripts: same supply-chain hardening as lint.yml. Vitest +
+        # @vitest/coverage-v8 are pure JS. Jest projects: swap for your
+        # `jest --coverage` command emitting cobertura.
+        run: |
+          if [ -f package-lock.json ] || [ -f npm-shrinkwrap.json ]; then
+            npm ci --ignore-scripts
+          else
+            npm install --ignore-scripts
+          fi
+          npx --no-install vitest run --coverage || true
+
+      # ── Gate: every changed line must be covered ──────────────────────────
+      - name: Enforce patch coverage (diff-cover)
+        run: |
+          pip install diff-cover
+          git fetch --no-tags --depth=1 origin "$GITHUB_BASE_REF"
+          REPORTS=""
+          [ -f coverage.xml ] && REPORTS="$REPORTS coverage.xml"
+          [ -f coverage/cobertura-coverage.xml ] && REPORTS="$REPORTS coverage/cobertura-coverage.xml"
+          if [ -z "$REPORTS" ]; then
+            echo "No coverage report produced (coverage.xml / cobertura-coverage.xml)."
+            echo "Add tests that emit coverage, or this gate cannot run."
+            exit 1
+          fi
+          # shellcheck disable=SC2086  # REPORTS is a deliberate space-split list
+          diff-cover $REPORTS \
+            --compare-branch "origin/$GITHUB_BASE_REF" \
+            --fail-under "$DIFF_COVER_FAIL_UNDER"

--- a/.github/workflows/lint.yml.template
+++ b/.github/workflows/lint.yml.template
@@ -82,6 +82,18 @@ jobs:
           fi
       - if: steps.detect.outputs.present == 'true'
         run: npx eslint .
+      - name: Format check (prettier --check)
+        if: steps.detect.outputs.present == 'true'
+        # Mirrors the pre-commit hook. Only runs when a prettier config is present
+        # AND prettier is installed — prettier formats, eslint checks correctness,
+        # and the two intentionally don't overlap (no eslint-config-prettier).
+        run: |
+          if { [ -f .prettierrc ] || [ -f .prettierrc.json ] || [ -f .prettierrc.js ] || [ -f prettier.config.js ]; } \
+             && npx --no-install prettier --version >/dev/null 2>&1; then
+            npx --no-install prettier --check .
+          else
+            echo "no prettier config or prettier not installed — skipping format check"
+          fi
       - name: Type-check (tsc --noEmit)
         if: steps.detect.outputs.present == 'true'
         # Project-wide type-check, guarded: only runs when a tsconfig.json is

--- a/.prettierignore.template
+++ b/.prettierignore.template
@@ -1,0 +1,13 @@
+# Copy to project root as `.prettierignore`. Prettier formats code only;
+# eslint owns correctness (the two don't overlap — strictTypeChecked ships no
+# stylistic rules, so there is intentionally NO eslint-config-prettier).
+# Keep generated / vendored / lockfile content out of formatting.
+node_modules
+dist
+build
+coverage
+*.min.js
+*.min.css
+package-lock.json
+pnpm-lock.yaml
+yarn.lock

--- a/.prettierrc.json.template
+++ b/.prettierrc.json.template
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://json.schemastore.org/prettierrc",
+  "singleQuote": true,
+  "trailingComma": "all",
+  "semi": true,
+  "printWidth": 100
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,46 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+## [v0.7.0] — 2026-06-16
+
+Toolchain setup: the scaffold now ships the tool *configs* its enforcement
+already assumed (strict `tsconfig.json`, Prettier, Vitest, pytest+coverage),
+detects and offers to install the *binaries* (safe auto-run only on an
+interactive TTY), enforces `prettier --check` in the hook + CI, and adds an
+opt-in CI patch-coverage gate that fails a PR when changed lines ship untested.
+
+### Added
+- **Toolchain setup (configs auto-installed by stack + detect/offer).** The
+  scaffold now ships the configs its enforcement already assumed but never
+  provided: a strict `tsconfig.json` (the type-aware eslint rules + `tsc
+  --noEmit` depend on it), `.prettierrc.json` + `.prettierignore` (Prettier runs
+  separately from eslint — `strictTypeChecked` has no stylistic rules, so there
+  is intentionally no `eslint-config-prettier`), `vitest.config.ts` (skipped when
+  the project already uses Jest), and `pytest.ini` + `.coveragerc` for Python
+  (pytest.ini skipped when pyproject/tox already configures pytest). All install
+  by stack like `ruff.toml` / `eslint.config.js`; `cp_safe` won't clobber
+  existing files.
+- **`prettier --check` in the pre-commit hook + CI**, guarded like ruff/eslint
+  (runs only when a prettier config is present and prettier is installed,
+  silently skipped otherwise; `prettier --write` fixes).
+- **Detect → offer toolchain step (replaces the post-install linter smoke
+  test).** `install.sh` now checks for `ruff`/`pytest` and
+  `eslint`/`tsc`/`prettier`/`vitest`, and offers to install anything missing.
+  Auto-install runs ONLY when safe — interactive TTY, not `--no-verify`, not in
+  CI (`$CI`), and not `--no-install`; otherwise it prints the command, so CI and
+  piped runs never mutate the environment. Package manager detected from
+  lockfiles (`npm`/`pnpm`/`yarn`, `pip`/`uv`). New flag: `--no-install`.
+- **Opt-in CI patch-coverage gate (`install.sh --coverage-gate` →
+  `.github/workflows/coverage.yml`).** Fails a PR when changed lines ship
+  untested (`diff-cover`, default 100% of changed lines, tunable via
+  `DIFF_COVER_FAIL_UNDER`). Covers both stacks via Cobertura XML. It gates
+  *execution* of changed lines, not assertion quality — documented ceiling, with
+  mutation testing as the deferred follow-up in `RECOMMENDATIONS.md` ("Forcing
+  tests"). Action SHAs match `lint.yml` so the pin-drift guard stays green.
+- **+10 tests** (119 total): config delivery by stack, Jest/pytest skip paths,
+  `coverage.yml` actionlint validity, and a regression guard that the detect/
+  offer step is print-only and non-mutating without a TTY.
+
 ## [v0.6.0] — 2026-06-11
 
 Multi-language enforcement (PHP/Go/Rust/Java/Kotlin/Ruby), broadened TypeScript

--- a/README.md
+++ b/README.md
@@ -43,10 +43,11 @@ Both invoke the same `lib/check-*` scripts (`check-size`, `check-patterns`, `che
 Two always-on enforcement layers (pre-commit hook + CI mirror) plus optional agent-runtime hooks. What each stack gets:
 
 - **Python** — `ruff` (annotations, complexity, `pathlib`, no-blind-except, async-safety `ASYNC`, FastAPI `FAST`, logging `G`/`LOG`, a curated `flake8-bandit` security subset) **+** a `backend.txt` regex deny-list: `print()`, `breakpoint()`/`pdb`/`ipdb`, `os.path.join`, deprecated `datetime.utcnow()` / `utcfromtimestamp()`. FastAPI (Pydantic responses) and SQLAlchemy-2.0 conventions live in `coding-rules.md`.
-- **TypeScript / JavaScript** — type-aware `eslint` (`strictTypeChecked`: floating/misused promises, `switch-exhaustiveness-check`, `preserve-caught-error`, `no-explicit-any`, import sort + unused-import removal) **+** `tsc --noEmit` **+** a `frontend.txt` deny-list: `console.log`/`debugger`/`alert`, focused tests (`.only`), `@ts-ignore`/`@ts-nocheck`, hardcoded `localhost`, and TLS-verification-disable (`NODE_TLS_REJECT_UNAUTHORIZED`, `rejectUnauthorized: false`).
+- **TypeScript / JavaScript** — type-aware `eslint` (`strictTypeChecked`: floating/misused promises, `switch-exhaustiveness-check`, `preserve-caught-error`, `no-explicit-any`, import sort + unused-import removal) **+** `tsc --noEmit` (against a shipped strict `tsconfig.json`) **+** `prettier --check` (formatting, run separately from eslint) **+** a `frontend.txt` deny-list: `console.log`/`debugger`/`alert`, focused tests (`.only`), `@ts-ignore`/`@ts-nocheck`, hardcoded `localhost`, and TLS-verification-disable (`NODE_TLS_REJECT_UNAUTHORIZED`, `rejectUnauthorized: false`).
   - **React** — `dangerouslySetInnerHTML` (XSS); opt-in `react-hooks` + `jsx-a11y` blocks.
   - **Vue** — `.vue` scanned; `v-html` (XSS).
   - **Svelte** — `.svelte` scanned; `{@html}` (XSS).
+- **Testing** — a runner config ships per stack (`vitest.config.ts` for TS/JS unless the project already uses Jest; `pytest.ini` + `.coveragerc` for Python). A runner alone forces nothing; the **opt-in patch-coverage gate** (`--coverage-gate`) fails a PR when *changed* lines ship untested. It gates execution of changed lines, not assertion quality — see [`RECOMMENDATIONS.md`](./RECOMMENDATIONS.md) on why you can't fully machine-force meaningful tests.
 - **PHP** — `php -l` syntax + `phpcs` (when configured) **+** `php.txt`: `var_dump`/`print_r`, `->dd()`/`dump()`, `die`/`exit` (opt-in).
 - **Go** — `go.txt`: `fmt.Println`/`Printf` debug, `panic`/`print` (opt-in); ready-to-uncomment golangci-lint CI job.
 - **Rust** — `rust.txt`: `dbg!`, `println!`, `.unwrap()`/`.expect()` (opt-in); clippy CI job stub.
@@ -63,7 +64,7 @@ Clone the scaffold somewhere stable:
 
 ```sh
 # Recommended: pin to a tagged release for reproducibility
-git clone --branch v0.6.0 https://github.com/Sting25/ai-coding-rules-scaffold ~/src/ai-coding-rules-scaffold
+git clone --branch v0.7.0 https://github.com/Sting25/ai-coding-rules-scaffold ~/src/ai-coding-rules-scaffold
 # Or track main if you want the latest changes
 git clone https://github.com/Sting25/ai-coding-rules-scaffold ~/src/ai-coding-rules-scaffold
 ```
@@ -83,12 +84,14 @@ The script auto-detects Python (`pyproject.toml` / `requirements.txt` / `setup.p
 ./install.sh --frontend     # TS/JS only
 ./install.sh --both         # both stacks
 ./install.sh --force        # overwrite existing files
-./install.sh --no-verify    # skip the post-install linter check
+./install.sh --no-verify    # skip the post-install toolchain check (no detect/offer)
 ./install.sh --claude       # also install opt-in Claude Code agent guardrails
 ./install.sh --cursor       # also install opt-in Cursor agent guardrails
 ./install.sh --commit-msg   # also install the Conventional-Commits commit-msg hook
 ./install.sh --gitleaks-hook # also install opt-in local gitleaks pre-commit pass
 ./install.sh --all-langs    # install every language's forbidden-pattern file
+./install.sh --coverage-gate # also install the opt-in CI patch-coverage gate
+./install.sh --no-install   # detect missing tools but never auto-run a package manager
 ./install.sh --help         # show usage
 ```
 
@@ -97,13 +100,22 @@ Language pattern files are auto-installed when their manifest is detected
 …); `--all-langs` installs them all. See [Opt-in layers](#opt-in-layers) for
 what `--claude`, `--cursor`, and `--commit-msg` add.
 
-At the end, `install.sh` verifies that `ruff` and/or `eslint` are installed and that their configs load. If either is missing, it prints the install command.
+**The scaffold ships configs + enforcement; the tools themselves are project
+deps.** At the end, `install.sh` runs a **detect → offer** pass: it checks for
+each tool its configs assume (`ruff`, `pytest`+coverage / `eslint`, `tsc`,
+`prettier`, `vitest`) and, for anything missing, offers to install it. The
+auto-install only runs when it's **safe** — an interactive terminal, not
+`--no-verify`, not inside CI (`$CI`), and not `--no-install`. In any
+non-interactive context it falls back to just printing the command, so CI and
+piped/scripted runs never mutate your `package.json` or environment. The
+package manager is detected from your lockfiles (`npm`/`pnpm`/`yarn`,
+`pip`/`uv`).
 
-Install the linters:
+To install the linters by hand instead:
 
 ```sh
-pip install ruff                                   # Python
-npm i -D eslint @eslint/js typescript-eslint       # TS/JS
+pip install ruff pytest pytest-cov                                      # Python
+npm i -D eslint @eslint/js typescript-eslint typescript prettier vitest # TS/JS
 ```
 
 ### Pairing with Husky / lefthook
@@ -128,7 +140,13 @@ Either way, the four `lib/check-*` scripts in `.githooks/lib/` are also runnable
 | `coding-rules.md` | `coding-rules.md` | Short list of code-level rules that aren't tool-enforceable |
 | `operational-rules.md` | `operational-rules.md` | Process and collaboration rules — failure modes that no linter can catch |
 | `ruff.toml.template` | `ruff.toml` | Python lint config |
+| `pytest.ini.template` | `pytest.ini` | Python test-runner config (skipped if pyproject/tox already configures pytest) |
+| `.coveragerc.template` | `.coveragerc` | coverage.py config for the patch-coverage gate |
 | `eslint.config.js.template` | `eslint.config.js` | TS/JS lint config (flat config, ESLint 9+) |
+| `tsconfig.json.template` | `tsconfig.json` | Strict TS config the type-aware eslint rules + `tsc --noEmit` assume |
+| `.prettierrc.json.template` | `.prettierrc.json` | Prettier formatting config (runs separately from eslint) |
+| `.prettierignore.template` | `.prettierignore` | Paths Prettier should not format |
+| `vitest.config.ts.template` | `vitest.config.ts` | Vitest runner + V8 coverage config (skipped if the project uses Jest) |
 | `githooks/pre-commit.template` | `.githooks/pre-commit` | Hook orchestrator — invokes the five `lib/check-*` scripts |
 | `githooks/lib/check-{size,patterns,filenames,secrets,hygiene}.template` | `.githooks/lib/check-{size,patterns,filenames,secrets,hygiene}` | Reusable check scripts; the same scripts run from CI so hook and CI can't drift |
 | `githooks/lib/scaffold-config.template` | `.githooks/lib/scaffold-config` | Reads per-project rule overrides from `.scaffold.toml` (per-path size caps, per-rule disable / severity) |
@@ -144,7 +162,7 @@ Scripts (stay in the scaffold repo):
 
 | Script | Purpose |
 |---|---|
-| `install.sh` | Copy templates into your project, wire `core.hooksPath`, verify linters |
+| `install.sh` | Copy templates into your project, wire `core.hooksPath`, detect/offer the toolchain |
 | `uninstall.sh` | Remove unmodified scaffold files, unwire the hook |
 
 ## AI agent integration
@@ -189,11 +207,12 @@ For parallel agent sessions, use `git worktree add ../proj-feat-x -b feat-x` so 
 ## What the tooling enforces
 
 The pre-commit hook now invokes `ruff` / `eslint` against staged files
-when their configs are present and the tool is on PATH — and, for
-TypeScript, `tsc --noEmit` when a `tsconfig.json` is present — so most of
-the build-breaking rules below also fire at commit time, not only in CI.
-Linters and the type-checker are silently skipped if not installed; CI is
-the authoritative backstop.
+when their configs are present and the tool is on PATH — plus, for
+TypeScript, `tsc --noEmit` (against the shipped strict `tsconfig.json`) and
+`prettier --check` when a prettier config is present — so most of the
+build-breaking rules below also fire at commit time, not only in CI.
+Linters, the type-checker, and the formatter are silently skipped if not
+installed; CI is the authoritative backstop.
 
 The shipped `eslint.config.js` extends typescript-eslint's
 **`strictTypeChecked`** tier (type-aware linting), wires import sorting and
@@ -224,6 +243,8 @@ Build-breaking (`ruff` / `eslint`, on every lint + commit + in CI):
 | Non-exhaustive `switch` over a union/enum (missing member) | `@typescript-eslint/switch-exhaustiveness-check` (type-aware) |
 | Re-throwing in `catch` while discarding the original error cause/stack | `eslint preserve-caught-error` (needs ESLint ≥ 9.35) |
 | TypeScript type errors | `tsc --noEmit` (hook + CI, when `tsconfig.json` present) |
+| Unformatted TS/JS | `prettier --check` (hook + CI, when a prettier config is present; `prettier --write` fixes) |
+| Changed lines shipped without a test (opt-in) | `diff-cover` patch-coverage gate (`--coverage-gate`, CI) |
 
 Commit + CI-breaking (pre-commit hook + `lint.yml`):
 
@@ -354,6 +375,19 @@ by default so the scaffold stays minimal; turn them on per project.
   on by default for public repos, requires GitHub Advanced Security for private
   repos (caveat documented in the template header).
 
+- **Patch-coverage gate (`install.sh --coverage-gate` →
+  `.github/workflows/coverage.yml`).** The one mechanism here that *forces tests
+  to be written*: it fails a PR when lines you **added or changed** aren't
+  executed by any test (`diff-cover`, default 100% of changed lines; lower the
+  `DIFF_COVER_FAIL_UNDER` env to ease adoption, then ratchet up). It deliberately
+  does **not** gate on whole-repo coverage %, which lets old untested code mask
+  new gaps. Honest ceiling: it forces changed lines to be **executed** by a test,
+  never **verified** by one — an assertion-free test still counts as covered.
+  Pair it with required human review; for real test-*quality* signal, layer on
+  mutation testing (see [`RECOMMENDATIONS.md`](./RECOMMENDATIONS.md), "Forcing
+  tests"). Opt-in because forcing tests on new code is a policy a team must
+  choose deliberately.
+
 Supply-chain hardening is **on by default** in the shipped CI + Dependabot
 config: `install.sh` drops a `.github/dependabot.yml` (weekly grouped bumps of
 the SHA-pinned Actions, with a **7-day `cooldown`** so a compromised-and-yanked
@@ -416,8 +450,8 @@ Safe mode only removes files whose content matches the current scaffold template
 |---|---|
 | Architecture / module boundaries | Your project spec or design doc |
 | Framework-specific rules (React Query, specific import paths) | `coding-rules.md` "Project-specific" section |
-| Test coverage thresholds, logging conventions | Per-project decision |
-| Formatter enforcement (`ruff format`, `prettier`) | Drop-in if you want; the scaffold stays opinion-light here |
+| Logging conventions, whole-repo coverage % | Per-project decision (the shipped gate measures *patch* coverage, not a global threshold) |
+| `ruff format` (Python formatting) | Drop-in if you want; Python formatting stays opinion-light (TS/JS formatting now ships via Prettier) |
 | Spec-first workflow templates (`SPEC.md`) | Out of scope — see [`RECOMMENDATIONS.md`](./RECOMMENDATIONS.md) |
 | Claude Code agent-runtime hooks (`.claude/settings.json` `PreToolUse`) | Deferred — see [`RECOMMENDATIONS.md`](./RECOMMENDATIONS.md) for design space and tradeoffs |
 | `git worktree` orchestration for parallel agent sessions | Documented in `AGENTS.md`; not automated |

--- a/RECOMMENDATIONS.md
+++ b/RECOMMENDATIONS.md
@@ -78,6 +78,23 @@ _Added 2026-06-11._
 
 ---
 
+## Forcing tests (patch coverage + mutation testing)
+
+_Added 2026-06-16. **Patch-coverage gate shipped 2026-06-16** — `install.sh --coverage-gate` installs `.github/workflows/coverage.yml`, a `diff-cover` job that fails a PR when changed lines aren't covered. Mutation testing below remains out of scope._
+
+**Adopt mutation testing if:** a coverage gate is already in place **and** assertion-free / trivially-passing tests are getting through review (a signature agent pattern when coverage is the target).
+
+**What you can and can't machine-force.** You cannot force *meaningful* tests with a build gate — only mechanical proxies, every one gameable, most of all by an agent optimizing to pass the gate. The proxies, weakest to strongest:
+
+- **"source changed ⇒ a test file changed"** — trivially satisfied by touching a test; high false-positive on refactors/docs. Not worth shipping.
+- **Whole-repo coverage threshold** (`≥ 80%`) — old untested code masks new gaps. Weak for a scaffold.
+- **Patch / diff coverage** (changed lines must be covered) — the strongest *defensible* gate, and what the scaffold ships (`--coverage-gate`). The honest ceiling: it forces changed lines to be **executed** by a test, never **verified** by one. An assertion-free test that just calls the function gives 100% patch coverage.
+- **Mutation testing** (`Stryker` for TS/JS, `mutmut` / `cosmic-ray` for Python) — the only tool that measures test *quality*: it injects faults and checks the tests catch them. It closes the assertion-free hole, but it's slow, needs tuning, and still requires tests to exist first. Gate on mutation score for the changed files only.
+
+**Why mutation testing stays deferred.** Default-on mutation testing makes CI minutes-to-tens-of-minutes slower and is flaky on some code shapes — too heavy to impose by default. Wire it as a separate opt-in job (or a nightly run) over the diff, not the whole tree. Until then this is docs-only; the patch-coverage gate plus required human review is the shipped answer to "how do we force tests."
+
+---
+
 ## `Biome` / `oxlint` instead of (or in front of) ESLint
 
 _Added 2026-06-11._

--- a/githooks/pre-commit.template
+++ b/githooks/pre-commit.template
@@ -132,6 +132,18 @@ if [ ${#STAGED_JS[@]} -gt 0 ] \
   npx --no-install eslint -- "${STAGED_JS[@]}" || FAILED=1
 fi
 
+# Prettier formats; eslint checks correctness — they don't overlap (the eslint
+# config ships no stylistic rules, so there's no eslint-config-prettier). Run
+# --check on staged files when a prettier config exists and prettier is
+# installed. Silently skipped otherwise, like the linters above. `prettier
+# --write` is the fix.
+if [ ${#STAGED_JS[@]} -gt 0 ] \
+   && { [ -f .prettierrc ] || [ -f .prettierrc.json ] || [ -f .prettierrc.js ] || [ -f prettier.config.js ] || grep -qs '"prettier"' package.json; } \
+   && command -v npx >/dev/null 2>&1 \
+   && npx --no-install prettier --version >/dev/null 2>&1; then
+  npx --no-install prettier --check -- "${STAGED_JS[@]}" || FAILED=1
+fi
+
 # Type-check with tsc when a tsconfig.json exists and TypeScript is installed.
 # Run PROJECT-WIDE (no file args) — passing individual files makes tsc ignore
 # tsconfig.json and its compiler options. Silently skipped when absent, like

--- a/install.sh
+++ b/install.sh
@@ -13,6 +13,8 @@
 #   install.sh --commit-msg # also install the Conventional-Commits commit-msg hook
 #   install.sh --gitleaks-hook # also install opt-in local gitleaks pre-commit pass
 #   install.sh --all-langs  # install every language's forbidden-pattern file
+#   install.sh --coverage-gate # also install the opt-in CI patch-coverage gate
+#   install.sh --no-install # detect missing tools but never auto-run a package manager
 #   install.sh --help       # show this help
 
 set -euo pipefail
@@ -26,6 +28,8 @@ CURSOR=0
 COMMIT_MSG=0
 GITLEAKS_HOOK=0
 ALL_LANGS=0
+COVERAGE_GATE=0
+NO_INSTALL=0
 
 for arg in "$@"; do
   case "$arg" in
@@ -39,7 +43,9 @@ for arg in "$@"; do
     --commit-msg) COMMIT_MSG=1 ;;
     --gitleaks-hook) GITLEAKS_HOOK=1 ;;
     --all-langs)  ALL_LANGS=1 ;;
-    --help|-h)    sed -n '2,16p' "$0"; exit 0 ;;
+    --coverage-gate) COVERAGE_GATE=1 ;;
+    --no-install) NO_INSTALL=1 ;;
+    --help|-h)    sed -n '2,18p' "$0"; exit 0 ;;
     *) echo "error: unknown argument: $arg" >&2; exit 1 ;;
   esac
 done
@@ -106,12 +112,35 @@ cp_safe "$SCAFFOLD_DIR/.scaffold.toml.template" ".scaffold.toml"
 if [ "$MODE" = "python" ] || [ "$MODE" = "both" ]; then
   cp_safe "$SCAFFOLD_DIR/ruff.toml.template" "ruff.toml"
   cp_safe "$SCAFFOLD_DIR/forbidden-patterns/backend.txt.template" ".forbidden-patterns/backend.txt"
+  # Test-runner + coverage config (standalone, like ruff.toml — never edits
+  # pyproject.toml). Skip pytest.ini if the project already configures pytest in
+  # pyproject.toml/tox.ini/setup.cfg, since pytest.ini would silently override it.
+  if grep -rqs -e '\[tool.pytest.ini_options\]' -e '\[pytest\]' pyproject.toml tox.ini setup.cfg 2>/dev/null; then
+    echo "skip (pytest config exists): pytest.ini  — merge .coveragerc settings into your existing config"
+  else
+    cp_safe "$SCAFFOLD_DIR/pytest.ini.template" "pytest.ini"
+  fi
+  cp_safe "$SCAFFOLD_DIR/.coveragerc.template" ".coveragerc"
 fi
 
 # Frontend
 if [ "$MODE" = "frontend" ] || [ "$MODE" = "both" ]; then
   cp_safe "$SCAFFOLD_DIR/eslint.config.js.template" "eslint.config.js"
   cp_safe "$SCAFFOLD_DIR/forbidden-patterns/frontend.txt.template" ".forbidden-patterns/frontend.txt"
+  # TypeScript config the eslint type-aware rules + the tsc --noEmit hook/CI
+  # step already assume (closes the gap where they silently degrade if absent).
+  cp_safe "$SCAFFOLD_DIR/tsconfig.json.template" "tsconfig.json"
+  # Formatting: Prettier runs SEPARATELY from eslint by design (strictTypeChecked
+  # ships no stylistic rules, so there is no eslint-config-prettier — see the
+  # header of eslint.config.js).
+  cp_safe "$SCAFFOLD_DIR/.prettierrc.json.template" ".prettierrc.json"
+  cp_safe "$SCAFFOLD_DIR/.prettierignore.template" ".prettierignore"
+  # Test runner: default to Vitest, but don't fight a project already on Jest.
+  if grep -qs '"jest"' package.json 2>/dev/null || ls -1 jest.config.* >/dev/null 2>&1; then
+    echo "skip (Jest detected): vitest.config.ts  — keep Jest; ensure it emits cobertura coverage for the gate"
+  else
+    cp_safe "$SCAFFOLD_DIR/vitest.config.ts.template" "vitest.config.ts"
+  fi
 fi
 
 # Additional language pattern files (config-driven check-patterns). Each ships a
@@ -177,6 +206,16 @@ if [ "$GITLEAKS_HOOK" -eq 1 ]; then
   echo "note: --gitleaks-hook is the LOCAL echo only. Add .github/workflows/gitleaks.yml (see gitleaks.yml.template) for the unskippable CI gate."
 fi
 
+# Opt-in CI patch-coverage gate (--coverage-gate). Fails a PR when CHANGED lines
+# ship untested (diff-cover). Kept opt-in: it forces tests on new code, which is
+# a policy choice a team must make deliberately. It gates EXECUTION of changed
+# lines, not assertion quality — see RECOMMENDATIONS.md.
+if [ "$COVERAGE_GATE" -eq 1 ]; then
+  cp_safe "$SCAFFOLD_DIR/.github/workflows/coverage.yml.template" ".github/workflows/coverage.yml"
+  echo "note: coverage.yml gates patch coverage (default 100% of changed lines)."
+  echo "      It forces changed lines to be RUN by a test, not verified — pair with review."
+fi
+
 # Wire the hook — preserve existing core.hooksPath if already set (e.g. Husky).
 # Use `git rev-parse --git-dir` so this works in worktrees (where .git is a
 # file, not a directory) and submodules.
@@ -196,34 +235,74 @@ fi
 echo ""
 echo "Done (mode: $MODE)."
 
-# Post-install smoke test — confirms linters are installed and configs load.
+# Post-install toolchain check — the scaffold ships CONFIGS and ENFORCEMENT, but
+# the actual tools (ruff/eslint/tsc/prettier/test runner) are project deps. This
+# step detects what's missing and OFFERS to install it. Auto-running a package
+# manager only happens when SAFE: interactive TTY, not --no-verify, not in CI,
+# and --no-install not set. Otherwise it just prints the command (the scaffold's
+# prior, non-mutating behavior) so CI and piped/scripted runs never install.
+CAN_AUTORUN=0
+if [ "$VERIFY" -eq 1 ] && [ "$NO_INSTALL" -eq 0 ] && [ -t 0 ] && [ -z "${CI:-}" ]; then
+  CAN_AUTORUN=1
+fi
+
+# Detect the project's package manager from lockfiles / available binaries.
+js_install_cmd() {
+  if [ -f pnpm-lock.yaml ] && command -v pnpm >/dev/null 2>&1; then echo "pnpm add -D"
+  elif [ -f yarn.lock ] && command -v yarn >/dev/null 2>&1; then echo "yarn add -D"
+  else echo "npm i -D"; fi
+}
+py_install_cmd() {
+  if { [ -f uv.lock ] || grep -qs '\[tool.uv\]' pyproject.toml 2>/dev/null; } && command -v uv >/dev/null 2>&1; then
+    echo "uv add --dev"
+  else echo "pip install"; fi
+}
+
+# offer <label> <presence-test-command> <install-base> <packages>
+# Prints ✓ when present; otherwise offers to install (auto-run only if safe).
+offer() {
+  local label=$1 testcmd=$2 base=$3 pkgs=$4 reply
+  if eval "$testcmd" >/dev/null 2>&1; then
+    echo "  ✓ $label installed"
+    return
+  fi
+  if [ "$CAN_AUTORUN" -eq 1 ]; then
+    printf "  ? %s not installed — install now with '%s %s'? [y/N] " "$label" "$base" "$pkgs"
+    read -r reply || reply=""
+    case "$reply" in
+      [yY]|[yY][eE][sS])
+        # shellcheck disable=SC2086  # word-split the package list deliberately
+        if $base $pkgs; then echo "  ✓ $label installed"; else echo "  ✗ $label install failed — run: $base $pkgs"; fi ;;
+      *) echo "  - skipped — run: $base $pkgs" ;;
+    esac
+  else
+    echo "  ! $label not installed — run: $base $pkgs"
+  fi
+}
+
 if [ "$VERIFY" -eq 1 ]; then
   echo ""
-  echo "Verifying linters:"
+  echo "Checking toolchain (the scaffold configures these; you supply the binaries):"
   case "$MODE" in
     python|both)
+      PYI=$(py_install_cmd)
+      offer "ruff" "command -v ruff" "$PYI" "ruff"
+      # ruff present: also confirm the config actually loads (2+ = config error).
       if command -v ruff >/dev/null 2>&1; then
-        # Explicit exit-code handling so the smoke test actually distinguishes
-        # "config parsed cleanly" from "ruff crashed on a bad config".
-        # ruff: 0 = no issues, 1 = lint issues found, 2+ = config/invocation error.
-        ruff_exit=0
-        ruff check --quiet . >/dev/null 2>&1 || ruff_exit=$?
-        if [ "$ruff_exit" -le 1 ]; then
-          echo "  ✓ ruff installed and config loads"
-        else
-          echo "  ✗ ruff installed but config errored (exit $ruff_exit) — check ruff.toml"
-        fi
-      else
-        echo "  ! ruff not installed — run: pip install ruff"
-      fi ;;
+        ruff_exit=0; ruff check --quiet . >/dev/null 2>&1 || ruff_exit=$?
+        [ "$ruff_exit" -ge 2 ] && echo "  ✗ ruff config errored (exit $ruff_exit) — check ruff.toml"
+      fi
+      offer "pytest + coverage" "command -v pytest" "$PYI" "pytest pytest-cov"
+      ;;
   esac
   case "$MODE" in
     frontend|both)
-      if command -v npx >/dev/null 2>&1 && npx --no-install eslint --version >/dev/null 2>&1; then
-        echo "  ✓ eslint installed"
-      else
-        echo "  ! eslint not installed — run: npm i -D eslint @eslint/js typescript-eslint eslint-plugin-import-x eslint-plugin-unused-imports"
-      fi ;;
+      JSI=$(js_install_cmd)
+      offer "eslint" "npx --no-install eslint --version" "$JSI" "eslint @eslint/js typescript-eslint eslint-plugin-import-x eslint-plugin-unused-imports"
+      offer "typescript (tsc)" "npx --no-install tsc --version" "$JSI" "typescript"
+      offer "prettier" "npx --no-install prettier --version" "$JSI" "prettier"
+      offer "vitest" "npx --no-install vitest --version" "$JSI" "vitest @vitest/coverage-v8"
+      ;;
   esac
 fi
 

--- a/pytest.ini.template
+++ b/pytest.ini.template
@@ -1,0 +1,12 @@
+# Copy to project root as `pytest.ini` (install.sh does this for Python stacks
+# when no pytest config already exists in pyproject.toml/pytest.ini/tox.ini).
+# Minimal, standalone — like ruff.toml, it does not edit your pyproject.toml.
+#
+# A runner forces nothing on its own. The opt-in patch-coverage gate
+# (`.github/workflows/coverage.yml`, `install.sh --coverage-gate`) is what
+# fails the build when CHANGED lines ship untested. See RECOMMENDATIONS.md.
+[pytest]
+testpaths = tests
+python_files = test_*.py *_test.py
+# -ra prints a summary of skips/xfails so silently-skipped tests stay visible.
+addopts = -ra

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -70,6 +70,17 @@ git add . && git commit --quiet -m "fixture" --no-verify
 "$SCAFFOLD_DIR/install.sh" --both --all-langs --no-verify >/dev/null
 git add . && git commit --quiet -m "install scaffold" --no-verify
 
+# The scaffold now ships tsconfig.json / prettier / vitest configs by stack.
+# Those gate the OPTIONAL tsc + prettier hook steps, which would otherwise fire
+# on the synthetic .ts fixtures below (and on vitest.config.ts) wherever a global
+# tsc/prettier is on PATH — e.g. GitHub's ubuntu runner — failing the regex unit
+# tests for the wrong reason. Remove them here so the pattern/secret cases stay
+# isolated to the layer they test; config DELIVERY is verified in its own fresh
+# install near the end, and the dedicated tsc test (case 42) makes its own
+# tsconfig.json on demand.
+git rm -q tsconfig.json .prettierrc.json .prettierignore vitest.config.ts
+git commit --quiet -m "isolate hook unit tests from optional tsc/prettier steps" --no-verify
+
 echo "Hook test cases:"
 
 # 1. file size cap
@@ -978,6 +989,77 @@ else
   sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
 fi
 rm -rf "$NOGL" "$GLBIN"
+reset_repo
+
+# --- toolchain config delivery + detect/offer ------------------------------
+# Fresh install (the bootstrap repo removed some of these to isolate the hook
+# unit tests). A --both install must drop every auto-by-stack config.
+cd "$WORK"
+DTMP=$(mktemp -d)
+( cd "$DTMP" && git init --quiet && echo '{"name":"x"}' >package.json && echo 'name="x"' >pyproject.toml \
+  && "$SCAFFOLD_DIR/install.sh" --both --no-verify ) >"$HOOK_OUT" 2>&1
+for f in tsconfig.json .prettierrc.json .prettierignore vitest.config.ts pytest.ini .coveragerc; do
+  if [ -f "$DTMP/$f" ]; then
+    echo "  ✓ install ships $f (auto by stack)"; PASS=$((PASS + 1))
+  else
+    echo "  ✗ install did not ship $f"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+  fi
+done
+rm -rf "$DTMP"
+
+# (T) coverage.yml.template is a valid GitHub Actions workflow (opt-in gate).
+if command -v actionlint >/dev/null 2>&1; then
+  CTMP=$(mktemp -d); mkdir -p "$CTMP/.github/workflows"
+  cp "$SCAFFOLD_DIR/.github/workflows/coverage.yml.template" "$CTMP/.github/workflows/coverage.yml"
+  if ( cd "$CTMP" && actionlint -shellcheck= -pyflakes= .github/workflows/coverage.yml ) >"$HOOK_OUT" 2>&1; then
+    echo "  ✓ coverage.yml.template is a valid GitHub Actions workflow"; PASS=$((PASS + 1))
+  else
+    echo "  ✗ coverage.yml.template failed actionlint"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+  fi
+  rm -rf "$CTMP"
+else
+  echo "  - skipped coverage.yml validation (actionlint not installed)"
+fi
+
+# (T) detect/offer is PRINT-ONLY and non-mutating under non-interactive stdin:
+#     no TTY → never auto-runs a package manager, never prompts, never hangs.
+OFFTMP=$(mktemp -d)
+( cd "$OFFTMP" && git init --quiet && echo '{"name":"x"}' >package.json \
+  && "$SCAFFOLD_DIR/install.sh" --frontend </dev/null ) >"$HOOK_OUT" 2>&1
+if grep -q "not installed — run:" "$HOOK_OUT" \
+   && ! grep -q "install now with" "$HOOK_OUT" \
+   && [ ! -d "$OFFTMP/node_modules" ]; then
+  echo "  ✓ detect/offer is print-only + non-mutating without a TTY"; PASS=$((PASS + 1))
+else
+  echo "  ✗ detect/offer — expected print-only run-hints, no prompt, no install"
+  sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$OFFTMP"
+
+# (T) Vitest config is NOT shipped when the project already uses Jest.
+JTMP=$(mktemp -d)
+( cd "$JTMP" && git init --quiet && echo '{"name":"x","devDependencies":{"jest":"^29"}}' >package.json \
+  && "$SCAFFOLD_DIR/install.sh" --frontend --no-verify ) >"$HOOK_OUT" 2>&1
+if [ ! -f "$JTMP/vitest.config.ts" ] && grep -q "Jest detected" "$HOOK_OUT"; then
+  echo "  ✓ vitest.config.ts skipped when Jest is present"; PASS=$((PASS + 1))
+else
+  echo "  ✗ vitest.config.ts — should be skipped for a Jest project"
+  sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$JTMP"
+
+# (T) pytest.ini is NOT shipped when pyproject.toml already configures pytest.
+PTMP=$(mktemp -d)
+( cd "$PTMP" && git init --quiet \
+  && printf '[tool.pytest.ini_options]\naddopts = "-q"\n' >pyproject.toml \
+  && "$SCAFFOLD_DIR/install.sh" --python --no-verify ) >"$HOOK_OUT" 2>&1
+if [ ! -f "$PTMP/pytest.ini" ] && grep -q "pytest config exists" "$HOOK_OUT"; then
+  echo "  ✓ pytest.ini skipped when pyproject configures pytest"; PASS=$((PASS + 1))
+else
+  echo "  ✗ pytest.ini — should be skipped when pyproject has [tool.pytest.ini_options]"
+  sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$PTMP"
 reset_repo
 
 echo ""

--- a/tsconfig.json.template
+++ b/tsconfig.json.template
@@ -1,0 +1,44 @@
+{
+  // Copy to project root as `tsconfig.json` (install.sh does this for frontend
+  // stacks). This is the type-checker config that `eslint.config.js`'s
+  // type-aware rules (`strictTypeChecked`) AND the `tsc --noEmit` step in the
+  // pre-commit hook + CI both rely on — without it, the highest-value async-
+  // safety rules silently degrade. tsconfig.json is JSONC: comments are allowed.
+  //
+  // Tuned for type-CHECKING, not building (`noEmit: true`). If you compile with
+  // tsc, a bundler, or a framework (Next/Vite/etc.), keep your build's own
+  // tsconfig and let this layer the strictness on via `extends`, or merge the
+  // `compilerOptions` below into yours. The flags here are the ones that turn
+  // whole classes of "compiles but wrong" into build failures.
+  "compilerOptions": {
+    // --- Strictness: the point of the file ---------------------------------
+    "strict": true,                       // the strict family (null checks, implicit-any, etc.)
+    "noUncheckedIndexedAccess": true,     // arr[i] / obj[k] is T | undefined — kills the #1 silent runtime crash
+    "exactOptionalPropertyTypes": true,   // `{ x?: T }` ≠ `{ x: T | undefined }`; stops accidental undefined writes
+    "noImplicitOverride": true,           // an override must say `override` — catches base-method renames
+    "noFallthroughCasesInSwitch": true,   // a case that falls through must be intentional
+    "noImplicitReturns": true,            // every code path returns, or none do
+    "noUnusedLocals": true,               // dead locals (eslint covers imports; this covers the rest)
+    "noUnusedParameters": true,           // prefix with _ to keep an intentionally-unused param
+    "forceConsistentCasingInFileNames": true,
+    "allowUnreachableCode": false,
+    "allowUnusedLabels": false,
+
+    // --- Module / target: modern defaults; adjust per runtime --------------
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",        // "NodeNext" if you run under Node without a bundler
+    "moduleDetection": "force",
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,              // per-file transpile safety (esbuild/swc/Vite)
+    "verbatimModuleSyntax": true,         // explicit `import type` — required by isolatedModules for type-only imports
+
+    // --- Type-check only; your build owns emit ----------------------------
+    "noEmit": true,
+    "skipLibCheck": true,                 // don't type-check node_modules .d.ts (speed; standard)
+    "lib": ["ES2022"]                     // add "DOM", "DOM.Iterable" for browser code
+  },
+  "include": ["**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules", "dist", "build", "coverage"]
+}

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -65,7 +65,13 @@ force_remove() {
 
 # Generated configs — removed only if unchanged
 remove_if_unmodified "ruff.toml"                     "$SCAFFOLD_DIR/ruff.toml.template"
+remove_if_unmodified "pytest.ini"                    "$SCAFFOLD_DIR/pytest.ini.template"
+remove_if_unmodified ".coveragerc"                   "$SCAFFOLD_DIR/.coveragerc.template"
 remove_if_unmodified "eslint.config.js"              "$SCAFFOLD_DIR/eslint.config.js.template"
+remove_if_unmodified "tsconfig.json"                 "$SCAFFOLD_DIR/tsconfig.json.template"
+remove_if_unmodified ".prettierrc.json"              "$SCAFFOLD_DIR/.prettierrc.json.template"
+remove_if_unmodified ".prettierignore"               "$SCAFFOLD_DIR/.prettierignore.template"
+remove_if_unmodified "vitest.config.ts"              "$SCAFFOLD_DIR/vitest.config.ts.template"
 remove_if_unmodified ".githooks/pre-commit"          "$SCAFFOLD_DIR/githooks/pre-commit.template"
 for check in check-size check-patterns check-filenames check-secrets check-hygiene scaffold-config scaffold-audit; do
   remove_if_unmodified ".githooks/lib/${check}" "$SCAFFOLD_DIR/githooks/lib/${check}.template"
@@ -85,6 +91,8 @@ remove_if_unmodified ".cursor/hooks.json"            "$SCAFFOLD_DIR/cursor-hooks
 remove_if_unmodified ".githooks/commit-msg"          "$SCAFFOLD_DIR/githooks/commit-msg.template"
 # Opt-in local gitleaks pass (only present if installed with --gitleaks-hook).
 remove_if_unmodified ".githooks/lib/check-gitleaks"  "$SCAFFOLD_DIR/githooks/lib/check-gitleaks.template"
+# Opt-in CI patch-coverage gate (only present if installed with --coverage-gate).
+remove_if_unmodified ".github/workflows/coverage.yml" "$SCAFFOLD_DIR/.github/workflows/coverage.yml.template"
 
 # Likely-customized files — only with --all
 if [ "$REMOVE_ALL" -eq 1 ]; then

--- a/vitest.config.ts.template
+++ b/vitest.config.ts.template
@@ -1,0 +1,30 @@
+// Copy to project root as `vitest.config.ts` (install.sh does this for frontend
+// stacks unless the project already uses Jest). Vitest is the default runner:
+// Vite-native, ESM-first, near-zero config. Swap for Jest if your stack already
+// standardized on it — the scaffold won't fight an existing choice.
+//
+// A test runner does NOT force tests to exist or to assert anything. The
+// opt-in patch-coverage gate (`.github/workflows/coverage.yml`,
+// `install.sh --coverage-gate`) is what makes the build fail when CHANGED lines
+// ship untested — and even that forces lines to be EXECUTED by a test, not
+// verified by one. See RECOMMENDATIONS.md ("forcing tests") for the ceiling.
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    // Glob mirrors the eslint test-file override so the same files are "tests"
+    // to both tools.
+    include: ['**/*.{test,spec}.{ts,tsx}'],
+    coverage: {
+      // V8 is built in (no extra dep). `json` + `cobertura` reporters feed the
+      // patch-coverage gate; `text` prints a summary locally.
+      provider: 'v8',
+      reporter: ['text', 'json', 'cobertura'],
+      reportsDirectory: 'coverage',
+      // Source under test — adjust `src` to your layout. Excludes keep config
+      // and the tests themselves out of the denominator.
+      include: ['src/**/*.{ts,tsx}'],
+      exclude: ['**/*.{test,spec}.{ts,tsx}', '**/*.d.ts'],
+    },
+  },
+});


### PR DESCRIPTION
## Summary

The scaffold shipped rule/enforcement configs but never the **tool** configs its own rules assume, and never the tools themselves — so consumers read TypeScript/test/format gaps as scaffold drift when they were always "bring your own." This closes that gap while keeping the enforcement-only philosophy intact: the scaffold still *configures* and *enforces*; it now also *detects* and *offers* the binaries.

### What changed
- **Configs auto-installed by stack** (via `cp_safe`, so existing files aren't clobbered):
  - strict `tsconfig.json` — the type-aware eslint rules + the already-wired `tsc --noEmit` depend on it
  - `.prettierrc.json` + `.prettierignore` — Prettier runs **separately** from eslint by design (`strictTypeChecked` ships no stylistic rules, so there is intentionally **no** `eslint-config-prettier`)
  - `vitest.config.ts` — skipped when the project already uses Jest
  - `pytest.ini` + `.coveragerc` — `pytest.ini` skipped when pyproject/tox already configures pytest
- **`prettier --check` in the pre-commit hook + `lint.yml`**, guarded like ruff/eslint (config present AND tool installed, else silently skipped).
- **Detect → offer step** replaces the post-install linter smoke test. Offers to install missing `ruff`/`pytest`/`eslint`/`tsc`/`prettier`/`vitest`. Auto-run **only when safe**: interactive TTY, not `--no-verify`, not in CI (`$CI`), not `--no-install`; otherwise prints the command so CI/piped runs never mutate the environment. Package manager detected from lockfiles. New flag: `--no-install`.
- **Opt-in CI patch-coverage gate** (`--coverage-gate` → `coverage.yml`): `diff-cover` fails a PR when changed lines ship untested. Gates *execution* of changed lines, not assertion quality — documented ceiling, with mutation testing deferred in `RECOMMENDATIONS.md` ("Forcing tests"). Action SHAs match `lint.yml` so the pin-drift guard stays green.
- `uninstall.sh` removes the new files; README/RECOMMENDATIONS/CHANGELOG updated; release **v0.7.0**.

### Test plan
- `tests/run.sh`: **119 passed, 0 failed** (+10 new: config delivery by stack, Jest/pytest skip paths, `coverage.yml` actionlint validity, and a regression guard that detect/offer is print-only and non-mutating without a TTY).
- `shellcheck -S info` clean across all shell + hook scripts.
- `actionlint` clean on rendered `lint.yml` + `coverage.yml`; pin-drift guard empty; `zizmor` clean.