### PR TITLE
fix(install): refresh scaffold-owned code on re-run (installer upgrade story)

### DIFF
--- a/SECURITY_AUDIT.md
+++ b/SECURITY_AUDIT.md
@@ -43,7 +43,7 @@
 | Title | Location |
 |---|---|
 | Mid-script `cp`/`mkdir` failure aborts under `set -e` with no rollback/summary | `install.sh:103-104,145-274` |
-| Plain re-run keeps stale scaffold-owned scanners — security fixes never reach upgraders | `install.sh:156-159` |
+| ~~Plain re-run keeps stale scaffold-owned scanners — security fixes never reach upgraders~~ **FIXED** — `cp_scaffold` refreshes scaffold-owned code on diff (see "installer upgrade story" below) | `install.sh` |
 | Uninstall never removes `.githooks/lib/ci-changed-files` (install adds 8 libs, uninstall removes 7) | `uninstall.sh:133` |
 | Generic credential keyword list omits `secret`, `client_secret`, `private_key`, `credential`, `pwd`, `auth` | `secrets.txt.template:53` |
 | URL-embedded-credentials rule misses empty-username userinfo (a redis-style URL with an empty user) | `secrets.txt.template:48` |
@@ -88,9 +88,17 @@ Secret-regex coverage, each validated against a positive **and** negative FP cor
 - **chmod robustness (low)** — a new `mkx()` helper chmods only a real regular file, so a skipped (symlink) scaffold path can't abort the install via a chmod-through-a-broken-link under `set -e`. Replaces every `chmod +x` site.
 - **uninstall gap (medium)** — the uninstall loop now includes `ci-changed-files` (install adds 8 libs; uninstall removed 7, leaving it orphaned). (`uninstall.sh:133`; test `cases/09`.)
 
-**Still open** (priority order): the **installer upgrade story** — a plain re-run prints "skip (exists)" for scaffold-owned scanners, so existing users don't receive these very fixes by re-running (needs a design call on scaffold-owned vs user-owned files; see note below); the remaining test-coverage gaps (A10 et al.); and the remaining doc reconciliations.
+### Fixed in follow-ups (installer upgrade story)
 
-> **Design decision needed — installer upgrades.** `cp_safe` treats every existing file as user-owned (skip unless `--force`). That's correct for `CLAUDE.md`/`AGENTS.md`/configs, but it means scaffold-owned *code* (`check-*`, libs, workflows) is never refreshed on re-run, so a security fix never reaches an upgrader who re-runs `install.sh`. A fix has to decide which paths are scaffold-owned (safe to auto-update when they differ from the shipped version) vs user-owned (never auto-replace) — and `.forbidden-patterns/*.txt` is the hard case (scaffold ships them, but users add custom patterns, so auto-replacing would clobber). Likely answer: auto-update the pure-code paths; for pattern files, append/merge new shipped rules rather than overwrite, or tell the user to re-run with `--force` and rely on the `.scaffold-bak` backups. Deferred pending that call.
+**The installer upgrade story is RESOLVED.** A plain re-run of `install.sh` is now the supported upgrade path, so security fixes reach an existing user just by re-running. `cp_safe` was one policy ("skip unless `--force`") applied to three kinds of file with conflicting needs; it's split into one write mechanism (`_cp_replace` + `_backup`, carrying the A7 symlink defenses) and three ownership policies:
+
+- **`cp_scaffold` — scaffold-owned code** (`pre-commit`, all `.githooks/lib/*`, `commit-msg`, `lint.yml`, `coverage.yml`): **refreshes on diff with no `--force` needed**, so an upgrader receives the latest scanners/hooks/workflows by re-running. Identical → silent no-op; a symlink planted at a scaffold path is replaced with the real file (never written through); the prior bytes are recoverable from git + the scaffold, so a routine refresh writes no `.scaffold-bak` (only `--force` does). Announced as `updated: <path>`.
+- **`cp_safe` — user-owned files** (`ruff.toml`, eslint/tsconfig/prettier/vitest, `.scaffold.toml`, `.github/dependabot.yml`, the rules docs): unchanged — skip unless `--force` (which backs up first). `CLAUDE.md`/`AGENTS.md` keep their dedicated merge handlers.
+- **`cp_pattern` — `.forbidden-patterns/*.txt`** (the hard case: scaffold-shipped yet user-extended): a re-run only **notifies on drift** (`note (drift): …`) and keeps the user's file; `--force` backs up the user's rows to `.scaffold-bak` and writes the shipped version for manual merge-back.
+
+Red-then-green tested in `tests/cases/09` (refresh-stale-scanner, refresh-stale-workflow, leave-user-config, notify-on-pattern-drift, `--force`-backs-up-drift, clean-no-op-when-current); full suite 164/164, shellcheck clean. The scope was deliberately limited to code/libs/workflows: the markdown rules docs (`coding-rules.md`/`operational-rules.md`) and `dependabot.yml` stay user-owned (`cp_safe`), since teams localize them.
+
+**Still open** (priority order): the remaining test-coverage gaps (A10 et al.); and the remaining doc reconciliations.
 
 ### What's solid (verified, so fixes don't regress it)
 

