### PR TITLE
test(agent-precheck): fix Linux MAX_ARG_STRLEN failure in the SIGPIPE regression test

### DIFF
--- a/tests/cases/07-agent-commit.sh
+++ b/tests/cases/07-agent-commit.sh
@@ -94,8 +94,14 @@ if command -v jq >/dev/null 2>&1; then
   #       (141 is non-zero too, so a "non-zero == blocked" check would wrongly
   #       pass here). `pass`+`word` is built at runtime so this file stays clean.
   pw=pass
-  big=$(for _ in $(seq 1 20000); do printf '%sword = "aaaaaaaaaaaaaaaa"\n' "$pw"; done)
-  pc=$(jq -n --arg c "$big" '{tool_name:"Write",tool_input:{file_path:"big.py",content:$c}}')
+  # Build the payload via --rawfile, NOT --arg: the ~600 KB content passed as a
+  # single CLI argument exceeds Linux MAX_ARG_STRLEN (128 KB) and aborts jq with
+  # "Argument list too long" (macOS has no per-arg cap, so --arg passed locally
+  # but failed on the ubuntu runner). --rawfile reads the content from a file.
+  bigf=$(mktemp)
+  for _ in $(seq 1 20000); do printf '%sword = "aaaaaaaaaaaaaaaa"\n' "$pw"; done >"$bigf"
+  pc=$(jq -n --rawfile c "$bigf" '{tool_name:"Write",tool_input:{file_path:"big.py",content:$c}}')
+  rm -f "$bigf"
   rc=0
   printf '%s' "$pc" | CLAUDE_PROJECT_DIR="$PWD" bash "$PRECHECK" >"$HOOK_OUT" 2>&1 || rc=$?
   if [ "$rc" -eq 2 ]; then


### PR DESCRIPTION
## Summary

Follow-up to #24. The A2 SIGPIPE regression test (`cases/07` #48g) built a
~600 KB `content` string and passed it to `jq` via `--arg`. Linux caps a single
argv element at `MAX_ARG_STRLEN` (128 KB), so `execve` aborted with
"Argument list too long" (exit 126) — failing `test (ubuntu-latest)` and
skipping the remaining cases. macOS has no per-arg cap, so it passed locally and
on `macos-latest`. (This is the exact BSD-vs-GNU asymmetry the audit's
portability dimension covers.)

Fix: read the content from a file with `jq --rawfile` instead of `--arg`. The
`agent-precheck` fix from #24 is unchanged; only the test's payload construction
changed. The test still drives a >64 KB `$hit` so it genuinely exercises the
SIGPIPE path (reverting the `|| true` makes it red again).

## Tests
- Suite **148/148** local; `shellcheck -S info` clean.
- Restores `test (ubuntu-latest)` to green (main was red after #24 merged before CI finished).

🤖 Generated with [Claude Code](https://claude.com/claude-code)