### PR TITLE
fix(ci): don't redden a fresh install — scope lint.yml to the PR/push diff

### DIFF
--- a/.github/workflows/lint.yml.template
+++ b/.github/workflows/lint.yml.template
@@ -22,10 +22,21 @@ jobs:
     # guardrails. The job always starts; its tool steps no-op when the
     # configs are absent (frontend-only repos see a green, empty python job).
     runs-on: ubuntu-latest
+    # Diff-scoped: ruff lints only files CHANGED in this PR/push, so installing
+    # the scaffold onto an existing project never retroactively fails the whole
+    # tree of pre-existing code. New/changed code is fully gated; legacy is
+    # grandfathered until it's next touched. fetch-depth: 0 gives the diff a base.
+    env:
+      EVENT: ${{ github.event_name }}
+      PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      PUSH_BEFORE: ${{ github.event.before }}
+      PUSH_AFTER: ${{ github.event.after }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           persist-credentials: false  # don't leave GITHUB_TOKEN in .git/config
+          fetch-depth: 0              # full history so the PR/push diff resolves
       - id: detect
         run: |
           if [ -f ruff.toml ] || [ -f pyproject.toml ]; then
@@ -37,16 +48,37 @@ jobs:
           python-version: "3.12"
       - if: steps.detect.outputs.present == 'true'
         run: pip install ruff
-      - if: steps.detect.outputs.present == 'true'
-        run: ruff check .
+      - name: ruff check (changed files only)
+        if: steps.detect.outputs.present == 'true'
+        run: |
+          # .githooks/lib/ci-changed-files resolves the PR/push diff (NUL list),
+          # failing open to the whole tree when there's no diff base. One shared
+          # implementation, unit-tested in tests/cases/10.
+          bash .githooks/lib/ci-changed-files >changed.nul
+          # Portable NUL read (bash 3.2-safe — same idiom as the check-* scripts);
+          # avoids `mapfile`, which predates bash 4 and is absent on some runners.
+          py=()
+          while IFS= read -r -d '' f; do case "$f" in *.py) py+=("$f") ;; esac; done <changed.nul
+          if [ ${#py[@]} -eq 0 ]; then echo "no changed Python files — skipping ruff"; exit 0; fi
+          printf 'ruff: linting %d changed Python file(s)\n' "${#py[@]}"
+          ruff check -- "${py[@]}"
 
   frontend:
     # Same pattern as `python` — detect in a step, not a job-level `if:`.
+    # Diff-scoped too: eslint + prettier check only the PR/push diff (tsc is
+    # whole-program, see its step). fetch-depth: 0 gives the diff a base.
     runs-on: ubuntu-latest
+    env:
+      EVENT: ${{ github.event_name }}
+      PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      PUSH_BEFORE: ${{ github.event.before }}
+      PUSH_AFTER: ${{ github.event.after }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           persist-credentials: false  # don't leave GITHUB_TOKEN in .git/config
+          fetch-depth: 0              # full history so the PR/push diff resolves
       - id: detect
         run: |
           if [ -f eslint.config.js ] || [ -f package.json ]; then
@@ -80,8 +112,41 @@ jobs:
             echo "no package-lock.json — using npm install (add a lockfile for reproducible CI)"
             npm install --ignore-scripts
           fi
-      - if: steps.detect.outputs.present == 'true'
-        run: npx eslint .
+      - name: Compute changed files
+        if: steps.detect.outputs.present == 'true'
+        run: |
+          # NUL-delimited list of files changed in this PR/push (shared by the
+          # eslint + prettier steps below — the workspace persists across steps).
+          # ci-changed-files fails open to the whole tree when there's no diff
+          # base; same shared helper the python + guardrails jobs use.
+          bash .githooks/lib/ci-changed-files >changed.nul
+      - name: ESLint (changed files only)
+        if: steps.detect.outputs.present == 'true'
+        run: |
+          # eslint must LOAD its flat config (every plugin resolved) before it can
+          # lint anything. The scaffold ships eslint.config.js whose peer deps must
+          # be in package.json + the lockfile, or `npm ci` won't install them and
+          # eslint crashes cryptically. Turn that into an actionable error instead.
+          PEERS='eslint @eslint/js typescript-eslint eslint-plugin-import-x eslint-plugin-unused-imports'
+          if [ -f eslint.config.js ]; then
+            if ! npx --no-install eslint --version >/dev/null 2>&1; then
+              echo "::error file=eslint.config.js::eslint is not installed. Run: npm i -D $PEERS  — then commit package-lock.json (CI installs from the lockfile)."
+              exit 1
+            fi
+            # Confirm the flat config actually loads — catches a missing PLUGIN dep
+            # (eslint --version passes even when a plugin import would fail).
+            if ! npx --no-install eslint --print-config eslint.config.js >/dev/null 2>cfg.err; then
+              echo "::error file=eslint.config.js::eslint.config.js failed to load — a peer dependency is likely missing. Run: npm i -D $PEERS (commit the lockfile)."
+              sed 's/^/  /' cfg.err >&2 || true
+              exit 1
+            fi
+          fi
+          # Portable NUL read (bash 3.2-safe — same idiom as the check-* scripts).
+          js=()
+          while IFS= read -r -d '' f; do case "$f" in *.ts|*.tsx|*.js|*.jsx|*.cjs|*.mjs|*.vue) js+=("$f") ;; esac; done <changed.nul
+          if [ ${#js[@]} -eq 0 ]; then echo "no changed JS/TS files — skipping eslint"; exit 0; fi
+          printf 'eslint: linting %d changed file(s)\n' "${#js[@]}"
+          npx --no-install eslint -- "${js[@]}"
       - name: Format check (prettier --check)
         if: steps.detect.outputs.present == 'true'
         # Mirrors the pre-commit hook. Only runs when a prettier config is present
@@ -90,7 +155,13 @@ jobs:
         run: |
           if { [ -f .prettierrc ] || [ -f .prettierrc.json ] || [ -f .prettierrc.js ] || [ -f prettier.config.js ]; } \
              && npx --no-install prettier --version >/dev/null 2>&1; then
-            npx --no-install prettier --check .
+            changed=()
+            while IFS= read -r -d '' f; do changed+=("$f"); done <changed.nul
+            if [ ${#changed[@]} -eq 0 ]; then echo "no changed files — skipping format check"; exit 0; fi
+            # --ignore-unknown lets prettier skip types it can't format, so passing
+            # every changed path is safe. Changed-files-only mirrors the rest of the
+            # workflow so a fresh install never format-fails pre-existing files.
+            npx --no-install prettier --check --ignore-unknown -- "${changed[@]}"
           else
             echo "no prettier config or prettier not installed — skipping format check"
           fi
@@ -101,6 +172,10 @@ jobs:
         # the two layers stay in lockstep. coding-rules.md rule 9 mandates a
         # type-checker; this is where it runs server-side.
         run: |
+          # NOTE: a type-check is inherently WHOLE-PROGRAM (types are interdependent),
+          # so unlike eslint/ruff it can't be diff-scoped. If a freshly-installed
+          # project has pre-existing type errors, narrow tsconfig "include" or fix
+          # them — this is a real correctness signal, not lint noise.
           if [ -f tsconfig.json ] && npx --no-install tsc --version >/dev/null 2>&1; then
             npx --no-install tsc --noEmit
           else
@@ -213,6 +288,13 @@ jobs:
     # File size, forbidden patterns, blocked filenames, secret scan —
     # the same lib/check-* scripts the pre-commit hook calls.
     #
+    # SCOPE: secrets + credential-filenames scan the WHOLE tree (catching an
+    # already-committed secret/key is the point, and they're the non-overridable
+    # security boundary). size + forbidden-patterns + hygiene scan only the
+    # PR/push DIFF, so installing the scaffold onto an existing repo doesn't
+    # retroactively fail its pre-existing code — only new/changed code is gated.
+    # fetch-depth: 0 (below) gives the diff a base.
+    #
     # Two limitations to know about (both inherent to how this job is wired,
     # not bugs you can patch in the script):
     #
@@ -237,10 +319,17 @@ jobs:
     #      If your repo keeps scannable text in LFS, add `lfs: true` to the
     #      checkout below and scan the smudged working tree for those paths.
     runs-on: ubuntu-latest
+    env:
+      EVENT: ${{ github.event_name }}
+      PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      PUSH_BEFORE: ${{ github.event.before }}
+      PUSH_AFTER: ${{ github.event.after }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           persist-credentials: false  # don't leave GITHUB_TOKEN in .git/config
+          fetch-depth: 0              # full history so the PR/push diff resolves
       - name: Show active rule overrides (.scaffold.toml)
         # Print every per-project override into the log so a disabled or
         # downgraded rule is visible in review, not silent. Informational only.
@@ -250,19 +339,29 @@ jobs:
       - name: Run scaffold checks
         run: |
           chmod +x .githooks/lib/* 2>/dev/null || true
-          # -z (NUL-delimited) so a filename containing a newline, tab, or
-          # quote can't split the list and slip a file past the scan. The
-          # check scripts read each file's committed blob (git show ":0:<path>"),
-          # so the server-side scan sees exactly what was committed — matching
-          # the pre-commit hook. A shell var can't hold NUL, so the list goes
-          # to a temp file fed to each check.
-          STAGED_LIST=$(mktemp)
-          git -c core.quotepath=off ls-files -z >"$STAGED_LIST"
+          # Two scopes (see the job header):
+          #  • ALL_LIST  — whole tree: secrets + credential-filenames. Catching an
+          #    already-committed secret/key is the point; these are the
+          #    non-overridable security boundary.
+          #  • CHANGED_LIST — PR/push diff: size + forbidden-patterns + hygiene. So
+          #    installing onto an existing repo never retroactively fails legacy
+          #    code; only new/changed code is gated.
+          # -z (NUL-delimited) so a filename with a newline/tab/quote can't split
+          # the list. The check scripts read each file's committed blob
+          # (git show ":0:<path>") — exactly what the pre-commit hook sees.
+          ALL_LIST=$(mktemp)
+          git -c core.quotepath=off ls-files -z >"$ALL_LIST"
+          CHANGED_LIST=$(mktemp)
+          # Shared helper: PR/push diff, failing open to the whole tree when there
+          # is no diff base (so a brand-new repo still gets fully scanned).
+          .githooks/lib/ci-changed-files >"$CHANGED_LIST"
           FAILED=0
-          .githooks/lib/check-size      --ci <"$STAGED_LIST" || FAILED=1
-          .githooks/lib/check-patterns  --ci <"$STAGED_LIST" || FAILED=1
-          .githooks/lib/check-filenames --ci <"$STAGED_LIST" || FAILED=1
-          .githooks/lib/check-secrets   --ci <"$STAGED_LIST" || FAILED=1
-          .githooks/lib/check-hygiene   --ci <"$STAGED_LIST" || FAILED=1
-          rm -f "$STAGED_LIST"
+          # Whole-tree security boundary (not overridable by .scaffold.toml):
+          .githooks/lib/check-secrets   --ci <"$ALL_LIST"     || FAILED=1
+          .githooks/lib/check-filenames --ci <"$ALL_LIST"     || FAILED=1
+          # Changed-files-only quality gates:
+          .githooks/lib/check-size      --ci <"$CHANGED_LIST" || FAILED=1
+          .githooks/lib/check-patterns  --ci <"$CHANGED_LIST" || FAILED=1
+          .githooks/lib/check-hygiene   --ci <"$CHANGED_LIST" || FAILED=1
+          rm -f "$ALL_LIST" "$CHANGED_LIST"
           exit $FAILED

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -19,4 +19,4 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           persist-credentials: false
-      - run: shellcheck -S info install.sh uninstall.sh tests/run.sh tests/lib/common.sh tests/cases/*.sh githooks/pre-commit.template githooks/lib/check-size.template githooks/lib/check-patterns.template githooks/lib/check-filenames.template githooks/lib/check-secrets.template githooks/lib/check-hygiene.template githooks/lib/agent-precheck.template githooks/commit-msg.template
+      - run: shellcheck -S info install.sh uninstall.sh tests/run.sh tests/lib/common.sh tests/cases/*.sh githooks/pre-commit.template githooks/lib/check-size.template githooks/lib/check-patterns.template githooks/lib/check-filenames.template githooks/lib/check-secrets.template githooks/lib/check-hygiene.template githooks/lib/ci-changed-files.template githooks/lib/agent-precheck.template githooks/commit-msg.template

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ versioning follows [SemVer](https://semver.org/).
 - **`tests/cases/10-ci-diff-scope.sh`** — regression test (9 assertions) for the
   diff-scoping: legacy grandfathered, new code gated, secrets/filenames caught
   whole-tree, and the no-diff-base fallback.
+- **`operational-rules.md` rule: "Capture pre-existing issues; never silently
+  drop them."** The complement to scope discipline — an out-of-scope bug, drift,
+  or lint finding noticed mid-task must land on a tracked fix-list, not be
+  dropped because "that's not what we're working on."
 
 ### Fixed
 - **`frontend` lint job emits an actionable error when the eslint config is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,40 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- **`lint.yml` CI scopes its quality gates to the PR/push diff.** The
+  `python` (ruff), `frontend` (eslint/prettier), and the size /
+  forbidden-pattern / hygiene `guardrails` checks now run only against files
+  changed in the PR or push, instead of the whole tree. This means installing
+  the scaffold onto an existing project no longer retroactively fails its
+  pre-existing code — only new/changed code is gated, matching the pre-commit
+  hook's staged-files scope. The **secret + credential-filename** scans
+  deliberately stay **whole-tree** (catching an already-committed secret/key is
+  the point, and they're the non-overridable security boundary). Falls open to
+  a whole-tree scan when there's no diff base (e.g. first push to a new repo).
+- **Workflow shell is bash-3.2-safe.** Replaced `mapfile` (bash 4+) in the
+  diff-scoped jobs with the portable NUL read-loop the `check-*` scripts use, so
+  the workflow runs on older/self-hosted runners too.
+
+### Added
+- **`githooks/lib/ci-changed-files`** — shared helper that resolves the
+  PR/push diff as a NUL-delimited list (failing open to the whole tree). One
+  testable implementation called by every diff-scoped `lint.yml` job, instead of
+  copy-pasted bash inside the workflow YAML. Installed by `install.sh`.
+- **`tests/cases/10-ci-diff-scope.sh`** — regression test (9 assertions) for the
+  diff-scoping: legacy grandfathered, new code gated, secrets/filenames caught
+  whole-tree, and the no-diff-base fallback.
+
+### Fixed
+- **`frontend` lint job emits an actionable error when the eslint config is
+  present but its peer deps aren't installed**, instead of a cryptic config-load
+  crash — it names the exact `npm i -D …` to run and to commit the lockfile.
+
+### Upgrade note
+- Existing installs must re-run `install.sh` (or copy
+  `githooks/lib/ci-changed-files` + the new `lint.yml`) — the updated `lint.yml`
+  calls the new helper.
+
 ## [v0.8.0] — 2026-06-27
 
 Audit-hardening release. Closes the self-application gap — the scaffold now

--- a/githooks/lib/ci-changed-files.template
+++ b/githooks/lib/ci-changed-files.template
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# .githooks/lib/ci-changed-files — print the set of files CI should scan as a
+# NUL-delimited list, scoped to the current PR/push DIFF. This is what lets
+# installing the scaffold onto an existing project NOT retroactively fail its
+# pre-existing code: the quality gates (size / forbidden-patterns / hygiene /
+# ruff / eslint) lint only new/changed files, while legacy is grandfathered
+# until it's next touched. (The secret + credential-filename scans deliberately
+# do NOT use this — they stay whole-tree; catching an already-committed secret
+# is the point. See lint.yml's guardrails job.)
+#
+# One implementation, called by every diff-scoped job in lint.yml, so the scope
+# logic lives in ONE testable place instead of being copy-pasted bash inside the
+# workflow YAML (where nothing could unit-test it). tests/cases/10 exercises it.
+#
+# Inputs (env, set from GitHub Actions ${{ }} expressions by the workflow):
+#   EVENT        github.event_name                  (pull_request | push | …)
+#   PR_BASE_SHA  github.event.pull_request.base.sha
+#   PR_HEAD_SHA  github.event.pull_request.head.sha
+#   PUSH_BEFORE  github.event.before
+#   PUSH_AFTER   github.event.after
+#
+# Output: NUL-delimited paths on stdout (consumed by the check-* scripts on
+# stdin, and split with a `while IFS= read -r -d ''` loop for ruff/eslint).
+#
+# FAILS OPEN to the whole tree (`git ls-files`) whenever there is no usable diff
+# base — an unrecognised event, a missing/zero base SHA (first push to a new
+# repo), or a diff that errors (e.g. unrelated histories without fetch-depth: 0).
+# Failing toward "scan everything" can only widen coverage, never hide a file.
+#
+# --diff-filter=d drops DELETED paths (no blob left to scan). core.quotepath=off
+# keeps unicode filenames raw rather than C-quoted. bash 3.2-safe (no mapfile,
+# no associative arrays) so it runs on any runner, matching the check-* scripts.
+
+set -euo pipefail
+
+EVENT=${EVENT:-}
+PR_BASE_SHA=${PR_BASE_SHA:-}
+PR_HEAD_SHA=${PR_HEAD_SHA:-}
+PUSH_BEFORE=${PUSH_BEFORE:-}
+PUSH_AFTER=${PUSH_AFTER:-}
+ZERO=0000000000000000000000000000000000000000
+
+# True when $1 names a commit object present in this checkout.
+have() { [ -n "$1" ] && git cat-file -e "$1^{commit}" 2>/dev/null; }
+
+# Emit the diff for the given revision args; on ANY failure fall back to the
+# whole tree. Buffer through a temp file so a mid-stream diff error can't emit a
+# partial list followed by the fallback (which would duplicate entries).
+changed_or_all() {
+  local tmp; tmp=$(mktemp)
+  if git -c core.quotepath=off diff -z --name-only --diff-filter=d "$@" >"$tmp" 2>/dev/null; then
+    cat "$tmp"; rm -f "$tmp"
+  else
+    rm -f "$tmp"; git -c core.quotepath=off ls-files -z
+  fi
+}
+
+if [ "$EVENT" = pull_request ] && have "$PR_BASE_SHA" && have "$PR_HEAD_SHA"; then
+  # Three-dot: changes on the PR branch since it diverged from base (ignores
+  # commits added to base after branch-off).
+  changed_or_all "$PR_BASE_SHA...$PR_HEAD_SHA"
+elif [ "$EVENT" = push ] && [ "$PUSH_BEFORE" != "$ZERO" ] && have "$PUSH_BEFORE" && have "$PUSH_AFTER"; then
+  changed_or_all "$PUSH_BEFORE" "$PUSH_AFTER"
+else
+  git -c core.quotepath=off ls-files -z
+fi

--- a/install.sh
+++ b/install.sh
@@ -151,7 +151,9 @@ chmod +x .githooks/pre-commit
 # scaffold-config + scaffold-audit are the per-project override layer
 # (.scaffold.toml): the check-* scripts source the former for per-rule
 # disable / severity / per-path size caps; the latter lists active overrides.
-for check in check-size check-patterns check-filenames check-secrets check-hygiene scaffold-config scaffold-audit; do
+# ci-changed-files scopes the CI quality gates to the PR/push diff (used by
+# lint.yml so a fresh install doesn't retroactively fail pre-existing code).
+for check in check-size check-patterns check-filenames check-secrets check-hygiene scaffold-config scaffold-audit ci-changed-files; do
   cp_safe "$SCAFFOLD_DIR/githooks/lib/${check}.template" ".githooks/lib/${check}"
   chmod +x ".githooks/lib/${check}"
 done
@@ -357,6 +359,10 @@ if [ "$VERIFY" -eq 1 ]; then
       offer "typescript (tsc)" "npx --no-install tsc --version" "$JSI" "typescript"
       offer "prettier" "npx --no-install prettier --version" "$JSI" "prettier"
       offer "vitest" "npx --no-install vitest --version" "$JSI" "vitest @vitest/coverage-v8"
+      # The 'frontend' CI job loads eslint.config.js (and its plugins) from the
+      # lockfile. If you skip the eslint prompt above, that job fails with an
+      # actionable error until you install the deps AND commit the lockfile.
+      echo "  → commit package-lock.json after installing eslint deps, or CI's frontend job will fail."
       ;;
   esac
 fi

--- a/operational-rules.md
+++ b/operational-rules.md
@@ -235,6 +235,19 @@ expansion as a separate question. Scope creep within a single
 change is one of the most common ways AI-assisted edits introduce
 unintended regressions.
 
+### Capture pre-existing issues; never silently drop them
+The complement to scope discipline: "out of scope" means don't
+silently EXPAND the change — it does NOT mean pretend you didn't
+see it. A pre-existing bug, drift, lint finding, or stale doc
+noticed while doing something else MUST land somewhere durable —
+a tracked fix-list, an issue, a flagged task — even when it won't
+be fixed now. Then let the human decide fix-now vs. later. Dropping
+it because "that's not what we're working on" is how known defects
+rot in place.
+*Anchor:* a session noticed a pre-existing lint finding, labeled it
+"out of scope," and moved on; with nothing tracking it, it was
+forgotten until it resurfaced later as a failure.
+
 ### Surface uncertainty rather than guessing
 When the agent doesn't have enough context to make a decision
 confidently, the right move is to ask, not to guess and proceed.

--- a/tests/cases/10-ci-diff-scope.sh
+++ b/tests/cases/10-ci-diff-scope.sh
@@ -1,0 +1,116 @@
+# shellcheck shell=bash
+# cases/10-ci-diff-scope.sh — verify lib/ci-changed-files scopes CI to the
+# PR/push diff, and that lint.yml's guardrails two-scope split behaves: a fresh
+# install onto a repo with LEGACY violations must NOT retroactively fail them
+# (size/patterns/hygiene are diff-scoped), while NEW violations and any
+# committed secret/.env ARE still caught (secrets/filenames stay whole-tree).
+# Sourced into the driver's shell, so it shares PASS/FAIL and runs under -euo
+# pipefail. This is the regression guard for the diff-scoping behavior — the
+# logic lives in a committed lib script precisely so it can be tested here
+# (rather than as untestable bash inside the workflow YAML).
+
+# shellcheck disable=SC2164
+cd "$WORK"
+C10=$(mktemp -d)
+
+# Build a synthetic project: scaffold install, a LEGACY baseline, then a feature
+# branch adding NEW violations (legacy left untouched). `yes | head` makes the
+# 600-line files without depending on python being present.
+(
+  cd "$C10"
+  git init -q
+  git config user.email test@test.local
+  git config user.name "Scaffold Test"
+  echo '{"name":"x"}' >package.json
+  echo 'name = "x"' >pyproject.toml
+  "$SCAFFOLD_DIR/install.sh" --both --no-verify >/dev/null
+  git add -A && git commit -q -m scaffold --no-verify          # scaffold-allow: test fixture
+  printf 'legacy_x = 1\n%.0s' {1..600} >legacy_big.py         # size > 500 (no pipe → pipefail-safe)
+  printf 'def legacy():\n    print("legacy debug")\n' >legacy_debug.py   # backend.txt: print(
+  # Split the literal in THIS source so self-lint's whole-tree secret scan
+  # doesn't flag this test file; the printf reassembles the full key at runtime
+  # into legacy_secret.py, which is what the scan under test must catch.
+  printf 'AWS = "%s"\n' "AKIA""IOSFODNN7EXAMPLE" >legacy_secret.py   # secrets.txt: AKIA…
+  printf 'FOO=bar\n' >.env                                     # check-filenames: .env
+  git add -A && git commit -q -m base --no-verify             # scaffold-allow: test fixture
+  git checkout -q -b feature
+  printf 'new_y = 1\n%.0s' {1..600} >new_big.py               # size > 500 (no pipe → pipefail-safe)
+  printf 'def fresh():\n    print("new debug")\n' >new_debug.py  # backend.txt: print(
+  printf '# docs only\n' >notes.md                            # .md → ignored
+  git add -A && git commit -q -m feat --no-verify            # scaffold-allow: test fixture
+) >"$HOOK_OUT" 2>&1
+
+HEAD=$(git -C "$C10" rev-parse feature 2>/dev/null || true)
+BASE=$(git -C "$C10" rev-parse feature^ 2>/dev/null || true)   # base = feature's parent
+ZERO=0000000000000000000000000000000000000000
+
+# Print the helper's NUL list as a newline list for an EVENT + (a,b) rev pair.
+# Both PR_* and PUSH_* are set to (a,b); the helper reads only the pair its
+# EVENT selects, so this one shape drives every scenario.
+changed_list() {
+  ( cd "$C10" \
+    && EVENT=$1 PR_BASE_SHA=${2:-} PR_HEAD_SHA=${3:-} PUSH_BEFORE=${2:-} PUSH_AFTER=${3:-} \
+       bash .githooks/lib/ci-changed-files ) 2>/dev/null | tr '\0' '\n' || true
+}
+in_list()  { grep -qxF "$2" <<<"$1"; }   # whole-line literal match (here-string → no SIGPIPE)
+
+echo "cases/10 — CI diff-scoping (lib/ci-changed-files)"
+
+if [ -z "$BASE" ] || [ -z "$HEAD" ]; then
+  echo "  ✗ setup failed (no feature history)"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+else
+  # (1) pull_request → only the new files, legacy excluded
+  PR=$(changed_list pull_request "$BASE" "$HEAD")
+  if in_list "$PR" new_big.py && in_list "$PR" new_debug.py; then
+    echo "  ✓ ci-changed-files(PR) lists new files"; PASS=$((PASS + 1))
+  else echo "  ✗ ci-changed-files(PR) missing new files"; printf '%s\n' "$PR" | sed 's/^/      /'; FAIL=$((FAIL + 1)); fi
+  if in_list "$PR" legacy_big.py || in_list "$PR" legacy_debug.py; then
+    echo "  ✗ ci-changed-files(PR) leaked legacy into diff"; FAIL=$((FAIL + 1))
+  else echo "  ✓ ci-changed-files(PR) excludes legacy"; PASS=$((PASS + 1)); fi
+
+  # (2) push (before=base, after=head) → same as PR
+  PUSH=$(changed_list push "$BASE" "$HEAD")
+  if in_list "$PUSH" new_big.py && ! in_list "$PUSH" legacy_big.py; then
+    echo "  ✓ ci-changed-files(push) scopes to the pushed range"; PASS=$((PASS + 1))
+  else echo "  ✗ ci-changed-files(push) wrong scope"; printf '%s\n' "$PUSH" | sed 's/^/      /'; FAIL=$((FAIL + 1)); fi
+
+  # (3) fallback: zero before-SHA (brand-new repo) → whole tree
+  FB=$(changed_list push "$ZERO" "$HEAD")
+  if in_list "$FB" legacy_big.py && in_list "$FB" new_big.py; then
+    echo "  ✓ ci-changed-files(fallback) scans whole tree"; PASS=$((PASS + 1))
+  else echo "  ✗ ci-changed-files(fallback) did not fall open"; printf '%s\n' "$FB" | sed 's/^/      /'; FAIL=$((FAIL + 1)); fi
+
+  # (4) unrecognized event → fail open to whole tree
+  WD=$(changed_list workflow_dispatch "$BASE" "$HEAD")
+  if in_list "$WD" legacy_big.py; then
+    echo "  ✓ ci-changed-files(unknown event) fails open to whole tree"; PASS=$((PASS + 1))
+  else echo "  ✗ ci-changed-files(unknown event) did not fail open"; printf '%s\n' "$WD" | sed 's/^/      /'; FAIL=$((FAIL + 1)); fi
+
+  # (5) INTEGRATION — mirror the guardrails job's two scopes and assert the split.
+  (
+    cd "$C10"
+    export EVENT=pull_request PR_BASE_SHA=$BASE PR_HEAD_SHA=$HEAD PUSH_BEFORE='' PUSH_AFTER=''
+    ALL=$(mktemp); git -c core.quotepath=off ls-files -z >"$ALL"
+    CH=$(mktemp);  bash .githooks/lib/ci-changed-files >"$CH"
+    .githooks/lib/check-size      --ci <"$CH"  || true
+    .githooks/lib/check-patterns  --ci <"$CH"  || true
+    .githooks/lib/check-secrets   --ci <"$ALL" || true
+    .githooks/lib/check-filenames --ci <"$ALL" || true
+  ) >"$WORK/c10.int" 2>&1 || true
+
+  if grep -qF new_big.py "$WORK/c10.int" && grep -qF new_debug.py "$WORK/c10.int"; then
+    echo "  ✓ guardrails flags NEW size + pattern violations"; PASS=$((PASS + 1))
+  else echo "  ✗ guardrails missed new violations"; sed 's/^/      /' "$WORK/c10.int"; FAIL=$((FAIL + 1)); fi
+  if grep -qF legacy_big.py "$WORK/c10.int" || grep -qF legacy_debug.py "$WORK/c10.int"; then
+    echo "  ✗ guardrails failed legacy code (not grandfathered)"; sed 's/^/      /' "$WORK/c10.int"; FAIL=$((FAIL + 1))
+  else echo "  ✓ guardrails grandfathers LEGACY size + pattern violations"; PASS=$((PASS + 1)); fi
+  if grep -qF legacy_secret.py "$WORK/c10.int"; then
+    echo "  ✓ guardrails catches committed SECRET whole-tree (unchanged legacy)"; PASS=$((PASS + 1))
+  else echo "  ✗ guardrails missed the committed secret"; sed 's/^/      /' "$WORK/c10.int"; FAIL=$((FAIL + 1)); fi
+  if grep -qF .env "$WORK/c10.int"; then
+    echo "  ✓ guardrails catches committed .env whole-tree (filenames)"; PASS=$((PASS + 1))
+  else echo "  ✗ guardrails missed the .env"; sed 's/^/      /' "$WORK/c10.int"; FAIL=$((FAIL + 1)); fi
+fi
+
+rm -rf "$C10"; rm -f "$WORK/c10.int"
+cd "$WORK"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -44,7 +44,8 @@ for case_file in \
   "$HERE/cases/06-hygiene-multilang.sh" \
   "$HERE/cases/07-agent-commit.sh" \
   "$HERE/cases/08-overrides-gitleaks.sh" \
-  "$HERE/cases/09-toolchain-clobber.sh"; do
+  "$HERE/cases/09-toolchain-clobber.sh" \
+  "$HERE/cases/10-ci-diff-scope.sh"; do
   # shellcheck source=/dev/null
   . "$case_file"
 done


### PR DESCRIPTION
## Problem
Installing the scaffold onto an existing project turned its CI red on the first run: `lint.yml`'s `python`/`frontend`/`guardrails` jobs scanned the **whole tree**, so every pre-existing legacy violation failed immediately. (The local pre-commit hook never had this problem — it only scans *staged* files.)

## Fix
Scope the **quality gates** to the PR/push diff so only new/changed code is gated; legacy is grandfathered until next touched.

- `python` (ruff), `frontend` (eslint/prettier), and the size/forbidden-pattern/hygiene `guardrails` now run on the **diff** only.
- **secrets + credential-filenames stay whole-tree** — catching an already-committed secret/key is the point, and they're the non-overridable security boundary.
- New shared helper **`githooks/lib/ci-changed-files`** resolves the diff (NUL list), **failing open to the whole tree** when there's no diff base (first push to a new repo). One testable implementation instead of copy-pasted bash in the YAML.
- Dropped bash-4-only `mapfile` for the portable NUL read-loop the `check-*` scripts use.
- `frontend` now emits an **actionable error** when `eslint.config.js` is present but its deps aren't installed (was a cryptic config-load crash).

Also adds the operational rule *"Capture pre-existing issues; never silently drop them"* (separate commit).

## Verification
- `tests/run.sh`: **141 passed, 0 failed** (new `tests/cases/10` adds 9 assertions executing the diff-scoping against a synthetic legacy+new repo).
- `shellcheck -S info`, `actionlint`, `zizmor`, pin-drift guard: all clean.
- self-lint repro on the whole tree: clean (the planted test key is split in source so the whole-tree scan doesn't flag the test file).

## Upgrade note
Existing installs must re-run `install.sh` (or copy `githooks/lib/ci-changed-files` + the new `lint.yml`) — the updated workflow calls the new helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)