### PR TITLE
fix(security): close critical long-line fail-open + 3 high scanner bypasses (2026-06-30 re-audit)

### DIFF
--- a/SECURITY_AUDIT.md
+++ b/SECURITY_AUDIT.md
@@ -1,5 +1,82 @@
 # Security & Code Audit — ai-coding-rules-scaffold
 
+## Audit 2026-06-30 — full-tree re-audit (latest)
+
+**Date:** 2026-06-30  ·  **Base:** HEAD of `main` (post-v0.8.0, commit `4ad17a9`)  ·  **Method:** 11-dimension multi-agent fan-out (68 agents) → per-finding adversarial verification (each finding reproduced in a throwaway git repo) → maintainer re-reproduction of the critical/high tier.
+
+**Result:** 57 confirmed · 49 confirmed-as-stated · 8 partial · 0 refuted.
+
+| Severity | Confirmed | Fixed on `fix/audit-2026-06-30` |
+|---|---|---|
+| critical | 1 | 1 |
+| high | 9 | 3 |
+| medium | 10 | 0 |
+| low | 37 | 0 |
+
+> ⚠️ **The historical sections below (2026-06-09/10, base `89ac255`, pre-PR #6) are STALE.** Several findings they mark `⬜ Open` have since been FIXED in shipped code, and one fix introduced a new critical bug. Trust *this* section over the per-finding `✅/⬜` markers further down:
+> - *"sk- regex misses modern OpenAI/Anthropic keys"* → **FIXED**: `secrets.txt` now ships `sk-ant-`, `sk-proj-`, `sk-svcacct-`/`sk-admin-`.
+> - *"Deleting the forbidden-patterns config disables the scan"* → **FIXED**: `pre-commit` now has the `DELETED_CONFIG` guard.
+> - *"Combined-ERE ReDoS hang"* → **FIXED** with a `MAX_LINE_LENGTH` line cap — but that cap **fails OPEN** (new finding **A1** below).
+> - *"scaffold-allow substring anywhere"* → **PARTIALLY fixed** (a comment leader is now required) but still bypassable (new finding **A3** below).
+
+### 🔴 Critical
+
+**A1 — Secret on a line longer than `MAX_LINE_LENGTH` is silently dropped (scanner fails OPEN)** — `githooks/lib/check-secrets.template:154-157` (same hole: `check-patterns.template:171-174`, `check-hygiene.template:106,163`, `agent-precheck.template:57-59`)
+- **What:** the ReDoS guard drops any line longer than `MAX_LINE_LENGTH` (default 50000) via `awk 'length > n { next }'`, emits only a stderr warning, and never sets `FAILED` — exit stays `0`, in the local hook **and** `--ci` mode. A credential on a single >50k-char line (minified/no-newline blob) is never scanned.
+- **Repro:** a 60000-char line + `AKIA…` → `--ci` prints "line(s) … dropped" and exits 0; the same key on a normal line exits 1. Verified end-to-end and via the awk pre-pass in isolation.
+- **Fix:** the secret scanner must **fail closed** on a dropped line (report + `exit 1`), or scan the long line with a linear matcher (fixed-string prescreen / fixed-width windows). `agent-precheck` should fail closed on the Bash path.
+
+### 🟠 High
+
+- **A2 — `agent-precheck` block path fails OPEN via SIGPIPE** — `githooks/lib/agent-precheck.template:99-106`. `{ …; printf '%s\n' "$hit" | head -3; } >&2` then `exit 2`, under `set -euo pipefail`: with ≥4 matched lines, `head` closes the pipe, `printf`→SIGPIPE→141, `pipefail`+`set -e` abort **before `exit 2`**. Claude/Cursor treat only exit 2 as "block", so the matched Write/Bash is **allowed**. *Fix:* `printf … | head -3 || true`.
+- **A3 — `scaffold-allow` can smuggle a real secret; documented "can't be smuggled" guarantee is false** — `check-secrets.template:167`, `check-patterns.template:188`, `check-hygiene.template:109,169`, `agent-precheck.template:96`. The exemption accepts a bare `--` anywhere on the line; secret charsets contain `-`, so `const k = "AKIA… -- scaffold-allow";` (marker inside the string, `--` not a comment in JS) suppresses the finding and exits 0. *Fix:* drop bare `--`, require the leader at start-of-line/after-whitespace, and correct the docs (inline suppression is inherently author-usable, like `# noqa`).
+- **A4 — `check-filenames` matches credential filenames case-sensitively** — `check-filenames.template:39,48-57`. `*.pem`, `.env`, `id_rsa` are byte-compared, so `key.PEM`/`.ENV`/`ID_RSA` bypass on the case-insensitive filesystems (macOS/Windows) the project targets. Dual-layer bypass: `.ENV` with `INTERNAL_TOKEN=plainword` passes both scanners. *Fix:* lowercase via `tr` before matching (bash-3.2-safe).
+- **A5 — Generic credential regex requires QUOTED values** — `secrets.txt.template:53`. `['"]…{16,}['"]` misses unquoted `.env`/YAML/shell/Dockerfile assignments (the dominant leak surface), JS backticks, and `=>` values. *Fix:* optional quotes + value terminator.
+- **A6 — Underscore-prefixed credential names evade the same rule** — `secrets.txt.template:53`. `(^|[^A-Za-z_])` treats `_` as a word char, so `db_password`, `MY_API_KEY`, `DATABASE_PASSWORD` aren't matched even when quoted. *Fix:* change the boundary to `(^|[^A-Za-z])`.
+- **A7 — `cp_safe` follows symlink destinations (arbitrary-path write; installed scanner left as a symlink)** — `install.sh:78-105`. `[ -e "$dst" ]` dereferences symlinks: a dangling symlink at a scaffold path makes `cp` write outside the repo and leaves the installed scanner as a symlink; a symlink→outside-file with `--force` overwrites that file. Gated on a planted symlink. *Fix:* `[ -e "$dst" ] || [ -L "$dst" ]`, `rm -f` before copy, `cp -P` for backups, guard the `cmp -s` no-op.
+- **A8 — Several common cloud/SaaS credential formats have no prefix rule** — `secrets.txt.template:12-35`. SendGrid, Twilio (AC-SID + auth token), Mailgun, Square, Shopify, Azure Storage/AD, Mailchimp, Telegram bot tokens fall through to the (weakened) generic rule → unscanned. *Fix:* add prefix-anchored lines.
+- **A9 — `scaffold-allow` exemption also smuggles past `check-hygiene`** — `check-hygiene.template:109,169` (hidden-Unicode / conflict markers). Same root cause as A3; *fix:* anchor the marker to a real trailing comment token.
+- **A10 — Test gap: `check-filenames` `*.pem` and SSH-key branches have zero tests** — `tests/cases/`. A typo in either `case` glob would let a private key through with the suite green. Highest-severity test gap per the threat model. *Fix:* add `key.pem`/`id_rsa` regression cases (with the expected-substring guard).
+
+### 🟡 Medium
+
+| Title | Location |
+|---|---|
+| Mid-script `cp`/`mkdir` failure aborts under `set -e` with no rollback/summary | `install.sh:103-104,145-274` |
+| Plain re-run keeps stale scaffold-owned scanners — security fixes never reach upgraders | `install.sh:156-159` |
+| Uninstall never removes `.githooks/lib/ci-changed-files` (install adds 8 libs, uninstall removes 7) | `uninstall.sh:133` |
+| Generic credential keyword list omits `secret`, `client_secret`, `private_key`, `credential`, `pwd`, `auth` | `secrets.txt.template:53` |
+| URL-embedded-credentials rule misses empty-username userinfo (`redis://:password@host`) | `secrets.txt.template:48` |
+| `agent-precheck` long-line filter empties content → exit 0, skipping a one-line Bash command scan | `agent-precheck.template:57-59` |
+| Template-only action pins get neither Dependabot updates nor drift-guard coverage; rot silently | `gitleaks.yml.template:38` (+ `dependency-review`/`coverage`/opt-in `lint` jobs) |
+| `dependency-review` defaults to `fail-on-severity: moderate`, allowing low-severity advisories | `dependency-review.yml.template:49` |
+| `scaffold-allow` over-broad in hygiene (substring after any leader, in files with no comments) | `check-hygiene.template:109,169` |
+| pre-commit stash push-failure and pop-conflict recovery paths are untested | `pre-commit.template:62-69,74-88` |
+
+### ⚪ Low (themes; 37 findings)
+
+- **Regex precision:** `check-secrets` `-i` false-positives on uppercase-only prefix tokens; leading whitespace before a pattern silently neuters it (`:102`); `backend.txt` `print()`/`os.path.join` unanchored (match `obj.print()`, comments); conflict-marker regex requires exactly 7 marker chars (8-run unmatched); hidden-Unicode scan skips any blob with a NUL in the first 8 KB (early NUL hides later Trojan-Source bytes); conflict/hidden-Unicode lines over `MAX_LINE_LENGTH` are dropped.
+- **`.scaffold.toml` parser:** a backslash in a rule-id defeats the override (awk `-v` C-escape); `scaffold-audit` can over-report inert entries as active.
+- **CI:** `check-hygiene` case-collision is diff-scoped in CI but the header claims whole-tree (`lint.yml.template:365`); `test.yml:66-68` pin-drift regex misses quoted `uses:`.
+- **`DELETED_CONFIG` gap** (`pre-commit.template:38`, partial): blocks deleting `.forbidden-patterns/*.txt` but not the `check-*` scripts, `scaffold-config`, or the hook itself.
+- **Uninstall** (partial): `--all` `rm -rf .forbidden-patterns` destroys user-authored pattern files (`uninstall.sh:159`); `awk`/`mv` failure in `clean_claude_md` aborts the rest of cleanup; `core.hooksPath --unset` can fail on a multivar value.
+- **Test gaps:** the `MAX_LINE_LENGTH` drop, invalid-pattern-dropped, combined-regex-invalid (`USE_PREFILTER=0`), CI fail-closed-on-missing-config, `ci-changed-files` fail-open branches, the `.env.example` allowlist, and 13 `assert_rejects` in `cases/01` that omit the expected-substring guard.
+- **Docs:** `README.md:281` advertises `password=`/`token=` detection that only fires on quoted values (A5); `SECURITY_AUDIT.md` (historical) stale "Open" statuses; `README.md:157-181` "what lands" table omits `.github/dependabot.yml`; `README.md:357-364` `--cursor` bullet omits the jq fail-open caveat; `forbidden-patterns/README.md:9` omits `.svelte`.
+
+### Fixed on this branch (`fix/audit-2026-06-30`)
+
+_Updated as fixes land (each with a red-then-green regression test):_
+
+- _(pending)_
+
+### What's solid (verified, so fixes don't regress it)
+
+Blob-scanning via `git show ":0:<path>"` (defeats symlink/NUL/post-stage edits); consistent `grep -a` text mode; up-front + combined-regex validation with fail-closed-to-per-pattern; GitHub-annotation escaping; the **non-overridable security boundary** (`check-secrets`/`check-filenames` genuinely never consult `.scaffold.toml` — verified by trace); `ci-changed-files` fail-open-to-whole-tree never emits a partial list; `lint.yml` hardening (SHA-pinned, `permissions: contents: read`, `persist-credentials: false`, env-routed expressions, `npm ci --ignore-scripts`); fail-closed test harness (`exit "$FAIL"`).
+
+---
+
+## Historical audit — 2026-06-09/10
+
 **Date:** 2026-06-09  ·  **Base commit audited:** `89ac255` (pre–PR #6)  ·  **Method:** multi-agent fan-out audit (86 agents, 6 dimensions) → adversarial empirical verification (PoCs reproduced in throwaway git repos) → completeness critic.
 
 **Result:** 73 candidates · **67 confirmed** (65 reproduced end-to-end) · 6 rejected by verification.

--- a/SECURITY_AUDIT.md
+++ b/SECURITY_AUDIT.md
@@ -65,9 +65,14 @@
 
 ### Fixed on this branch (`fix/audit-2026-06-30`)
 
-_Updated as fixes land (each with a red-then-green regression test):_
+Each landed with a red-then-green regression test; full suite 148/148 green.
 
-- _(pending)_
+- **A1 (critical)** — `check-secrets` now FAILS CLOSED on a line over `MAX_LINE_LENGTH` (reports it + fails) instead of dropping it with a warning and exit 0. The line is still dropped before the ERE, so the ReDoS guard is unchanged. (`2f79605`; tests cases/04 #31, #31b)
+- **A2 (high)** — `agent-precheck` block path no longer takes SIGPIPE (`printf … | head -3 || true`), so it reliably reaches `exit 2` and actually blocks. (`98c6d41`; cases/07 #48g asserts the exit code is exactly 2)
+- **A3 (high)** — `scaffold-allow` dropped bare `--` as a leader and now requires a start-of-line/whitespace boundary, across all five exemption sites (check-secrets, check-patterns, check-hygiene ×2, agent-precheck); over-claiming docs corrected. (`2a92e6e`; cases/04 #28b)
+- **A4 (high)** — `check-filenames` folds name+path to lowercase before matching, so `.PEM`/`.ENV`/`ID_RSA` are blocked; the `.env.example` allowlist still holds. (`16ab43b`; cases/04 #36, #36b)
+
+**Still open** (recommended next, in priority order): the secret-regex coverage cluster (A5/A6/A8 + the medium keyword/URL gaps — needs positive **and** negative corpus validation to manage false positives); `cp_safe` symlink handling (A7); the installer/uninstaller robustness cluster; the remaining test-coverage gaps (A10 et al.); and the doc reconciliations.
 
 ### What's solid (verified, so fixes don't regress it)
 

--- a/forbidden-patterns/README.md
+++ b/forbidden-patterns/README.md
@@ -72,14 +72,19 @@ sees this on every blocked commit.
 ## Per-line opt-out: `scaffold-allow`
 
 A line is exempt from `check-patterns` and `check-secrets` when it carries a
-`scaffold-allow` marker **after a comment leader** — `#`, `//`, `/*`, `<!--`,
-or `--` (case-insensitive). The comment-leader requirement is deliberate: it
-stops the bare substring from being smuggled inside a string literal to
-whitelist a real secret (e.g. `token = "scaffold-allow..."` is **not**
-exempt). Use it as an inline escape valve when a match is intentional — a CLI
+`scaffold-allow` marker **after a comment leader** — `#`, `//`, `/*`, or
+`<!--` (case-insensitive) — at the start of the line or following whitespace.
+The comment-leader requirement raises the bar against smuggling the bare
+substring inside a string literal (e.g. `token = "scaffold-allow..."` is
+**not** exempt). Bare `--` is intentionally **not** a leader: it is a comment
+in too few languages to justify the cross-language bypass it opened
+(`x = "<secret> -- scaffold-allow"` once suppressed the finding in JS/Python/
+shell). Use it as an inline escape valve when a match is intentional — a CLI
 entry point that needs `print`, a docs example showing an AWS key prefix, a
 test fixture with a synthetic credential. Mirrors the role `# noqa` plays for
-ruff.
+ruff. It is **not** a security boundary against a hostile committer (who
+controls the file and can also pass `--no-verify`); pair the scaffold with
+branch protection and required review.
 
 ```python
 print("entering CLI")  # scaffold-allow — no logger configured yet

--- a/githooks/lib/agent-precheck.template
+++ b/githooks/lib/agent-precheck.template
@@ -93,7 +93,7 @@ scan_against() {
 
   # A comment-anchored `scaffold-allow` exempts a line, exactly like the scanners.
   hit=$(printf '%s\n' "$content" | grep -an"${iflag}"E -- "$combined" \
-          | grep -ivE '(#|//|/\*|<!--|--)[[:space:]]*scaffold-allow' || true)
+          | grep -ivE '(^|[[:space:]])(#|//|/\*|<!--)[[:space:]]*scaffold-allow' || true)
   [ -n "$hit" ] || return 0
 
   {

--- a/githooks/lib/agent-precheck.template
+++ b/githooks/lib/agent-precheck.template
@@ -101,7 +101,11 @@ scan_against() {
     echo "(${pfile#"$ROOT"/}). If this is deliberate and safe, append a comment"
     echo "containing 'scaffold-allow' on the matching line."
     echo "Matched:"
-    printf '%s\n' "$hit" | head -3
+    # `|| true`: on a many-line $hit, `head -3` closes the pipe early and printf
+    # takes SIGPIPE (exit 141). Under `set -euo pipefail` that would abort the
+    # script BEFORE the `exit 2` below — and the agent runtimes treat only exit 2
+    # as "block", so a non-2 exit silently ALLOWS the matched action (fail-open).
+    printf '%s\n' "$hit" | head -3 || true
   } >&2
   exit 2
 }

--- a/githooks/lib/check-filenames.template
+++ b/githooks/lib/check-filenames.template
@@ -35,7 +35,12 @@ emit() {
 FAILED=0
 while IFS= read -r -d '' file; do
   [ -z "$file" ] && continue
-  case "$file" in
+  # Match case-INSENSITIVELY. macOS/Windows filesystems are case-insensitive, so
+  # `cert.PEM` / `.ENV` / `ID_RSA` are the SAME files as their lowercase forms and
+  # must not slip past a byte-exact glob. bash 3.2 has no ${var,,}, so fold with
+  # tr; the original $file/$name is kept for the human-readable message.
+  lfile=$(printf '%s' "$file" | tr '[:upper:]' '[:lower:]')
+  case "$lfile" in
     *.pem)
       emit "$file" "PEM file (likely private key) — rotate and use a secret manager"
       FAILED=1
@@ -45,7 +50,8 @@ while IFS= read -r -d '' file; do
   # `basename -- "$file"` so a path/name beginning with `-` is treated as data,
   # not an option.
   name=$(basename -- "$file")
-  case "$name" in
+  lname=$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]')
+  case "$lname" in
     .env.example|.env.sample|.env.template) ;;
     .env|.env.*)
       emit "$file" "environment file — use .env.example for shared config, keep secrets in env vars"

--- a/githooks/lib/check-hygiene.template
+++ b/githooks/lib/check-hygiene.template
@@ -106,7 +106,7 @@ if [ "$CONFLICT_STATE" != disabled ]; then
     content=$(git show ":0:$file" 2>/dev/null | awk -v n="$MAX_LINE_LENGTH" 'length > n { next } { print }') || cap_rc=$?
     [ "$cap_rc" -eq 0 ] || true
     [ -n "$content" ] || continue
-    m=$(grep -anE -- "$CONFLICT_RE" <<<"$content" | grep -ivE '(#|//|/\*|<!--|--)[[:space:]]*scaffold-allow' || true)
+    m=$(grep -anE -- "$CONFLICT_RE" <<<"$content" | grep -ivE '(^|[[:space:]])(#|//|/\*|<!--)[[:space:]]*scaffold-allow' || true)
     if [ -n "$m" ]; then
       emit "$CONFLICT_STATE" "$file" "merge-conflict marker — resolve the conflict before committing"
       printf '%s\n' "$m" | head -3 | sed 's/^/    /' >&2 || true
@@ -166,7 +166,7 @@ if [ "$HIDDEN_STATE" != disabled ]; then
     # mid-file occurrence trips the EF-BB-BF branch.
     content=${content#$'\xef\xbb\xbf'}
     m=$(LC_ALL=C grep -anE -- "$HIDDEN_RE" <<<"$content" \
-          | grep -ivE '(#|//|/\*|<!--|--)[[:space:]]*scaffold-allow' || true)
+          | grep -ivE '(^|[[:space:]])(#|//|/\*|<!--)[[:space:]]*scaffold-allow' || true)
     if [ -n "$m" ]; then
       emit "$HIDDEN_STATE" "$file" "hidden Unicode control char (bidi / zero-width / tag) — strip it; this is the 'Rules File Backdoor' / Trojan Source surface"
       # Never echo the raw invisible bytes back to a terminal/CI log — sanitize

--- a/githooks/lib/check-patterns.template
+++ b/githooks/lib/check-patterns.template
@@ -18,7 +18,9 @@
 # passes -a/--text for the same reason.
 #
 # A `scaffold-allow` marker exempts a line, but ONLY after a comment leader
-# (`#`, `//`, `/*`, `<!--`, `--`) — like `# noqa`. Use sparingly.
+# (`#`, `//`, `/*`, `<!--`) at start-of-line or after whitespace — like `# noqa`.
+# Bare `--` was dropped as a leader (cross-language bypass); see check-secrets
+# for why inline suppression isn't a hostile-committer boundary. Use sparingly.
 #
 # Output: human-readable on tty; ::error file=...:: when --ci is passed.
 # Exit:   0 if all OK, 1 if any violation.
@@ -185,7 +187,7 @@ scan() {
       pat="${patterns[$i]}"
       desc="${descriptions[$i]}"
       # Exempt only a comment-anchored marker (see check-secrets).
-      m=$(grep -anE -- "$pat" <<<"$content" | grep -ivE '(#|//|/\*|<!--|--)[[:space:]]*scaffold-allow' || true)
+      m=$(grep -anE -- "$pat" <<<"$content" | grep -ivE '(^|[[:space:]])(#|//|/\*|<!--)[[:space:]]*scaffold-allow' || true)
       [ -n "$m" ] || continue
       # Per-rule override: `disabled` skips the rule, `warn` reports without
       # failing, anything else (incl. missing config) enforces as `error`.

--- a/githooks/lib/check-secrets.template
+++ b/githooks/lib/check-secrets.template
@@ -17,9 +17,14 @@
 # Pattern format: <regex><TAB><description>
 # (TAB is the field separator so regex can use literal `|` alternation.)
 #
-# A `scaffold-allow` marker exempts a line, but ONLY when it appears after a
-# comment leader (`#`, `//`, `/*`, `<!--`, `--`) — so the substring can't be
-# smuggled inside a string literal to whitelist a real secret.
+# A `scaffold-allow` marker exempts a line, but ONLY when it follows a comment
+# leader (`#`, `//`, `/*`, `<!--`) at start-of-line or after whitespace — like
+# `# noqa`. Bare `--` was dropped as a leader: it is a comment in too few
+# languages to justify the cross-language bypass it opened (`"x -- scaffold-allow"`
+# once suppressed a real secret in JS/Python/shell). Inline suppression is still
+# inherently usable by anyone who controls the file — it is NOT a defense against
+# a hostile committer (who can also use `--no-verify`); the real backstop is
+# branch protection + review + a base-ref scan (see lint.yml.template).
 #
 # Output: human-readable on tty; ::error file=...:: when --ci is passed.
 # Exit:   0 if all OK, 1 if any violation.
@@ -175,7 +180,7 @@ for file in "${FILES[@]}"; do
     desc="${DESCRIPTIONS[$i]}"
     # Exempt only a comment-anchored marker, so `scaffold-allow` inside a string
     # literal cannot whitelist a real secret.
-    m=$(grep -aniE -- "$pat" <<<"$content" | grep -ivE '(#|//|/\*|<!--|--)[[:space:]]*scaffold-allow' || true)
+    m=$(grep -aniE -- "$pat" <<<"$content" | grep -ivE '(^|[[:space:]])(#|//|/\*|<!--)[[:space:]]*scaffold-allow' || true)
     [ -n "$m" ] || continue
     if [ "$CI_MODE" -eq 1 ]; then
       echo "::error file=$(ghesc prop "$file")::$(ghesc data "$desc")"

--- a/githooks/lib/check-secrets.template
+++ b/githooks/lib/check-secrets.template
@@ -153,7 +153,18 @@ for file in "${FILES[@]}"; do
   cap_rc=0
   content=$(git show ":0:$file" 2>/dev/null | awk -v n="$MAX_LINE_LENGTH" 'length > n { d=1; next } { print } END { exit (d ? 9 : 0) }') || cap_rc=$?
   if [ "$cap_rc" -eq 9 ]; then
-    echo "warning: $file: line(s) over $MAX_LINE_LENGTH chars dropped from the scan (minified/generated?)" >&2
+    # FAIL CLOSED. The line is dropped before the ERE (so it can't hang the scan
+    # — that is the ReDoS guard), but for the SECRET scanner an unscannable line
+    # must not pass silently: a secret on a >MAX_LINE_LENGTH line used to ride
+    # through with only a warning and exit 0 (a fail-OPEN hole). Report it and
+    # set FAILED, while still scanning the remaining in-cap lines below.
+    over="line(s) over $MAX_LINE_LENGTH chars cannot be scanned for secrets — split/relocate the minified asset, raise MAX_LINE_LENGTH (accepts the ReDoS cost), or point a dedicated scanner at it"
+    if [ "$CI_MODE" -eq 1 ]; then
+      echo "::error file=$(ghesc prop "$file")::$(ghesc data "$over")"
+    else
+      echo "✗ $file: $over"
+    fi
+    FAILED=1
   fi
   [ -n "$content" ] || continue
   if [ "$USE_PREFILTER" -eq 1 ]; then

--- a/tests/cases/04-shell-config-rename.sh
+++ b/tests/cases/04-shell-config-rename.sh
@@ -171,3 +171,27 @@ else
   sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
 fi
 reset_repo
+
+# 36. check-filenames is CASE-INSENSITIVE. macOS/Windows filesystems (which the
+#     project explicitly targets — see the case-collision hygiene check) treat
+#     `cert.PEM`, `.ENV`, `ID_RSA` as the same files as their lowercase forms, so
+#     an uppercase/mixed-case credential filename must still be blocked. Each
+#     fixture's CONTENT is benign, so only the filename rule can fire (isolating
+#     this from check-secrets).
+echo "placeholder" >cert.PEM
+git add -f cert.PEM
+assert_rejects "uppercase .PEM filename is blocked (case-insensitive)" "PEM file"
+
+printf 'FOO=bar\n' >.ENV
+git add -f .ENV
+assert_rejects "uppercase .ENV filename is blocked (case-insensitive)" "environment file"
+
+echo "placeholder" >ID_RSA
+git add -f ID_RSA
+assert_rejects "uppercase ID_RSA filename is blocked (case-insensitive)" "SSH private key"
+
+# 36b. NEGATIVE: the .env.example allowlist still holds regardless of case —
+#      a shared-config template must NOT be blocked.
+printf 'FOO=bar\n' >.ENV.EXAMPLE
+git add -f .ENV.EXAMPLE
+assert_passes ".ENV.EXAMPLE (allowlisted template) is not blocked"

--- a/tests/cases/04-shell-config-rename.sh
+++ b/tests/cases/04-shell-config-rename.sh
@@ -95,9 +95,12 @@ else
 fi
 reset_repo
 
-# 31. ReDoS guard: a line over MAX_LINE_LENGTH is dropped before the combined
-#     ERE (which can hang superlinearly on a long line), while a secret on a
-#     normal line is still caught. Long line is benign filler; AKIA split.
+# 31. ReDoS guard now FAILS CLOSED. A line over MAX_LINE_LENGTH is still dropped
+#     before the combined ERE (so it can't hang superlinearly), but check-secrets
+#     no longer lets that file pass silently — an unscannable line is reported
+#     and the commit is rejected. The old behavior (warn + exit 0) was a
+#     fail-OPEN hole: a secret on a >50k line rode straight through. A secret on
+#     a normal line is still caught too.
 {
   echo "AKIA""IOSFODNN7EXAMPLE"
   head -c 60000 /dev/zero | tr '\0' a
@@ -105,16 +108,24 @@ reset_repo
 } >redos.txt
 git add redos.txt
 if .githooks/pre-commit >"$HOOK_OUT" 2>&1; then
-  echo "  ✗ ReDoS guard — accepted, expected reject (secret on the normal line)"
+  echo "  ✗ ReDoS guard — accepted, expected reject (over-long line is unscannable)"
   sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
-elif grep -qF "AWS access key" "$HOOK_OUT" && grep -qF "chars dropped from the scan" "$HOOK_OUT"; then
-  echo "  ✓ over-long line dropped with warning; secret on normal line still caught"
+elif grep -qF "AWS access key" "$HOOK_OUT" && grep -qF "cannot be scanned for secrets" "$HOOK_OUT"; then
+  echo "  ✓ over-long line fails closed; secret on normal line still caught"
   PASS=$((PASS + 1))
 else
-  echo "  ✗ ReDoS guard — rejected but missing the secret hit or the drop warning"
+  echo "  ✗ ReDoS guard — rejected but missing the secret hit or the fail-closed message"
   sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
 fi
 reset_repo
+
+# 31b. The bypass that motivated the fail-closed change: a secret embedded IN a
+#      single >MAX_LINE_LENGTH line. The old scanner dropped the whole line (and
+#      the secret with it) and exited 0; now the unscannable line is reported and
+#      the commit is rejected. AKIA literal split so this harness file is clean.
+{ head -c 60000 /dev/zero | tr '\0' a; printf ' AKIA''IOSFODNN7EXAMPLE\n'; } >longsecret.txt
+git add longsecret.txt
+assert_rejects "secret hidden on a >MAX_LINE_LENGTH line no longer slips through" "cannot be scanned for secrets"
 
 # 32. Rename bypass: a secret-bearing TEXT file given a binary extension is
 #     still scanned. Binary is decided by CONTENT (a NUL byte), not by the name,

--- a/tests/cases/04-shell-config-rename.sh
+++ b/tests/cases/04-shell-config-rename.sh
@@ -63,6 +63,16 @@ echo 'note = "scaffold-allow AKIA''IOSFODNN7EXAMPLE"' >sneaky2.txt
 git add sneaky2.txt
 assert_rejects "scaffold-allow in a string does not exempt a secret" "AWS access key"
 
+# 28b. REGRESSION (scaffold-allow `--` smuggle): the bare `--` leader used to
+#      exempt ANY line in ANY language. `--` is not a comment in JS, yet a marker
+#      placed inside a string literal — `"<secret> -- scaffold-allow"` — got the
+#      whole line dropped from the findings. Dropping `--` as a leader closes it.
+#      AKIA split so this harness file carries no live key; the temp-repo .js
+#      fixture reassembles the key + marker on one line.
+printf 'const k = "%s -- scaffold-allow";\n' "AKIA""IOSFODNN7EXAMPLE" >smuggle.js
+git add smuggle.js
+assert_rejects "bare -- scaffold-allow does not exempt a secret" "AWS access key"
+
 # 29. A config line with no TAB separator is skipped with a warning (not promoted
 #     to a whole-line pattern); a valid pattern on another line still scans.
 printf 'this line has no tab separator at all\n' >>.forbidden-patterns/backend.txt

--- a/tests/cases/07-agent-commit.sh
+++ b/tests/cases/07-agent-commit.sh
@@ -86,6 +86,24 @@ if command -v jq >/dev/null 2>&1; then
     echo "  ✗ agent-precheck — Cursor secret block missing expected message"
     sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
   fi
+  # (48g) REGRESSION (SIGPIPE fail-OPEN): when a block fires on MANY matching
+  #       lines, the block message's `printf '%s\n' "$hit" | head -3` took
+  #       SIGPIPE under `set -euo pipefail` and the script aborted at exit 141 —
+  #       BEFORE the `exit 2` the agent runtimes require to actually block, so
+  #       the dangerous action was allowed. Assert the exit code is EXACTLY 2
+  #       (141 is non-zero too, so a "non-zero == blocked" check would wrongly
+  #       pass here). `pass`+`word` is built at runtime so this file stays clean.
+  pw=pass
+  big=$(for _ in $(seq 1 20000); do printf '%sword = "aaaaaaaaaaaaaaaa"\n' "$pw"; done)
+  pc=$(jq -n --arg c "$big" '{tool_name:"Write",tool_input:{file_path:"big.py",content:$c}}')
+  rc=0
+  printf '%s' "$pc" | CLAUDE_PROJECT_DIR="$PWD" bash "$PRECHECK" >"$HOOK_OUT" 2>&1 || rc=$?
+  if [ "$rc" -eq 2 ]; then
+    echo "  ✓ agent-precheck blocks with exit 2 on a many-line match (no SIGPIPE)"; PASS=$((PASS + 1))
+  else
+    echo "  ✗ agent-precheck — block exited $rc, expected exactly 2 (SIGPIPE fail-open?)"
+    FAIL=$((FAIL + 1))
+  fi
 else
   echo "  - skipped agent-precheck tests (jq not installed)"
 fi


### PR DESCRIPTION
## Summary

Full-tree re-audit of the scaffold (11-dimension multi-agent fan-out, 68 agents, every finding adversarially verified with a concrete repro). 57 confirmed findings — **1 critical, 9 high, 10 medium, 37 low** — recorded in `SECURITY_AUDIT.md` under "Audit 2026-06-30", which also flags the prior 2026-06-09/10 sections as stale (they mark several now-fixed findings as Open, and the ReDoS line-cap they introduced is what opened today's critical fail-open).

This PR lands the **critical + top-3 high** fixes, each with a red-then-green regression test. The remaining findings are tracked in `SECURITY_AUDIT.md` → "Still open".

## Fixes (each false-negative = a leaked credential, so all fail toward *closed*)

| Finding | Sev | Change |
|---|---|---|
| **A1** `check-secrets` | critical | **Fail closed** on a line over `MAX_LINE_LENGTH` instead of dropping it with a warning + exit 0. A secret on a single >50k-char line used to ride straight through (hook **and** `--ci`). The line is still dropped before the ERE, so the ReDoS guard is unchanged. |
| **A2** `agent-precheck` | high | Block path `printf '%s\n' "$hit" \| head -3 \|\| true` so it reliably reaches `exit 2`. SIGPIPE (exit 141) under `set -euo pipefail` aborted before `exit 2`; runtimes treat non-2 as *allow*, so the guard failed open exactly when it matched. |
| **A3** scanners ×4 | high | `scaffold-allow` drops bare `--` as a comment leader and requires a start-of-line/whitespace boundary (5 exemption sites). `"<secret> -- scaffold-allow"` no longer self-exempts in non-SQL files; over-claiming docs corrected. |
| **A4** `check-filenames` | high | Fold name+path to lowercase before matching, so `.PEM`/`.ENV`/`ID_RSA` are blocked on case-insensitive filesystems; the `.env.example` allowlist still holds. |

## Behavior change to note before release

**A1 is fail-closed by default**: a repo committing a legit >`MAX_LINE_LENGTH` line (e.g. a vendored minified bundle) will now *fail* the secret scan until it splits the file, raises `MAX_LINE_LENGTH`, or points a dedicated scanner at it. This is the correct security default but is a visible change.

## Tests

- Suite: **148 passed / 0 failed** (was 141).
- New regression cases: `cases/04` #31/#31b (A1), #28b (A3), #36/#36b (A4); `cases/07` #48g (A2, asserts exit code is *exactly* 2).
- `shellcheck -S info` clean across all scripts.

See `SECURITY_AUDIT.md` for the full finding list and the prioritized "Still open" set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
