### PR TITLE
fix(install): don't write through symlinks at scaffold paths; uninstall ci-changed-files (A7)

### DIFF
--- a/SECURITY_AUDIT.md
+++ b/SECURITY_AUDIT.md
@@ -82,7 +82,15 @@ Secret-regex coverage, each validated against a positive **and** negative FP cor
 
 **A5 (unquoted values) is deliberately NOT fixed.** Loosening the quote requirement false-positives on ordinary `api_key = some_variable` assignments. Per the project's standing decision (and the README), unquoted/env-var secrets are the gitleaks layer's job — the README's secret-scan row now says "quoted" explicitly and points there.
 
-**Still open** (priority order): `cp_safe` symlink handling (A7); the installer/uninstaller robustness cluster (re-run keeps stale scanners; uninstall gaps); the remaining test-coverage gaps (A10 et al.); and the remaining doc reconciliations.
+### Fixed in follow-ups (`fix/audit-installer`)
+
+- **A7 (high)** — `cp_safe` no longer writes THROUGH a symlink at a scaffold path. `[ -e ]` is false for a dangling link and follows a live one, so a planted symlink used to make `cp` write the scanner to the link's target outside the repo (and leave the installed scanner as a symlink). Now: test `-L` too, never compare/no-op through a symlink, back up the link itself with `cp -P`, and `rm -f` the dst before writing a real regular file. (`install.sh`; tests `cases/09` live-force + dangling-no-force.)
+- **chmod robustness (low)** — a new `mkx()` helper chmods only a real regular file, so a skipped (symlink) scaffold path can't abort the install via a chmod-through-a-broken-link under `set -e`. Replaces every `chmod +x` site.
+- **uninstall gap (medium)** — the uninstall loop now includes `ci-changed-files` (install adds 8 libs; uninstall removed 7, leaving it orphaned). (`uninstall.sh:133`; test `cases/09`.)
+
+**Still open** (priority order): the **installer upgrade story** — a plain re-run prints "skip (exists)" for scaffold-owned scanners, so existing users don't receive these very fixes by re-running (needs a design call on scaffold-owned vs user-owned files; see note below); the remaining test-coverage gaps (A10 et al.); and the remaining doc reconciliations.
+
+> **Design decision needed — installer upgrades.** `cp_safe` treats every existing file as user-owned (skip unless `--force`). That's correct for `CLAUDE.md`/`AGENTS.md`/configs, but it means scaffold-owned *code* (`check-*`, libs, workflows) is never refreshed on re-run, so a security fix never reaches an upgrader who re-runs `install.sh`. A fix has to decide which paths are scaffold-owned (safe to auto-update when they differ from the shipped version) vs user-owned (never auto-replace) — and `.forbidden-patterns/*.txt` is the hard case (scaffold ships them, but users add custom patterns, so auto-replacing would clobber). Likely answer: auto-update the pure-code paths; for pattern files, append/merge new shipped rules rather than overwrite, or tell the user to re-run with `--force` and rely on the `.scaffold-bak` backups. Deferred pending that call.
 
 ### What's solid (verified, so fixes don't regress it)
 