--- a/install.sh
+++ b/install.sh
@@ -16,6 +16,12 @@
 #   install.sh --coverage-gate # also install the opt-in CI patch-coverage gate
 #   install.sh --no-install # detect missing tools but never auto-run a package manager
 #   install.sh --help       # show this help
+#
+# On re-run (upgrade): scaffold-owned code (the hook, .githooks/lib/*, CI
+# workflows) is REFRESHED when it differs from the shipped version, so security
+# fixes reach you just by re-running. User-owned configs are left alone; a
+# drifted .forbidden-patterns/*.txt only prints a notice (use --force to replace
+# it — your customizations are backed up to .scaffold-bak first).
 
 set -euo pipefail
 
@@ -45,7 +51,7 @@ for arg in "$@"; do
     --all-langs)  ALL_LANGS=1 ;;
     --coverage-gate) COVERAGE_GATE=1 ;;
     --no-install) NO_INSTALL=1 ;;
-    --help|-h)    sed -n '2,18p' "$0"; exit 0 ;;
+    --help|-h)    sed -n '2,24p' "$0"; exit 0 ;;
     *) echo "error: unknown argument: $arg" >&2; exit 1 ;;
   esac
 done
@@ -75,14 +81,63 @@ if [ "$MODE" = "auto" ]; then
   fi
 fi
 
