### PR TITLE
feat(npm): distribute via npx ai-coding-rules-scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,20 @@ Language pattern files auto-install when their manifest is detected (`go.mod`, `
 
 ## Install
 
-Clone the scaffold somewhere stable:
+**Quickest — `npx`, no clone.** From your project root:
+
+```sh
+npx ai-coding-rules-scaffold            # auto-detects Python / JS
+npx ai-coding-rules-scaffold --both     # or pick the stack explicitly
+```
+
+This fetches the pinned package and runs the same installer documented below —
+every flag in the list further down works after `npx ai-coding-rules-scaffold …`.
+Needs Node ≥ 14 and `bash` (preinstalled on macOS/Linux; use Git Bash or WSL on
+Windows). The package has zero dependencies — it's just the installer + templates.
+
+**Or clone + run** (language-agnostic, no Node required). Clone the scaffold
+somewhere stable:
 
 ```sh
 # Recommended: pin to a tagged release for reproducibility

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+'use strict';
+
+// Thin wrapper so `npx ai-coding-rules-scaffold` runs the same install.sh the
+// git-clone path uses. The installer is pure bash and reads its templates from
+// its own directory ($SCAFFOLD_DIR), writing only into the caller's cwd — so we
+// exec it from the package root (read-only node_modules location) with cwd left
+// at the user's project. Args pass straight through (--both, --frontend, etc.).
+//
+// No npm dependencies on purpose: this uses only Node built-ins, so the package
+// installs instantly and there is no lockfile / supply-chain surface to audit.
+
+const { spawnSync } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+
+const pkgRoot = path.resolve(__dirname, '..');
+const installer = path.join(pkgRoot, 'install.sh');
+
+if (!fs.existsSync(installer)) {
+  process.stderr.write(
+    'ai-coding-rules-scaffold: install.sh is missing from the package at ' +
+      pkgRoot +
+      '.\nThis is a packaging bug — please report it at ' +
+      'https://github.com/Sting25/ai-coding-rules-scaffold/issues\n'
+  );
+  process.exit(1);
+}
+
+const result = spawnSync('bash', [installer, ...process.argv.slice(2)], {
+  stdio: 'inherit',
+  cwd: process.cwd(),
+});
+
+if (result.error) {
+  if (result.error.code === 'ENOENT') {
+    process.stderr.write(
+      'ai-coding-rules-scaffold: `bash` was not found on PATH.\n' +
+        'This installer needs bash — preinstalled on macOS/Linux; on Windows ' +
+        'run it from Git Bash or WSL.\n'
+    );
+  } else {
+    process.stderr.write('ai-coding-rules-scaffold: ' + result.error.message + '\n');
+  }
+  process.exit(1);
+}
+
+// Propagate the installer's exit code (0 ok, non-zero on failure) so CI and
+// scripted callers see the real status.
+process.exit(result.status === null ? 1 : result.status);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,62 @@
+{
+  "name": "ai-coding-rules-scaffold",
+  "version": "0.9.0",
+  "description": "Agent-agnostic coding-rules scaffold: pre-commit + CI guardrails (file size, forbidden patterns, secret/credential scanning, hygiene) that install into your project. Run via `npx ai-coding-rules-scaffold`.",
+  "bin": {
+    "ai-coding-rules-scaffold": "bin/cli.js"
+  },
+  "files": [
+    "install.sh",
+    "uninstall.sh",
+    "bin/",
+    "githooks/",
+    "forbidden-patterns/",
+    "coding-rules.md",
+    "operational-rules.md",
+    "AGENTS.md.template",
+    "CLAUDE.md.pointer",
+    "claude-settings.json.template",
+    "cursor-hooks.json.template",
+    "eslint.config.js.template",
+    "tsconfig.json.template",
+    "vitest.config.ts.template",
+    ".prettierrc.json.template",
+    ".prettierignore.template",
+    "ruff.toml.template",
+    "pytest.ini.template",
+    ".coveragerc.template",
+    ".scaffold.toml.template",
+    ".github/dependabot.yml.template",
+    ".github/workflows/lint.yml.template",
+    ".github/workflows/coverage.yml.template"
+  ],
+  "engines": {
+    "node": ">=14"
+  },
+  "os": [
+    "darwin",
+    "linux"
+  ],
+  "keywords": [
+    "pre-commit",
+    "git-hooks",
+    "linting",
+    "secrets",
+    "secret-scanning",
+    "security",
+    "guardrails",
+    "scaffold",
+    "ci",
+    "ai-coding",
+    "code-review"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Sting25/ai-coding-rules-scaffold.git"
+  },
+  "homepage": "https://github.com/Sting25/ai-coding-rules-scaffold#readme",
+  "bugs": {
+    "url": "https://github.com/Sting25/ai-coding-rules-scaffold/issues"
+  },
+  "license": "MIT"
+}

--- a/tests/cases/11-npm-bundle.sh
+++ b/tests/cases/11-npm-bundle.sh
@@ -1,0 +1,62 @@
+# shellcheck shell=bash
+# cases/11-npm-bundle.sh — guard the npm package against bundle drift. The npm
+# distribution (`npx ai-coding-rules-scaffold`) ships the SAME install.sh +
+# template tree as the git-clone path, selected by package.json's "files"
+# allowlist. If install.sh starts reading a new template but it's forgotten in
+# "files", git-clone users are fine while npm users get a SILENT broken install
+# (a missing source file surfaces only mid-install on someone else's machine).
+# So derive the required-file set from install.sh itself and assert every entry
+# is in the packed tarball — the allowlist can't drift out of sync undetected.
+#
+# Skips (does not fail) when npm or jq is unavailable, so the suite still runs on
+# a minimal box; GitHub runners have both, so this is real coverage in CI.
+
+echo "cases/11 — npm package bundle completeness"
+
+if ! command -v npm >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1; then
+  echo "  ~ skipped (npm or jq not available)"
+else
+  C11=$(mktemp)
+  # PACKED: exactly what `npm publish` would ship, per the "files" allowlist.
+  if ( cd "$SCAFFOLD_DIR" && npm pack --dry-run --json 2>/dev/null ) >"$C11"; then
+    PACKED=$(jq -r '.[0].files[].path' "$C11" 2>/dev/null | sort -u)
+
+    # REQUIRED: every static $SCAFFOLD_DIR/<path> install.sh reads, the two
+    # dynamically-globbed dirs (${L}.txt.template / ${check}.template) expanded
+    # to their real members, plus the installer scripts and the npm wrapper.
+    REQUIRED=$(
+      {
+        # SC2016 off on purpose: we match the LITERAL text "$SCAFFOLD_DIR" / "${"
+        # as it appears in install.sh's source, so single quotes (no expansion)
+        # are exactly right.
+        # shellcheck disable=SC2016
+        grep -oE '\$SCAFFOLD_DIR/[^"'"'"' ]+' "$SCAFFOLD_DIR/install.sh" \
+          | sed 's#\$SCAFFOLD_DIR/##' | grep -v '\${'
+        ( cd "$SCAFFOLD_DIR" \
+            && ls forbidden-patterns/*.txt.template githooks/*.template githooks/lib/*.template )
+        printf '%s\n' install.sh uninstall.sh bin/cli.js
+      } | sort -u
+    )
+
+    missing=0
+    while IFS= read -r req; do
+      [ -z "$req" ] && continue
+      if ! grep -qxF "$req" <<<"$PACKED"; then
+        echo "  ✗ MISSING from npm bundle (add to package.json \"files\"): $req"
+        missing=$((missing + 1))
+      fi
+    done <<<"$REQUIRED"
+
+    n=$(grep -c . <<<"$REQUIRED")
+    if [ "$missing" -eq 0 ] && [ -n "$PACKED" ]; then
+      echo "  ✓ every install.sh source file is in the npm bundle ($n checked)"
+      PASS=$((PASS + 1))
+    else
+      echo "  ✗ npm bundle is missing $missing of $n required source file(s)"
+      FAIL=$((FAIL + 1))
+    fi
+  else
+    echo "  ✗ npm pack --dry-run failed"; sed 's/^/      /' "$C11"; FAIL=$((FAIL + 1))
+  fi
+  rm -f "$C11"
+fi

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -45,7 +45,8 @@ for case_file in \
   "$HERE/cases/07-agent-commit.sh" \
   "$HERE/cases/08-overrides-gitleaks.sh" \
   "$HERE/cases/09-toolchain-clobber.sh" \
-  "$HERE/cases/10-ci-diff-scope.sh"; do
+  "$HERE/cases/10-ci-diff-scope.sh" \
+  "$HERE/cases/11-npm-bundle.sh"; do
   # shellcheck source=/dev/null
   . "$case_file"
 done


### PR DESCRIPTION
First half of the "easier install" work: an **npm package** so JS-stack users install with no clone —

```sh
npx ai-coding-rules-scaffold        # auto-detects Python / JS
```

## What's here
- **`package.json`** — `bin` → `bin/cli.js`; a `files` allowlist that bundles `install.sh` + the whole template tree (`githooks/`, `forbidden-patterns/`, and the root + workflow templates `install.sh` reads). **Zero dependencies**, MIT, `node >=14`, `os: [darwin, linux]`.
- **`bin/cli.js`** — thin wrapper that execs `bash install.sh` from the (read-only) package root with `cwd` at the user's project, forwarding args + exit code. Clear errors when `bash` or the installer is missing. No npm deps → no lockfile / supply-chain surface.
- **`tests/cases/11-npm-bundle.sh`** — bundle-completeness guard. Derives the required-file set **from `install.sh`'s own `$SCAFFOLD_DIR` references** (static paths + the globbed `githooks/` and `forbidden-patterns/` dirs) and asserts every one is in `npm pack`'s output. This stops the `files` allowlist from silently drifting and shipping a broken install to npm users (clone users would be unaffected — exactly the silent-failure class the project guards against). Skips when npm/jq absent; runs for real on CI.
- **README** — leads with the `npx` option.

## Verification
- End-to-end: `npm pack` → install the tarball into a throwaway consumer project → run the bin → **the installed hook gates a committed secret**.
- Bundle guard teeth: dropping `forbidden-patterns/` from `files` turns cases/11 red with specific MISSING lines.
- Self-lint simulated over the whole tree incl. `bin/cli.js` + `package.json` — clean.
- Suite **174 → 175**. shellcheck clean at `-S info`.

## Not in this PR
- **Publishing to npm** is a maintainer step (needs npm auth) — see the follow-up for release automation.
- **Homebrew tap** is the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)