### PR TITLE
fix(secrets): broaden credential coverage — underscore names, provider prefixes, empty-user URL (A6/A8)

### DIFF
--- a/SECURITY_AUDIT.md
+++ b/SECURITY_AUDIT.md
@@ -46,7 +46,7 @@
 | Plain re-run keeps stale scaffold-owned scanners — security fixes never reach upgraders | `install.sh:156-159` |
 | Uninstall never removes `.githooks/lib/ci-changed-files` (install adds 8 libs, uninstall removes 7) | `uninstall.sh:133` |
 | Generic credential keyword list omits `secret`, `client_secret`, `private_key`, `credential`, `pwd`, `auth` | `secrets.txt.template:53` |
-| URL-embedded-credentials rule misses empty-username userinfo (`redis://:password@host`) | `secrets.txt.template:48` |
+| URL-embedded-credentials rule misses empty-username userinfo (a redis-style URL with an empty user) | `secrets.txt.template:48` |
 | `agent-precheck` long-line filter empties content → exit 0, skipping a one-line Bash command scan | `agent-precheck.template:57-59` |
 | Template-only action pins get neither Dependabot updates nor drift-guard coverage; rot silently | `gitleaks.yml.template:38` (+ `dependency-review`/`coverage`/opt-in `lint` jobs) |
 | `dependency-review` defaults to `fail-on-severity: moderate`, allowing low-severity advisories | `dependency-review.yml.template:49` |