+# --- file ownership & the install/upgrade model -----------------------------
+# Re-running install.sh is the supported UPGRADE path, so each destination is
+# copied through the policy its OWNERSHIP demands:
+#
+#   cp_scaffold  scaffold-owned CODE — scanners, libs, hooks, CI workflows. These
+#                carry security fixes, so a plain re-run REFRESHES them whenever
+#                they differ from the shipped version (no --force needed); that's
+#                how an upgrader who just re-runs install.sh actually receives the
+#                fixes. The prior bytes are recoverable from git + the scaffold,
+#                so a routine refresh writes no backup (only --force does).
+#   cp_safe      USER-OWNED files — ruff.toml, eslint config, .scaffold.toml,
+#                dependabot.yml, the rules docs, etc. A project customizes these,
+#                so they're never auto-replaced: skip unless --force (which backs
+#                up first). CLAUDE.md / AGENTS.md have their own merge handlers.
+#   cp_pattern   .forbidden-patterns/*.txt — the hard case: scaffold-SHIPPED yet
+#                user-EXTENDED (teams append their own rows). Auto-overwriting
+#                would clobber those rows, so a re-run only NOTIFIES on drift and
+#                keeps the user's file; --force backs up + replaces so the user's
+#                additions survive in .scaffold-bak for manual merge-back.
+#
+# The three policies share one write MECHANISM (_cp_replace) and one backup
+# routine (_backup), so the A7 symlink defenses live in exactly one place.
+
+# _cp_replace SRC DST — the actual write. `[ -e ]` alone is false for a DANGLING
+# symlink and follows a LIVE one, so a pre-existing symlink at a scaffold path
+# used to make `cp` follow it and write the scanner to the link's target OUTSIDE
+# the repo. We `rm -f` the destination first (dropping any symlink) so we always
+# write a real regular file IN the tree, never THROUGH a link.
+_cp_replace() {
+  local src=$1 dst=$2
+  mkdir -p "$(dirname "$dst")"
+  rm -f "$dst"
+  cp "$src" "$dst"
+}
+
+# _backup DST — copy an existing file/symlink aside to <dst>.scaffold-bak[.N]
+# before it is replaced, so no local edit is ever silently destroyed. `-P` backs
+# up a symlink AS the link, never the dereferenced target content.
+_backup() {
+  local dst=$1
+  local bak="${dst}.scaffold-bak" n=0
+  while [ -e "$bak" ] || [ -L "$bak" ]; do
+    n=$((n + 1))
+    if [ "$n" -gt 99 ]; then
+      echo "error: too many .scaffold-bak files for $dst — clean some up" >&2
+      return 1
+    fi
+    bak="${dst}.scaffold-bak.${n}"
+  done
+  cp -P "$dst" "$bak"
+  echo "backed up:    $dst -> $bak"
+}
+
+# cp_safe SRC DST — USER-OWNED file. Install if absent; otherwise leave it alone
+# unless --force (which backs up the differing file, then replaces it).
 cp_safe() {
   local src=$1 dst=$2
-  # `[ -e ]` alone is false for a DANGLING symlink and follows a LIVE one, so a
-  # pre-existing symlink at a scaffold path used to make the `cp` below follow it
-  # and write the scanner to the link's target OUTSIDE the repo, leaving the
-  # installed scanner as a symlink (arbitrary write + scanner substitution). Test
-  # `-L` too so a symlink is always treated as an existing thing to replace, and
-  # we never write THROUGH it (the `rm -f` before the final `cp` guarantees that).
   if [ -e "$dst" ] || [ -L "$dst" ]; then
     if [ "$FORCE" -eq 0 ]; then
       if [ -L "$dst" ]; then
@@ -92,30 +147,60 @@ cp_safe() {
       fi
       return
     fi
-    # --force: back up the existing file before overwriting, but only when it
-    # actually differs — so no edit is ever silently destroyed. A symlink is
-    # never compared through (`-L` short-circuits) and is always replaced.
+    # --force: back up before overwriting, but only when it actually differs. A
+    # symlink is never compared through (`-L` short-circuits) and always replaced.
     if [ ! -L "$dst" ] && cmp -s "$src" "$dst"; then
       return
     fi
-    local bak="${dst}.scaffold-bak" n=0
-    while [ -e "$bak" ] || [ -L "$bak" ]; do
-      n=$((n + 1))
-      if [ "$n" -gt 99 ]; then
-        echo "error: too many .scaffold-bak files for $dst — clean some up" >&2
-        return 1
-      fi
-      bak="${dst}.scaffold-bak.${n}"
-    done
-    # -P: back up a symlink AS the link, never the dereferenced target content.
-    cp -P "$dst" "$bak"
-    echo "backed up:    $dst -> $bak"
+    _backup "$dst" || return 1
   fi
-  mkdir -p "$(dirname "$dst")"
-  # Remove any existing dst first (incl. a symlink) so we write a real regular
-  # file rather than following a link out of the tree.
-  rm -f "$dst"
-  cp "$src" "$dst"
+  _cp_replace "$src" "$dst"
+  echo "installed:    $dst"
+}
+
+# cp_scaffold SRC DST — SCAFFOLD-OWNED code. Refreshes on diff so security fixes
+# reach upgraders on a plain re-run. Identical → silent no-op. A symlink planted
+# at a scaffold-owned path is always replaced with the real scanner (better than
+# leaving a dead link there) and never written through. No backup on a routine
+# refresh — the prior bytes are scaffold code, recoverable from git history and
+# the scaffold repo; --force still backs up first for parity with cp_safe.
+cp_scaffold() {
+  local src=$1 dst=$2
+  if [ -e "$dst" ] || [ -L "$dst" ]; then
+    # Already current? Never compare THROUGH a symlink (A7).
+    if [ ! -L "$dst" ] && cmp -s "$src" "$dst"; then
+      return
+    fi
+    [ "$FORCE" -eq 1 ] && { _backup "$dst" || return 1; }
+    _cp_replace "$src" "$dst"
+    echo "updated:      $dst (refreshed to the shipped version)"
+    return
+  fi
+  _cp_replace "$src" "$dst"
+  echo "installed:    $dst"
+}
+
+# cp_pattern SRC DST — .forbidden-patterns/*.txt. Install if absent; if it drifts
+# from the shipped version, NOTIFY (the user may have added rows; new shipped
+# rules may be worth merging) but keep the user's file. --force backs up + writes
+# the shipped version, so the user's additions survive in .scaffold-bak.
+cp_pattern() {
+  local src=$1 dst=$2
+  if [ -e "$dst" ] || [ -L "$dst" ]; then
+    if [ ! -L "$dst" ] && cmp -s "$src" "$dst"; then
+      return
+    fi
+    if [ "$FORCE" -eq 0 ]; then
+      if [ -L "$dst" ]; then
+        echo "skip (exists, symlink): $dst — left untouched; a scaffold path that is a symlink is suspicious. Replace it with --force."
+      else
+        echo "note (drift):  $dst differs from the shipped patterns — your customizations are kept. Diff against forbidden-patterns/$(basename "$dst").template for new rules to merge, or re-run with --force to replace (backs yours up to .scaffold-bak)."
+      fi
+      return
+    fi
+    _backup "$dst" || return 1
+  fi
+  _cp_replace "$src" "$dst"
   echo "installed:    $dst"
 }
 
@@ -166,21 +251,24 @@ cp_safe "$SCAFFOLD_DIR/coding-rules.md" "coding-rules.md"
 cp_safe "$SCAFFOLD_DIR/operational-rules.md" "operational-rules.md"
 install_agents_md   # never clobbers an existing AGENTS.md
 install_claude_md   # merges; never overwrites your CLAUDE.md
-cp_safe "$SCAFFOLD_DIR/githooks/pre-commit.template" ".githooks/pre-commit"
+cp_scaffold "$SCAFFOLD_DIR/githooks/pre-commit.template" ".githooks/pre-commit"
 mkx .githooks/pre-commit
 # scaffold-config + scaffold-audit are the per-project override layer
 # (.scaffold.toml): the check-* scripts source the former for per-rule
 # disable / severity / per-path size caps; the latter lists active overrides.
 # ci-changed-files scopes the CI quality gates to the PR/push diff (used by
 # lint.yml so a fresh install doesn't retroactively fail pre-existing code).
+# All scaffold-owned code → cp_scaffold so a re-run delivers security fixes.
 for check in check-size check-patterns check-filenames check-secrets check-hygiene scaffold-config scaffold-audit ci-changed-files; do
-  cp_safe "$SCAFFOLD_DIR/githooks/lib/${check}.template" ".githooks/lib/${check}"
+  cp_scaffold "$SCAFFOLD_DIR/githooks/lib/${check}.template" ".githooks/lib/${check}"
   mkx ".githooks/lib/${check}"
 done
-cp_safe "$SCAFFOLD_DIR/.github/workflows/lint.yml.template" ".github/workflows/lint.yml"
+cp_scaffold "$SCAFFOLD_DIR/.github/workflows/lint.yml.template" ".github/workflows/lint.yml"
+# dependabot.yml is user-owned config (teams add their own ecosystems) → cp_safe.
 cp_safe "$SCAFFOLD_DIR/.github/dependabot.yml.template" ".github/dependabot.yml"
-cp_safe "$SCAFFOLD_DIR/forbidden-patterns/secrets.txt.template" ".forbidden-patterns/secrets.txt"
-cp_safe "$SCAFFOLD_DIR/forbidden-patterns/shell.txt.template" ".forbidden-patterns/shell.txt"
+# Pattern files are scaffold-shipped but user-extended → cp_pattern (notify on drift).
+cp_pattern "$SCAFFOLD_DIR/forbidden-patterns/secrets.txt.template" ".forbidden-patterns/secrets.txt"
+cp_pattern "$SCAFFOLD_DIR/forbidden-patterns/shell.txt.template" ".forbidden-patterns/shell.txt"
 # Per-project override file — ships empty (all examples commented), so it
 # enforces nothing until a team uncomments an entry. See scaffold-config.
 cp_safe "$SCAFFOLD_DIR/.scaffold.toml.template" ".scaffold.toml"
@@ -188,7 +276,7 @@ cp_safe "$SCAFFOLD_DIR/.scaffold.toml.template" ".scaffold.toml"
 # Python
 if [ "$MODE" = "python" ] || [ "$MODE" = "both" ]; then
   cp_safe "$SCAFFOLD_DIR/ruff.toml.template" "ruff.toml"
-  cp_safe "$SCAFFOLD_DIR/forbidden-patterns/backend.txt.template" ".forbidden-patterns/backend.txt"
+  cp_pattern "$SCAFFOLD_DIR/forbidden-patterns/backend.txt.template" ".forbidden-patterns/backend.txt"
   # Test-runner + coverage config (standalone, like ruff.toml — never edits
   # pyproject.toml). Skip pytest.ini if the project already configures pytest in
   # pyproject.toml/tox.ini/setup.cfg, since pytest.ini would silently override it.
@@ -203,7 +291,7 @@ fi
 # Frontend
 if [ "$MODE" = "frontend" ] || [ "$MODE" = "both" ]; then
   cp_safe "$SCAFFOLD_DIR/eslint.config.js.template" "eslint.config.js"
-  cp_safe "$SCAFFOLD_DIR/forbidden-patterns/frontend.txt.template" ".forbidden-patterns/frontend.txt"
+  cp_pattern "$SCAFFOLD_DIR/forbidden-patterns/frontend.txt.template" ".forbidden-patterns/frontend.txt"
   # TypeScript config the eslint type-aware rules + the tsc --noEmit hook/CI
   # step already assume (closes the gap where they silently degrade if absent).
   cp_safe "$SCAFFOLD_DIR/tsconfig.json.template" "tsconfig.json"
@@ -237,7 +325,7 @@ else
   if [ -f Gemfile ] || ls -1 ./*.gemspec >/dev/null 2>&1; then add_lang ruby; fi
 fi
 for L in $LANGS; do
-  cp_safe "$SCAFFOLD_DIR/forbidden-patterns/${L}.txt.template" ".forbidden-patterns/${L}.txt"
+  cp_pattern "$SCAFFOLD_DIR/forbidden-patterns/${L}.txt.template" ".forbidden-patterns/${L}.txt"
 done
 
 # Agent-runtime guardrails (opt-in: --claude / --cursor). Both runtimes share
@@ -246,7 +334,7 @@ done
 # existing .claude/settings.json or .cursor/hooks.json is left alone by cp_safe —
 # merge the template's keys in by hand.
 if [ "$CLAUDE" -eq 1 ] || [ "$CURSOR" -eq 1 ]; then
-  cp_safe "$SCAFFOLD_DIR/githooks/lib/agent-precheck.template" ".githooks/lib/agent-precheck"
+  cp_scaffold "$SCAFFOLD_DIR/githooks/lib/agent-precheck.template" ".githooks/lib/agent-precheck"
   mkx ".githooks/lib/agent-precheck"
   if ! command -v jq >/dev/null 2>&1; then
     echo "warning: jq not found — the agent precheck needs jq (it fails open without it): https://jqlang.github.io/jq/"
@@ -266,7 +354,7 @@ fi
 # Conventional-Commits commit-msg hook (opt-in: --commit-msg). Active the moment
 # it lands in core.hooksPath, so it's off by default to avoid surprising users.
 if [ "$COMMIT_MSG" -eq 1 ]; then
-  cp_safe "$SCAFFOLD_DIR/githooks/commit-msg.template" ".githooks/commit-msg"
+  cp_scaffold "$SCAFFOLD_DIR/githooks/commit-msg.template" ".githooks/commit-msg"
   mkx ".githooks/commit-msg"
 fi
 
@@ -275,7 +363,7 @@ fi
 # it here is what turns it on. Kept opt-in because a local scan only fires where
 # the gitleaks binary is present; pair it with gitleaks.yml.template in CI.
 if [ "$GITLEAKS_HOOK" -eq 1 ]; then
-  cp_safe "$SCAFFOLD_DIR/githooks/lib/check-gitleaks.template" ".githooks/lib/check-gitleaks"
+  cp_scaffold "$SCAFFOLD_DIR/githooks/lib/check-gitleaks.template" ".githooks/lib/check-gitleaks"
   mkx ".githooks/lib/check-gitleaks"
   if ! command -v gitleaks >/dev/null 2>&1; then
     echo "warning: gitleaks not found — the local pass fails open (skips) until you install it: https://github.com/gitleaks/gitleaks#installing"
@@ -288,7 +376,7 @@ fi
 # a policy choice a team must make deliberately. It gates EXECUTION of changed
 # lines, not assertion quality — see RECOMMENDATIONS.md.
 if [ "$COVERAGE_GATE" -eq 1 ]; then
-  cp_safe "$SCAFFOLD_DIR/.github/workflows/coverage.yml.template" ".github/workflows/coverage.yml"
+  cp_scaffold "$SCAFFOLD_DIR/.github/workflows/coverage.yml.template" ".github/workflows/coverage.yml"
   echo "note: coverage.yml gates patch coverage (default 100% of changed lines)."
   echo "      It forces changed lines to be RUN by a test, not verified — pair with review."
 fi

--- a/tests/cases/09-toolchain-clobber.sh
+++ b/tests/cases/09-toolchain-clobber.sh
@@ -239,3 +239,109 @@ else
 fi
 rm -rf "$UCI"
 reset_repo
+
+# --- installer upgrade story: re-runs refresh scaffold-owned code -------------
+# A plain re-run must REFRESH scaffold-owned code (check-*, libs, hooks,
+# workflows) so security fixes reach an upgrader who just re-runs install.sh,
+# LEAVE user-owned files alone, and NOTIFY (never silently overwrite) on
+# .forbidden-patterns/*.txt drift. Each upgrade scenario installs once, mutates
+# one file to simulate the prior state, then re-runs and asserts the outcome.
+
+# (T) re-run refreshes a STALE scaffold-owned scanner to the shipped version,
+#     without --force — the core upgrade path the design note called for.
+#     Simulate an older installed scanner by clobbering it, then re-run and
+#     assert it matches the template again, is announced as updated, and stays
+#     executable (the post-copy chmod must still run on the refreshed file).
+URS=$(mktemp -d)
+( cd "$URS" && git init --quiet && echo '{"name":"x"}' >package.json \
+  && "$SCAFFOLD_DIR/install.sh" --frontend --no-verify >/dev/null 2>&1 )
+printf '#!/usr/bin/env bash\n# STALE OLD VERSION\nexit 0\n' >"$URS/.githooks/lib/check-secrets"
+( cd "$URS" && "$SCAFFOLD_DIR/install.sh" --frontend --no-verify ) >"$HOOK_OUT" 2>&1
+if cmp -s "$SCAFFOLD_DIR/githooks/lib/check-secrets.template" "$URS/.githooks/lib/check-secrets" \
+   && [ -x "$URS/.githooks/lib/check-secrets" ] \
+   && grep -q 'updated:.*check-secrets' "$HOOK_OUT"; then
+  echo "  ✓ re-run refreshes a stale scaffold-owned scanner to the shipped version"; PASS=$((PASS + 1))
+else
+  echo "  ✗ re-run did not refresh the stale scanner"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$URS"
+
+# (T) re-run refreshes a stale scaffold-owned WORKFLOW (lint.yml) too — the
+#     guardrails job hardening has to reach upgraders, not just the scanners.
+URW=$(mktemp -d)
+( cd "$URW" && git init --quiet && echo '{"name":"x"}' >package.json \
+  && "$SCAFFOLD_DIR/install.sh" --frontend --no-verify >/dev/null 2>&1 )
+echo '# stale workflow' >"$URW/.github/workflows/lint.yml"
+( cd "$URW" && "$SCAFFOLD_DIR/install.sh" --frontend --no-verify ) >"$HOOK_OUT" 2>&1
+if cmp -s "$SCAFFOLD_DIR/.github/workflows/lint.yml.template" "$URW/.github/workflows/lint.yml" \
+   && grep -q 'updated:.*lint.yml' "$HOOK_OUT"; then
+  echo "  ✓ re-run refreshes a stale scaffold-owned workflow"; PASS=$((PASS + 1))
+else
+  echo "  ✗ re-run did not refresh the stale workflow"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$URW"
+
+# (T) re-run LEAVES a user-edited, user-owned config alone — no refresh, no
+#     backup. The scaffold-owned auto-update must not bleed into user files.
+UUE=$(mktemp -d)
+( cd "$UUE" && git init --quiet && echo 'name="x"' >pyproject.toml \
+  && "$SCAFFOLD_DIR/install.sh" --python --no-verify >/dev/null 2>&1 )
+echo '# my local ruff tweak' >>"$UUE/ruff.toml"
+( cd "$UUE" && "$SCAFFOLD_DIR/install.sh" --python --no-verify ) >"$HOOK_OUT" 2>&1
+if grep -q 'my local ruff tweak' "$UUE/ruff.toml" \
+   && grep -q 'skip (exists): ruff.toml' "$HOOK_OUT" \
+   && [ ! -e "$UUE/ruff.toml.scaffold-bak" ]; then
+  echo "  ✓ re-run leaves a user-edited config untouched (no refresh, no backup)"; PASS=$((PASS + 1))
+else
+  echo "  ✗ re-run should leave a user-owned config alone"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$UUE"
+
+# (T) re-run NOTIFIES on .forbidden-patterns drift and KEEPS the user's custom
+#     rules — these files are scaffold-shipped AND user-extended, so a silent
+#     overwrite would clobber a team's added rows. Notify, never overwrite.
+UPD=$(mktemp -d)
+( cd "$UPD" && git init --quiet && echo '{"name":"x"}' >package.json \
+  && "$SCAFFOLD_DIR/install.sh" --frontend --no-verify >/dev/null 2>&1 )
+printf '\nMYCUSTOMRULE\tmy custom rule\n' >>"$UPD/.forbidden-patterns/secrets.txt"
+( cd "$UPD" && "$SCAFFOLD_DIR/install.sh" --frontend --no-verify ) >"$HOOK_OUT" 2>&1
+if grep -q 'MYCUSTOMRULE' "$UPD/.forbidden-patterns/secrets.txt" \
+   && grep -q 'note (drift)' "$HOOK_OUT" && grep -q 'secrets.txt' "$HOOK_OUT"; then
+  echo "  ✓ re-run notifies on forbidden-patterns drift, keeps user rules"; PASS=$((PASS + 1))
+else
+  echo "  ✗ re-run should notify (not overwrite) on pattern drift"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$UPD"
+
+# (T) --force on a drifted pattern file backs up the user's version, then
+#     installs the shipped one (the user's rows land in .scaffold-bak to merge
+#     back) — the documented escape hatch from the drift note.
+UPF=$(mktemp -d)
+( cd "$UPF" && git init --quiet && echo '{"name":"x"}' >package.json \
+  && "$SCAFFOLD_DIR/install.sh" --frontend --no-verify >/dev/null 2>&1 )
+printf '\nMYCUSTOMRULE\tmy custom rule\n' >>"$UPF/.forbidden-patterns/secrets.txt"
+( cd "$UPF" && "$SCAFFOLD_DIR/install.sh" --frontend --force --no-verify ) >"$HOOK_OUT" 2>&1
+if [ -f "$UPF/.forbidden-patterns/secrets.txt.scaffold-bak" ] \
+   && grep -q 'MYCUSTOMRULE' "$UPF/.forbidden-patterns/secrets.txt.scaffold-bak" \
+   && cmp -s "$SCAFFOLD_DIR/forbidden-patterns/secrets.txt.template" "$UPF/.forbidden-patterns/secrets.txt"; then
+  echo "  ✓ --force backs up a drifted pattern file then installs the shipped one"; PASS=$((PASS + 1))
+else
+  echo "  ✗ --force should back up then replace a drifted pattern file"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$UPF"
+
+# (T) a re-run over an already-current install is a CLEAN no-op: scaffold-owned
+#     files match the shipped version, so nothing is refreshed and no drift
+#     note fires. Guards against spurious churn / .scaffold-bak clutter on every
+#     routine re-run.
+UNO=$(mktemp -d)
+( cd "$UNO" && git init --quiet && echo '{"name":"x"}' >package.json \
+  && "$SCAFFOLD_DIR/install.sh" --frontend --no-verify >/dev/null 2>&1 )
+( cd "$UNO" && "$SCAFFOLD_DIR/install.sh" --frontend --no-verify ) >"$HOOK_OUT" 2>&1
+if ! grep -q 'updated:' "$HOOK_OUT" && ! grep -q 'note (drift)' "$HOOK_OUT"; then
+  echo "  ✓ re-run over a current install is a clean no-op"; PASS=$((PASS + 1))
+else
+  echo "  ✗ re-run churned an already-current install"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$UNO"
+reset_repo


### PR DESCRIPTION
## What

Resolves the **installer upgrade story** tracked in `SECURITY_AUDIT.md`: a plain re-run of `install.sh` printed `skip (exists)` for every scaffold-owned scanner, so existing users never received security fixes just by re-running — the upgrade path was broken.

## How

Split `cp_safe`'s single "skip unless `--force`" policy into one shared write **mechanism** (`_cp_replace` + `_backup`, holding the A7 symlink defenses) and three ownership **policies**:

| Policy | Files | Re-run behavior |
|---|---|---|
| `cp_scaffold` | `pre-commit`, all `.githooks/lib/*`, `commit-msg`, `lint.yml`, `coverage.yml` | **Refreshes on diff, no `--force`** → security fixes reach upgraders. Identical → silent no-op. Announced `updated:`. |
| `cp_safe` (unchanged) | `ruff.toml`, eslint/tsconfig/prettier/vitest, `.scaffold.toml`, `dependabot.yml`, rules docs | Skip unless `--force` (backs up first) |
| `cp_pattern` | `.forbidden-patterns/*.txt` | **Notify on drift** (`note (drift):`), keep user file; `--force` backs up user rows to `.scaffold-bak` then writes shipped |

A dangling symlink at a scaffold-owned path is now replaced with the real scanner even without `--force` (more correct — a broken link means the scanner wasn't running), and the `rm -f`-before-`cp` guarantee still prevents writing *through* the link.

## Tests

Red-then-green in `tests/cases/09` — 6 new cases (refresh-stale-scanner, refresh-stale-workflow, leave-user-config, notify-on-pattern-drift, `--force`-backs-up-drift, clean-no-op-when-current). The 3 new-behavior assertions were confirmed failing before the change, passing after.

- Suite: **164 passed, 0 failed**
- `shellcheck install.sh`: clean
- Both changed files under the 500-line cap; repo's own dogfood `pre-commit` accepts them

## Scope

Deliberately limited to code/libs/workflows per the design note: the markdown rules docs (`coding-rules.md`/`operational-rules.md`) and `dependabot.yml` stay user-owned (`cp_safe`), since teams localize them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)