--- a/install.sh
+++ b/install.sh
@@ -77,19 +77,29 @@ fi
 
 cp_safe() {
   local src=$1 dst=$2
-  if [ -e "$dst" ]; then
+  # `[ -e ]` alone is false for a DANGLING symlink and follows a LIVE one, so a
+  # pre-existing symlink at a scaffold path used to make the `cp` below follow it
+  # and write the scanner to the link's target OUTSIDE the repo, leaving the
+  # installed scanner as a symlink (arbitrary write + scanner substitution). Test
+  # `-L` too so a symlink is always treated as an existing thing to replace, and
+  # we never write THROUGH it (the `rm -f` before the final `cp` guarantees that).
+  if [ -e "$dst" ] || [ -L "$dst" ]; then
     if [ "$FORCE" -eq 0 ]; then
-      echo "skip (exists): $dst  — left untouched (use --force to replace)"
+      if [ -L "$dst" ]; then
+        echo "skip (exists, symlink): $dst — left untouched; a scaffold path that is a symlink is suspicious. Replace it with --force."
+      else
+        echo "skip (exists): $dst  — left untouched (use --force to replace)"
+      fi
       return
     fi
     # --force: back up the existing file before overwriting, but only when it
-    # actually differs — so no edit is ever silently destroyed. Identical
-    # files are a no-op.
-    if cmp -s "$src" "$dst"; then
+    # actually differs — so no edit is ever silently destroyed. A symlink is
+    # never compared through (`-L` short-circuits) and is always replaced.
+    if [ ! -L "$dst" ] && cmp -s "$src" "$dst"; then
       return
     fi
     local bak="${dst}.scaffold-bak" n=0
-    while [ -e "$bak" ]; do
+    while [ -e "$bak" ] || [ -L "$bak" ]; do
       n=$((n + 1))
       if [ "$n" -gt 99 ]; then
         echo "error: too many .scaffold-bak files for $dst — clean some up" >&2
@@ -97,13 +107,23 @@ cp_safe() {
       fi
       bak="${dst}.scaffold-bak.${n}"
     done
-    cp "$dst" "$bak"
+    # -P: back up a symlink AS the link, never the dereferenced target content.
+    cp -P "$dst" "$bak"
     echo "backed up:    $dst -> $bak"
   fi
   mkdir -p "$(dirname "$dst")"
+  # Remove any existing dst first (incl. a symlink) so we write a real regular
+  # file rather than following a link out of the tree.
+  rm -f "$dst"
   cp "$src" "$dst"
   echo "installed:    $dst"
 }
+
+# chmod +x only a real regular file. A scaffold path that cp_safe deliberately
+# SKIPPED because it's a (possibly dangling) symlink must not abort the install
+# via a chmod that follows a broken link and fails under set -e — nor should we
+# flip the mode of a skipped, user-owned file.
+mkx() { if [ -f "$1" ]; then chmod +x "$1"; fi; }
 
 # install_claude_md — CLAUDE.md is USER-OWNED project memory, not a scaffold
 # file. Never replace it (not even with --force). If absent, create it from
@@ -147,7 +167,7 @@ cp_safe "$SCAFFOLD_DIR/operational-rules.md" "operational-rules.md"
 install_agents_md   # never clobbers an existing AGENTS.md
 install_claude_md   # merges; never overwrites your CLAUDE.md
 cp_safe "$SCAFFOLD_DIR/githooks/pre-commit.template" ".githooks/pre-commit"
-chmod +x .githooks/pre-commit
+mkx .githooks/pre-commit
 # scaffold-config + scaffold-audit are the per-project override layer
 # (.scaffold.toml): the check-* scripts source the former for per-rule
 # disable / severity / per-path size caps; the latter lists active overrides.
@@ -155,7 +175,7 @@ chmod +x .githooks/pre-commit
 # lint.yml so a fresh install doesn't retroactively fail pre-existing code).
 for check in check-size check-patterns check-filenames check-secrets check-hygiene scaffold-config scaffold-audit ci-changed-files; do
   cp_safe "$SCAFFOLD_DIR/githooks/lib/${check}.template" ".githooks/lib/${check}"
-  chmod +x ".githooks/lib/${check}"
+  mkx ".githooks/lib/${check}"
 done
 cp_safe "$SCAFFOLD_DIR/.github/workflows/lint.yml.template" ".github/workflows/lint.yml"
 cp_safe "$SCAFFOLD_DIR/.github/dependabot.yml.template" ".github/dependabot.yml"
@@ -227,7 +247,7 @@ done
 # merge the template's keys in by hand.
 if [ "$CLAUDE" -eq 1 ] || [ "$CURSOR" -eq 1 ]; then
   cp_safe "$SCAFFOLD_DIR/githooks/lib/agent-precheck.template" ".githooks/lib/agent-precheck"
-  chmod +x ".githooks/lib/agent-precheck"
+  mkx ".githooks/lib/agent-precheck"
   if ! command -v jq >/dev/null 2>&1; then
     echo "warning: jq not found — the agent precheck needs jq (it fails open without it): https://jqlang.github.io/jq/"
   fi
@@ -247,7 +267,7 @@ fi
 # it lands in core.hooksPath, so it's off by default to avoid surprising users.
 if [ "$COMMIT_MSG" -eq 1 ]; then
   cp_safe "$SCAFFOLD_DIR/githooks/commit-msg.template" ".githooks/commit-msg"
-  chmod +x ".githooks/commit-msg"
+  mkx ".githooks/commit-msg"
 fi
 
 # Local gitleaks pre-commit pass (opt-in: --gitleaks-hook). The pre-commit
@@ -256,7 +276,7 @@ fi
 # the gitleaks binary is present; pair it with gitleaks.yml.template in CI.
 if [ "$GITLEAKS_HOOK" -eq 1 ]; then
   cp_safe "$SCAFFOLD_DIR/githooks/lib/check-gitleaks.template" ".githooks/lib/check-gitleaks"
-  chmod +x ".githooks/lib/check-gitleaks"
+  mkx ".githooks/lib/check-gitleaks"
   if ! command -v gitleaks >/dev/null 2>&1; then
     echo "warning: gitleaks not found — the local pass fails open (skips) until you install it: https://github.com/gitleaks/gitleaks#installing"
   fi

--- a/tests/cases/09-toolchain-clobber.sh
+++ b/tests/cases/09-toolchain-clobber.sh
@@ -188,4 +188,54 @@ else
   echo "  ✗ install concatenated the import onto the last handwritten line"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
 fi
 rm -rf "$UNL"
+
+# --- installer does not write THROUGH a symlink at a scaffold path (A7) -------
+# A pre-existing symlink at a scaffold destination used to make cp follow it and
+# write the scanner to the link's target OUTSIDE the repo, leaving the installed
+# scanner as a symlink (arbitrary write + scanner substitution).
+
+# (T) live symlink -> outside file, with --force: the outside file must NOT be
+#     overwritten, and the installed path must become a real regular file.
+USL=$(mktemp -d)
+mkdir -p "$USL/repo/.githooks/lib"
+printf 'PRECIOUS_DO_NOT_TOUCH\n' >"$USL/outside_target"
+ln -s "$USL/outside_target" "$USL/repo/.githooks/lib/check-secrets"
+( cd "$USL/repo" && git init --quiet && echo '{"name":"x"}' >package.json \
+  && "$SCAFFOLD_DIR/install.sh" --frontend --force --no-verify ) >"$HOOK_OUT" 2>&1
+if [ -f "$USL/repo/.githooks/lib/check-secrets" ] && [ ! -L "$USL/repo/.githooks/lib/check-secrets" ] \
+   && grep -q 'PRECIOUS_DO_NOT_TOUCH' "$USL/outside_target" \
+   && head -1 "$USL/repo/.githooks/lib/check-secrets" | grep -q '#!/usr/bin/env bash'; then
+  echo "  ✓ install replaces a symlinked scaffold path with a real file (no write-through)"; PASS=$((PASS + 1))
+else
+  echo "  ✗ install wrote through a symlink or clobbered the outside target"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$USL"
+
+# (T) DANGLING symlink -> outside path, no --force: must be skipped, NOT written
+#     through (the dangling case is where `[ -e ]` is false and cp used to fall
+#     through and create the outside file).
+USD=$(mktemp -d)
+mkdir -p "$USD/repo/.githooks/lib"
+ln -s "$USD/nonexistent_outside" "$USD/repo/.githooks/lib/check-filenames"
+( cd "$USD/repo" && git init --quiet && echo '{"name":"x"}' >package.json \
+  && "$SCAFFOLD_DIR/install.sh" --frontend --no-verify ) >"$HOOK_OUT" 2>&1
+if [ ! -e "$USD/nonexistent_outside" ]; then
+  echo "  ✓ install does not write through a dangling symlink (no --force)"; PASS=$((PASS + 1))
+else
+  echo "  ✗ install wrote through a dangling symlink to an outside path"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$USD"
+
+# (T) uninstall removes ci-changed-files too (install adds 8 libs; the uninstall
+#     loop dropped this one, leaving the scaffold half-uninstalled).
+UCI=$(mktemp -d)
+( cd "$UCI" && git init --quiet && echo '{"name":"x"}' >package.json \
+  && "$SCAFFOLD_DIR/install.sh" --frontend --no-verify >/dev/null 2>&1 \
+  && "$SCAFFOLD_DIR/uninstall.sh" ) >"$HOOK_OUT" 2>&1
+if [ ! -e "$UCI/.githooks/lib/ci-changed-files" ]; then
+  echo "  ✓ uninstall removes .githooks/lib/ci-changed-files"; PASS=$((PASS + 1))
+else
+  echo "  ✗ uninstall left ci-changed-files behind"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$UCI"
 reset_repo

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -130,7 +130,7 @@ remove_if_unmodified ".prettierrc.json"              "$SCAFFOLD_DIR/.prettierrc.
 remove_if_unmodified ".prettierignore"               "$SCAFFOLD_DIR/.prettierignore.template"
 remove_if_unmodified "vitest.config.ts"              "$SCAFFOLD_DIR/vitest.config.ts.template"
 remove_if_unmodified ".githooks/pre-commit"          "$SCAFFOLD_DIR/githooks/pre-commit.template"
-for check in check-size check-patterns check-filenames check-secrets check-hygiene scaffold-config scaffold-audit; do
+for check in check-size check-patterns check-filenames check-secrets check-hygiene scaffold-config scaffold-audit ci-changed-files; do
   remove_if_unmodified ".githooks/lib/${check}" "$SCAFFOLD_DIR/githooks/lib/${check}.template"
 done
 # Per-project override file — removed only if still byte-identical to the


### PR DESCRIPTION
## Summary

Closes the installer security finding A7 plus two related robustness gaps from the 2026-06-30 audit. Each landed with a red-then-green regression test (`cases/09`).

## Fixes

- **A7 (high) — `cp_safe` wrote THROUGH symlinks.** `[ -e "$dst" ]` is false for a *dangling* symlink and *follows* a live one, so a pre-existing symlink at a scaffold path made `cp` write the scanner to the link's target **outside the repo**, leaving the installed scanner as a symlink (arbitrary write + scanner substitution). Now: test `-L` too, never compare/no-op through a symlink, back up the link itself with `cp -P`, and `rm -f` the dst before writing a real regular file.
- **chmod robustness (low).** New `mkx()` helper chmods only a real regular file, so a *skipped* (symlink) scaffold path can't abort the whole install via a `chmod`-through-a-broken-link under `set -e`. Routes every `chmod +x` through it.
- **uninstall gap (medium).** The uninstall loop now includes `ci-changed-files` — install adds 8 libs, uninstall removed 7, orphaning it.

## Tests (`cases/09`)
- live symlink → outside file, `--force`: outside file untouched, installed path becomes a real regular file.
- dangling symlink, no `--force`: no write-through to the outside path (and the install no longer aborts on the follow-up chmod).
- uninstall removes `.githooks/lib/ci-changed-files`.

Suite **158/158**; `shellcheck -S info` clean.

## Still open (called out in SECURITY_AUDIT.md)
The **installer upgrade story** — a plain re-run skips scaffold-owned scanners, so existing users don't get security fixes by re-running. That needs a design call (scaffold-owned vs user-owned paths; `.forbidden-patterns/*.txt` is the hard case). Documented, deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)