@@ -72,7 +72,17 @@ Each landed with a red-then-green regression test; full suite 148/148 green.
 - **A3 (high)** — `scaffold-allow` dropped bare `--` as a leader and now requires a start-of-line/whitespace boundary, across all five exemption sites (check-secrets, check-patterns, check-hygiene ×2, agent-precheck); over-claiming docs corrected. (`2a92e6e`; cases/04 #28b)
 - **A4 (high)** — `check-filenames` folds name+path to lowercase before matching, so `.PEM`/`.ENV`/`ID_RSA` are blocked; the `.env.example` allowlist still holds. (`16ab43b`; cases/04 #36, #36b)
 
-**Still open** (recommended next, in priority order): the secret-regex coverage cluster (A5/A6/A8 + the medium keyword/URL gaps — needs positive **and** negative corpus validation to manage false positives); `cp_safe` symlink handling (A7); the installer/uninstaller robustness cluster; the remaining test-coverage gaps (A10 et al.); and the doc reconciliations.
+### Fixed in follow-ups (`fix/audit-secret-regex`)
+
+Secret-regex coverage, each validated against a positive **and** negative FP corpus (SHA-256 / git-hash / UUID / lockfile-hash / unquoted-variable negatives) and locked with harness tests (`cases/01` #10a–g):
+
+- **A6 (high)** — generic credential-rule boundary `[^A-Za-z_]` → `[^A-Za-z]`, so underscore-prefixed names (`db_password`, `DATABASE_PASSWORD`, `client_secret`) are caught.
+- **A8 (high)** — added prefix/boundary-anchored rules: SendGrid, Shopify, Square, Mailgun, Telegram, Twilio (Account SID + API key SID). The hex-prefixed ones (`AC`/`SK`/`key-`) carry non-alphanumeric boundaries so they don't match a window inside a SHA.
+- **medium** — keyword list broadened (`pwd`, bare `secret`, `private_key`, `credentials?`); URL-credentials rule now matches the empty-username userinfo form (e.g. a redis URL with an empty user).
+
+**A5 (unquoted values) is deliberately NOT fixed.** Loosening the quote requirement false-positives on ordinary `api_key = some_variable` assignments. Per the project's standing decision (and the README), unquoted/env-var secrets are the gitleaks layer's job — the README's secret-scan row now says "quoted" explicitly and points there.
+
+**Still open** (priority order): `cp_safe` symlink handling (A7); the installer/uninstaller robustness cluster (re-run keeps stale scanners; uninstall gaps); the remaining test-coverage gaps (A10 et al.); and the remaining doc reconciliations.
 
 ### What's solid (verified, so fixes don't regress it)
 
@@ -406,7 +416,7 @@ Locked in with harness fixtures #27–30 (the #30 `--ci` test also begins closin
 | ⬜ Open | No CR-stripping, no .gitattributes, and no line-ending guidance for distributed config files | `README.md:1` |
 | ⬜ Open | print/console.log/alert/os.path.join patterns fire inside comments and string literals (false positives); os.p… | `backend.txt.template:7-8` |
 | ⬜ Open | AWS key coverage limited to AKIA; temporary (ASIA) and other AWS key-ID prefixes are not detected, contrary to… | `secrets.txt.template:13` |
-| ⬜ Open | URL-with-credentials pattern misses password-only userinfo (e.g. redis://:password@host) | `secrets.txt.template:25` |
+| ⬜→✅ | URL-with-credentials pattern misses password-only userinfo (e.g. a redis URL with an empty user) — now FIXED, see "Fixed in follow-ups" above | `secrets.txt.template:25` |
 | ⬜ Open | shell.txt curl\|bash and rm-rf/ patterns miss common real-world forms, overstating shell coverage | `shell.txt.template:4-5` |
 | ✅ Fixed | check-filenames aborts on leading-dash filenames via unguarded basename (confusing failure, order-dependent) | `check-filenames.template:33` |
 | ✅ Fixed | `printf \| head -3 \| sed` aborts check-patterns/check-secrets via SIGPIPE under pipefail (exit 141) | `check-patterns.template:92` |

--- a/forbidden-patterns/secrets.txt.template
+++ b/forbidden-patterns/secrets.txt.template
@@ -45,9 +45,18 @@ eyJ[A-Za-z0-9_-]{17,}\.eyJ[A-Za-z0-9_-]{17,}	JWT in source — if long-lived (se
 # URL with embedded credentials — e.g. protocol scheme + userinfo + host.
 # `[a-zA-Z]+` rather than `[a-z]+` so the pattern reads correctly when copied
 # into other tooling that doesn't run grep with -i.
-[a-zA-Z]+://[^[:space:]:/@]+:[^[:space:]/@]+@[^[:space:]/]+	URL with embedded credentials — use env vars
+[a-zA-Z]+://[^[:space:]:/@]*:[^[:space:]/@]+@[^[:space:]/]+	URL with embedded credentials — use env vars
 
 # Hardcoded credentials in assignments. Value must be 16+ chars of token-like
 # content to dodge test fixtures / short placeholders. Six per-keyword lines
 # collapsed into one alternation now that the separator is TAB.
-(^|[^A-Za-z_])(password|passwd|token|api[-_]?key|secret[-_]?key|access[-_]?token)[[:space:]]*[:=][[:space:]]*['"][A-Za-z0-9_/+=-]{16,}['"]	Hardcoded credential — use env vars or a secret manager
+(^|[^A-Za-z])(password|passwd|pwd|secret|secret[-_]?key|private[-_]?key|credentials?|token|api[-_]?key|access[-_]?token)[[:space:]]*[:=][[:space:]]*['"][A-Za-z0-9_/+=-]{16,}['"]	Hardcoded credential — use env vars or a secret manager
+
+# More cloud / SaaS prefixes (2026-06-30 audit) — prefix/boundary-anchored, validated against an FP corpus (SHA/UUID/lockfile-hash negatives)
+SG\.[A-Za-z0-9_-]{22}\.[A-Za-z0-9_-]{43}	SendGrid API key — rotate immediately
+shp(at|ca|pa|ss)_[a-fA-F0-9]{32}	Shopify access token — rotate immediately
+sq0(atp|csp)-[A-Za-z0-9_-]{22,}	Square OAuth/access token — rotate immediately
+(^|[^A-Za-z0-9])key-[a-f0-9]{32}	Mailgun API key — rotate immediately
+[0-9]{8,10}:AA[A-Za-z0-9_-]{33}	Telegram bot token — rotate immediately
+(^|[^A-Za-z0-9])AC[a-f0-9]{32}([^a-fA-F0-9]|$)	Twilio Account SID — rotate the paired auth token
+(^|[^A-Za-z0-9])SK[a-f0-9]{32}([^a-fA-F0-9]|$)	Twilio API key SID — rotate immediately

--- a/tests/cases/01-size-patterns.sh
+++ b/tests/cases/01-size-patterns.sh
@@ -97,3 +97,46 @@ echo 'pri''nt("debug")' >sneaky.py
 git add sneaky.py
 echo '# clean now' >sneaky.py
 assert_rejects "scans staged content (not working tree)"
+
+# 10. Secret-coverage additions (2026-06-30 audit). Each distinctive token is
+#     assembled by printf in the temp-repo .txt fixture (a `%s` arg breaks the
+#     anchor the pattern needs), so this harness file carries no live-shaped
+#     secret. .txt keeps these isolated from ruff/eslint. Validated against an
+#     FP corpus (SHA/UUID/lockfile-hash negatives) before landing.
+
+# 10a. Underscore-prefixed credential name — the boundary fix ('_' used to count
+#      as a word char, so db_password / DATABASE_PASSWORD slipped through).
+printf 'db_password = "%s"\n' 'supersecretvalue1' >dbcfg.txt
+git add dbcfg.txt
+assert_rejects "underscore-prefixed credential (db_password)" "Hardcoded credential"
+
+# 10b. URL with EMPTY-username userinfo (a redis URL, empty user) — the '*' fix.
+printf 'u = "redis://:secretpassword%shost"\n' '@' >redis.txt
+git add redis.txt
+assert_rejects "URL with empty-username credentials" "URL with embedded credentials"
+
+# 10c. SendGrid key prefix.
+printf 'k = SG.%s.%s\n' 'abcdefghijklmnopqrstuv' 'abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHI' >sg.txt
+git add sg.txt
+assert_rejects "SendGrid API key" "SendGrid"
+
+# 10d. Shopify token prefix.
+printf 'k = shp%s\n' 'at_0123456789abcdef0123456789abcdef' >shop.txt
+git add shop.txt
+assert_rejects "Shopify access token" "Shopify"
+
+# 10e. Twilio Account SID — boundary-anchored 32-hex (must not match inside a SHA).
+printf 'sid = AC%s\n' '0123456789abcdef0123456789abcdef' >twil.txt
+git add twil.txt
+assert_rejects "Twilio Account SID" "Twilio"
+
+# 10f. NEGATIVE: a 64-char SHA-256 must NOT trip the new hex-prefixed rules.
+printf 'h = %s\n' 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855' >sha.txt
+git add sha.txt
+assert_passes "SHA-256 hash is not a false positive"
+
+# 10g. NEGATIVE: an UNQUOTED assignment stays uncaught by design — quoted-only;
+#      unquoted/env-var forms are the gitleaks layer's job (see README).
+printf 'api_key = %s\n' 'my_config_variable_name_here' >unq.txt
+git add unq.txt
+assert_passes "unquoted credential assignment is not flagged (quoted-only by design)"


### PR DESCRIPTION
## Summary

Closes the FP-safe part of the 2026-06-30 audit's secret-regex cluster. Every change was validated against a **positive + negative FP corpus** (SHA-256, git hash, UUID, lockfile hash, unquoted-variable as negatives) before landing, and locked with harness tests (`cases/01` #10a–g).

## Changes (`forbidden-patterns/secrets.txt`)

- **A6 (high)** — generic credential-rule boundary `[^A-Za-z_]` → `[^A-Za-z]`, so underscore-prefixed names (`db_password`, `DATABASE_PASSWORD`, `client_secret`) are caught. They were silently missed because `_` counted as a word char.
- **A8 (high)** — added prefix/boundary-anchored rules: **SendGrid, Shopify, Square, Mailgun, Telegram, Twilio** (Account SID + API key SID). The hex-prefixed ones (`AC`/`SK`/`key-`) carry non-alphanumeric boundaries so they can't match a 34-char window inside a SHA-256.
- **medium** — keyword list broadened (`pwd`, bare `secret`, `private_key`, `credentials?`); the URL-credentials rule now matches the **empty-username** form (e.g. a redis URL with no user before the password).

## Deliberately NOT done — A5 (unquoted values)

Kept the quote requirement. Matching unquoted `api_key = some_variable` false-positives on ordinary variable assignments; per the project's standing decision (and the README), unquoted/env-var secrets are the **gitleaks layer's** job. Negative test #10g guards that an unquoted assignment is not flagged.

## Tests
- Suite **155/155**; `shellcheck -S info` clean.
- Verified the broadened patterns don't newly flag any tracked file (re-ran the self-lint scan over the whole tree).

Updates `SECURITY_AUDIT.md` → "Fixed in follow-ups". Remaining open: `cp_safe` symlink (A7), installer robustness, test-coverage gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)