### PR TITLE
fix: install.sh never clobbers user-owned CLAUDE.md / AGENTS.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- **`install.sh` no longer clobbers user-owned `CLAUDE.md` / `AGENTS.md`.**
+  `CLAUDE.md` is now *merged* — a marked `@AGENTS.md` import block is appended
+  once if missing, and existing content is never replaced, even with `--force`
+  (previously `--force` overwrote it wholesale with the pointer stub,
+  destroying hand-written project memory). An existing `AGENTS.md` is likewise
+  left untouched (its Project section is user-authored). For every other file,
+  `--force` now backs the current copy up to `<file>.scaffold-bak` before
+  replacing it, so no edit is silently destroyed. `uninstall.sh` strips only
+  the marked block from a user's `CLAUDE.md` (or removes the file only when
+  it's an unmodified scaffold-created pointer). +5 tests.
+
 ## [v0.7.0] — 2026-06-16
 
 Toolchain setup: the scaffold now ships the tool *configs* its enforcement

--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,7 @@
 #   install.sh --python     # Python only
 #   install.sh --frontend   # TS/JS only
 #   install.sh --both       # install both stacks
-#   install.sh --force      # overwrite existing files
+#   install.sh --force      # replace scaffold files (backs each up first; never CLAUDE.md/AGENTS.md)
 #   install.sh --no-verify  # skip the post-install linter smoke test
 #   install.sh --claude     # also install opt-in Claude Code agent guardrails
 #   install.sh --cursor     # also install opt-in Cursor agent guardrails (.cursor/hooks.json)
@@ -77,20 +77,75 @@ fi
 
 cp_safe() {
   local src=$1 dst=$2
-  if [ -e "$dst" ] && [ "$FORCE" -eq 0 ]; then
-    echo "skip (exists): $dst  — use --force to overwrite"
-    return
+  if [ -e "$dst" ]; then
+    if [ "$FORCE" -eq 0 ]; then
+      echo "skip (exists): $dst  — left untouched (use --force to replace)"
+      return
+    fi
+    # --force: back up the existing file before overwriting, but only when it
+    # actually differs — so no edit is ever silently destroyed. Identical
+    # files are a no-op.
+    if cmp -s "$src" "$dst"; then
+      return
+    fi
+    local bak="${dst}.scaffold-bak" n=0
+    while [ -e "$bak" ]; do
+      n=$((n + 1))
+      if [ "$n" -gt 99 ]; then
+        echo "error: too many .scaffold-bak files for $dst — clean some up" >&2
+        return 1
+      fi
+      bak="${dst}.scaffold-bak.${n}"
+    done
+    cp "$dst" "$bak"
+    echo "backed up:    $dst -> $bak"
   fi
   mkdir -p "$(dirname "$dst")"
   cp "$src" "$dst"
   echo "installed:    $dst"
 }
 
+# install_claude_md — CLAUDE.md is USER-OWNED project memory, not a scaffold
+# file. Never replace it (not even with --force). If absent, create it from
+# the pointer template. If present, append a marked block importing AGENTS.md
+# once, and only if no @AGENTS.md import already exists.
+install_claude_md() {
+  if [ ! -e "CLAUDE.md" ]; then
+    cp "$SCAFFOLD_DIR/CLAUDE.md.pointer" "CLAUDE.md"
+    echo "installed:    CLAUDE.md (new — pointer to AGENTS.md)"
+    return
+  fi
+  if grep -q '@AGENTS.md' "CLAUDE.md" 2>/dev/null \
+     || grep -q 'ai-coding-rules-scaffold:begin' "CLAUDE.md" 2>/dev/null; then
+    echo "ok (wired):   CLAUDE.md already imports AGENTS.md — left untouched"
+    return
+  fi
+  {
+    printf '\n<!-- ai-coding-rules-scaffold:begin -->\n'
+    printf 'See [AGENTS.md](./AGENTS.md) — agent + project rules (cross-tool convention).\n\n'
+    printf '@AGENTS.md\n'
+    printf '<!-- ai-coding-rules-scaffold:end -->\n'
+  } >>"CLAUDE.md"
+  echo "merged:       appended @AGENTS.md import to existing CLAUDE.md (your content kept)"
+}
+
+# install_agents_md — AGENTS.md carries a Project section the user fills in,
+# so an existing one is never clobbered (even with --force). Skip if present;
+# create from template only when absent.
+install_agents_md() {
+  if [ -e "AGENTS.md" ]; then
+    echo "skip (exists): AGENTS.md — left untouched (your Project section is safe)"
+    return
+  fi
+  cp "$SCAFFOLD_DIR/AGENTS.md.template" "AGENTS.md"
+  echo "installed:    AGENTS.md"
+}
+
 # Always
 cp_safe "$SCAFFOLD_DIR/coding-rules.md" "coding-rules.md"
 cp_safe "$SCAFFOLD_DIR/operational-rules.md" "operational-rules.md"
-cp_safe "$SCAFFOLD_DIR/AGENTS.md.template" "AGENTS.md"
-cp_safe "$SCAFFOLD_DIR/CLAUDE.md.pointer" "CLAUDE.md"
+install_agents_md   # never clobbers an existing AGENTS.md
+install_claude_md   # merges; never overwrites your CLAUDE.md
 cp_safe "$SCAFFOLD_DIR/githooks/pre-commit.template" ".githooks/pre-commit"
 chmod +x .githooks/pre-commit
 # scaffold-config + scaffold-audit are the per-project override layer

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1062,6 +1062,74 @@ fi
 rm -rf "$PTMP"
 reset_repo
 
+# --- install never clobbers user-owned files (CLAUDE.md / AGENTS.md) --------
+# Regression guard for the reported data-loss bug: install.sh --force used to
+# overwrite a hand-written CLAUDE.md wholesale with the pointer stub. CLAUDE.md
+# is now merged (import block appended once) and AGENTS.md is never replaced.
+cd "$WORK"
+mk_userproj() {
+  local d; d=$(mktemp -d)
+  ( cd "$d" && git init --quiet && echo '{"name":"x"}' >package.json && echo 'name="x"' >pyproject.toml \
+    && printf '# Mine\n\nHAND-WRITTEN-MEMORY\n' >CLAUDE.md \
+    && printf '# AGENTS\n\nCUSTOM-PROJECT-SECTION\n' >AGENTS.md )
+  echo "$d"
+}
+
+# (T) install merges CLAUDE.md: keeps user content AND appends the import.
+UMG=$(mk_userproj)
+( cd "$UMG" && "$SCAFFOLD_DIR/install.sh" --both --no-verify ) >"$HOOK_OUT" 2>&1
+if grep -q 'HAND-WRITTEN-MEMORY' "$UMG/CLAUDE.md" && grep -q '@AGENTS.md' "$UMG/CLAUDE.md"; then
+  echo "  ✓ install merges CLAUDE.md (keeps content + adds import)"; PASS=$((PASS + 1))
+else
+  echo "  ✗ install should merge CLAUDE.md, not replace it"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$UMG"
+
+# (T) install --force must NOT clobber CLAUDE.md or a customized AGENTS.md.
+UFC=$(mk_userproj)
+( cd "$UFC" && "$SCAFFOLD_DIR/install.sh" --both --force --no-verify ) >"$HOOK_OUT" 2>&1
+if grep -q 'HAND-WRITTEN-MEMORY' "$UFC/CLAUDE.md" && grep -q 'CUSTOM-PROJECT-SECTION' "$UFC/AGENTS.md"; then
+  echo "  ✓ --force preserves user CLAUDE.md and AGENTS.md"; PASS=$((PASS + 1))
+else
+  echo "  ✗ --force clobbered a user-owned file"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$UFC"
+
+# (T) install is idempotent — CLAUDE.md import block appears exactly once.
+UIDEM=$(mk_userproj)
+( cd "$UIDEM" && "$SCAFFOLD_DIR/install.sh" --both --no-verify >/dev/null 2>&1 \
+             && "$SCAFFOLD_DIR/install.sh" --both --no-verify ) >"$HOOK_OUT" 2>&1
+if [ "$(grep -c 'ai-coding-rules-scaffold:begin' "$UIDEM/CLAUDE.md")" = "1" ]; then
+  echo "  ✓ CLAUDE.md import is idempotent (appended once)"; PASS=$((PASS + 1))
+else
+  echo "  ✗ CLAUDE.md import not idempotent"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$UIDEM"
+
+# (T) --force backs up a locally-modified scaffold file before replacing it.
+UBK=$(mk_userproj)
+( cd "$UBK" && "$SCAFFOLD_DIR/install.sh" --both --no-verify >/dev/null 2>&1 \
+            && echo '# local edit' >>ruff.toml \
+            && "$SCAFFOLD_DIR/install.sh" --both --force --no-verify ) >"$HOOK_OUT" 2>&1
+if [ -f "$UBK/ruff.toml.scaffold-bak" ] && grep -q 'local edit' "$UBK/ruff.toml.scaffold-bak"; then
+  echo "  ✓ --force backs up changed files to .scaffold-bak"; PASS=$((PASS + 1))
+else
+  echo "  ✗ --force did not back up the changed file"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$UBK"
+
+# (T) uninstall strips the scaffold block but keeps the user's CLAUDE.md content.
+UUN=$(mk_userproj)
+( cd "$UUN" && "$SCAFFOLD_DIR/install.sh" --both --no-verify >/dev/null 2>&1 \
+            && "$SCAFFOLD_DIR/uninstall.sh" ) >"$HOOK_OUT" 2>&1
+if grep -q 'HAND-WRITTEN-MEMORY' "$UUN/CLAUDE.md" && ! grep -q 'ai-coding-rules-scaffold:begin' "$UUN/CLAUDE.md"; then
+  echo "  ✓ uninstall strips block, keeps CLAUDE.md content"; PASS=$((PASS + 1))
+else
+  echo "  ✗ uninstall should strip only the block, keep content"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$UUN"
+reset_repo
+
 echo ""
 echo "Result: $PASS passed, $FAIL failed"
 exit $FAIL

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -7,7 +7,7 @@
 #
 # Files considered "likely customized" (AGENTS.md, coding-rules.md,
 # .forbidden-patterns/*.txt) are always left alone unless --all is given.
-# CLAUDE.md is treated as a regenerable pointer and removed if unchanged.
+# CLAUDE.md is user-owned — only a scaffold-created file or our appended block is removed.
 #
 # Usage:
 #   uninstall.sh          # safe mode: only unchanged generated files
@@ -63,6 +63,37 @@ force_remove() {
   fi
 }
 
+# clean_claude_md — CLAUDE.md is user-owned. If we created it wholesale
+# (byte-equal to the pointer template), remove it. If we appended our marked
+# import block to the user's own file, strip ONLY that block and keep the
+# rest. Otherwise leave it entirely alone. Never deletes user content.
+clean_claude_md() {
+  [ -e "CLAUDE.md" ] || return
+  if same_as_template "CLAUDE.md" "$SCAFFOLD_DIR/CLAUDE.md.pointer"; then
+    if [ "$DRY_RUN" -eq 1 ]; then
+      echo "would remove: CLAUDE.md (scaffold-created pointer)"
+    else
+      rm "CLAUDE.md"
+      echo "removed:      CLAUDE.md (scaffold-created pointer)"
+    fi
+    return
+  fi
+  if grep -q 'ai-coding-rules-scaffold:begin' "CLAUDE.md" 2>/dev/null; then
+    if [ "$DRY_RUN" -eq 1 ]; then
+      echo "would strip:  scaffold import block from CLAUDE.md (your content kept)"
+    else
+      # -i.scaffold-tmp works on both GNU and BSD sed; remove the backup after.
+      sed -i.scaffold-tmp \
+        '/<!-- ai-coding-rules-scaffold:begin -->/,/<!-- ai-coding-rules-scaffold:end -->/d' \
+        "CLAUDE.md"
+      rm -f "CLAUDE.md.scaffold-tmp"
+      echo "stripped:     scaffold import block from CLAUDE.md (your content kept)"
+    fi
+    return
+  fi
+  echo "kept:         CLAUDE.md — no scaffold block found, left untouched"
+}
+
 # Generated configs — removed only if unchanged
 remove_if_unmodified "ruff.toml"                     "$SCAFFOLD_DIR/ruff.toml.template"
 remove_if_unmodified "pytest.ini"                    "$SCAFFOLD_DIR/pytest.ini.template"
@@ -81,7 +112,7 @@ done
 remove_if_unmodified ".scaffold.toml"                "$SCAFFOLD_DIR/.scaffold.toml.template"
 remove_if_unmodified ".github/workflows/lint.yml"    "$SCAFFOLD_DIR/.github/workflows/lint.yml.template"
 remove_if_unmodified ".github/dependabot.yml"        "$SCAFFOLD_DIR/.github/dependabot.yml.template"
-remove_if_unmodified "CLAUDE.md"                     "$SCAFFOLD_DIR/CLAUDE.md.pointer"
+clean_claude_md
 # Opt-in Claude Code guardrails (only present if installed with --claude).
 remove_if_unmodified ".githooks/lib/agent-precheck"  "$SCAFFOLD_DIR/githooks/lib/agent-precheck.template"
 remove_if_unmodified ".claude/settings.json"         "$SCAFFOLD_DIR/claude-settings.json.template"


### PR DESCRIPTION
## Problem

`install.sh --force` overwrites user-owned files wholesale — `CLAUDE.md` is replaced with the 4-line pointer stub, **destroying hand-written project memory**. This is still reproducible on current `main`: `cp_safe` treats `CLAUDE.md`/`AGENTS.md` like scaffold-owned templates, and the skip message (`use --force to overwrite`) lures users into the destructive `--force` path.

## Fix — classify files by ownership

- **`CLAUDE.md`** (user-owned project memory): *merge*, never replace. Append a marked `@AGENTS.md` import block only if missing; never overwrite existing content, even with `--force`.
- **`AGENTS.md`** (user fills in the Project section): never overwrite an existing one, even with `--force`.
- **All other files under `--force`**: back up to `<file>.scaffold-bak` (only when content differs) before replacing — no edit is ever silently destroyed.
- **`uninstall.sh`**: strip only the marked block from a user's `CLAUDE.md`; remove the file only when it's an unmodified scaffold-created pointer.

## Tests

+5 regression tests in `tests/run.sh`: CLAUDE.md merge, `--force` non-clobber of CLAUDE.md/AGENTS.md, idempotency (block appended once), `.scaffold-bak` backup, and uninstall block-stripping.

- Full suite: **121 passed, 0 failed**
- `shellcheck` clean on `install.sh` / `uninstall.sh` / `tests/run.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)