### PR TITLE
feat(homebrew): add formula + tap, document the release process

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,14 @@ every flag in the list further down works after `npx ai-coding-rules-scaffold �
 Needs Node ≥ 14 and `bash` (preinstalled on macOS/Linux; use Git Bash or WSL on
 Windows). The package has zero dependencies — it's just the installer + templates.
 
+**Or Homebrew** (macOS/Linux, no Node):
+
+```sh
+brew install sting25/tap/ai-coding-rules-scaffold
+# then, from your project root:
+ai-coding-rules-scaffold            # auto-detects Python / JS
+```
+
 **Or clone + run** (language-agnostic, no Node required). Clone the scaffold
 somewhere stable:
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,105 @@
+# Releasing
+
+The **git tag is the single source of truth** for the version. Everything else
+(the `package.json` version, the README clone pin, the Homebrew formula) is a
+derived copy that must be updated to match in the same release. This checklist
+keeps them from drifting.
+
+The version lives in these places — all must agree on `vX.Y.Z`:
+
+| Place | File | What to change |
+|-------|------|----------------|
+| git tag | — | annotated tag `vX.Y.Z` |
+| changelog | `CHANGELOG.md` | promote `[Unreleased]` → `[vX.Y.Z] — DATE` |
+| README pin | `README.md` | the `git clone --branch vX.Y.Z` line |
+| npm | `package.json` | `"version": "X.Y.Z"` |
+| Homebrew | `packaging/homebrew/ai-coding-rules-scaffold.rb` + the tap | `url` (tag) + `sha256` |
+
+## 1. Prepare (PR to `main`)
+
+1. Make sure `main` is green on both runners and `CHANGELOG.md`'s `[Unreleased]`
+   section lists everything since the last tag. (If entries were missed, back-fill
+   them — the changelog is the release notes.)
+2. Pick `X.Y.Z` per SemVer: bug-fix-only → patch; new features / behavior changes
+   → minor; breaking consumer-facing changes → major.
+3. In one PR:
+   - Promote `[Unreleased]` → `## [vX.Y.Z] — YYYY-MM-DD` in `CHANGELOG.md`.
+   - Bump the `git clone --branch` pin in `README.md`.
+   - Bump `"version"` in `package.json`.
+   - Run a self-lint dry run before pushing (a fat changelog can trip the secret
+     scanner on its own prose):
+     ```sh
+     mkdir -p .githooks/lib .forbidden-patterns
+     for t in githooks/lib/*.template; do cp "$t" ".githooks/lib/$(basename "$t" .template)"; done
+     for t in forbidden-patterns/*.txt.template; do cp "$t" ".forbidden-patterns/$(basename "$t" .template)"; done
+     git -c core.quotepath=off ls-files -z | .githooks/lib/check-secrets --ci
+     ```
+   - Open the PR, wait for CI green on **both** runners, merge (`--merge`, never
+     `--auto` — this repo has no branch protection).
+
+## 2. Tag + GitHub release
+
+```sh
+git checkout main && git pull --ff-only
+git tag -a vX.Y.Z -m "vX.Y.Z — <one-line summary>"
+git push origin vX.Y.Z
+# Release notes = the CHANGELOG section for this version:
+awk '/^## \[vX\.Y\.Z\]/{f=1} /^## \[/{if(f && !/vX\.Y\.Z/)exit} f' CHANGELOG.md > /tmp/notes.md
+gh release create vX.Y.Z --title "vX.Y.Z — <summary>" --notes-file /tmp/notes.md
+```
+
+Confirm it's latest: `gh release list` shows `vX.Y.Z` marked **Latest**.
+
+## 3. Publish to npm
+
+```sh
+npm publish            # needs `npm login` first; npm may prompt for a 2FA OTP
+npm view ai-coding-rules-scaffold version   # confirm it shows X.Y.Z
+```
+
+The package has zero dependencies, so there's no lockfile to manage. `npx
+ai-coding-rules-scaffold` resolves the new version automatically.
+
+## 4. Update the Homebrew tap
+
+The formula's `url` points at the GitHub source tarball for the tag; bump the
+`url` + recompute the `sha256`:
+
+```sh
+SHA=$(curl -fsSL https://github.com/Sting25/ai-coding-rules-scaffold/archive/refs/tags/vX.Y.Z.tar.gz | shasum -a 256 | awk '{print $1}')
+echo "$SHA"
+```
+
+Edit `packaging/homebrew/ai-coding-rules-scaffold.rb` (canonical source) — set the
+`url` tag to `vX.Y.Z` and `sha256` to `$SHA` — then copy the file into the tap
+(`Sting25/homebrew-tap` → `Formula/ai-coding-rules-scaffold.rb`) and push.
+
+Validate before pushing the tap (with Homebrew installed):
+
+```sh
+brew style  packaging/homebrew/ai-coding-rules-scaffold.rb   # via a local tap; see below
+brew install sting25/tap/ai-coding-rules-scaffold            # after the tap push
+brew test    sting25/tap/ai-coding-rules-scaffold            # runs the install-into-a-repo assertions
+brew uninstall ai-coding-rules-scaffold                      # clean up
+```
+
+> `brew style`/`audit` only apply the formula cops inside a tap. To lint locally:
+> `brew tap-new you/localtest --no-git`, copy the `.rb` into its `Formula/`, then
+> `brew style you/localtest/ai-coding-rules-scaffold`. Untap when done.
+
+## 5. Smoke-test both registries
+
+```sh
+# npm
+npx -y ai-coding-rules-scaffold@X.Y.Z --help
+# Homebrew
+brew install sting25/tap/ai-coding-rules-scaffold && ai-coding-rules-scaffold --help
+```
+
+## Future: automate
+
+This is currently manual on purpose (it needs the maintainer's npm + GitHub
+auth). A `release.yml` triggered on tag push could publish to npm (with an
+`NPM_TOKEN` secret) and open a PR to the tap bumping `url`/`sha256` (with a
+tap-scoped PAT) — deriving every copy from the tag so steps 3–4 can't drift.
+Worth adding once the cadence justifies the secret setup.

--- a/packaging/homebrew/ai-coding-rules-scaffold.rb
+++ b/packaging/homebrew/ai-coding-rules-scaffold.rb
@@ -1,0 +1,68 @@
+# Homebrew formula for ai-coding-rules-scaffold.
+#
+# CANONICAL SOURCE. The installable copy lives in the tap repo
+# (Sting25/homebrew-tap) as Formula/ai-coding-rules-scaffold.rb; this copy is
+# version-controlled here so it's reviewed alongside the code and validated in
+# CI. On each release, bump `url` (the tag) + `sha256` and sync this file to the
+# tap (see RELEASING.md). The sha256 is of the GitHub source tarball:
+#   curl -fsSL .../archive/refs/tags/vX.Y.Z.tar.gz | shasum -a 256
+class AiCodingRulesScaffold < Formula
+  desc "Pre-commit and CI guardrails: size, pattern, secret, and hygiene checks"
+  homepage "https://github.com/Sting25/ai-coding-rules-scaffold"
+  url "https://github.com/Sting25/ai-coding-rules-scaffold/archive/refs/tags/v0.9.0.tar.gz"
+  sha256 "38c2b1ee5b732ff41a7440ba3a85513132ff47c66b29ee7b189176a36400aa34"
+  license "MIT"
+
+  def install
+    # The installer is pure bash and reads its templates from its own directory,
+    # writing only into the caller's cwd — so stage the whole tree in libexec and
+    # expose a wrapper on PATH that execs it. Args (--both, --frontend, …) pass
+    # straight through; the wrapper inherits the user's cwd as the install target.
+    #
+    # Dir["*"] alone SKIPS dotfiles, dropping .github/ and the dot-templates
+    # (.scaffold.toml.template, .coveragerc.template, .prettierrc.json.template,
+    # .prettierignore.template) that install.sh copies — so glob both and exclude
+    # only "." / "..". (Release tarballs carry no .git, so this is safe.)
+    # Drop only the "." / ".." self/parent entries; keep everything else,
+    # dotfiles included. The skip list is hoisted out of the block so there's no
+    # array literal inside it (brew style: Performance/CollectionLiteralInLoop).
+    skip = [".", ".."]
+    entries = (Dir["*"] + Dir[".*"]).reject { |f| skip.include?(File.basename(f)) }
+    libexec.install entries
+    (bin/"ai-coding-rules-scaffold").write <<~SH
+      #!/bin/bash
+      exec "#{libexec}/install.sh" "$@"
+    SH
+  end
+
+  def caveats
+    <<~EOS
+      Run it from your project's root to install the guardrails into that repo:
+        ai-coding-rules-scaffold            # auto-detects Python / JS
+        ai-coding-rules-scaffold --both     # or pick the stack explicitly
+        ai-coding-rules-scaffold --help     # all flags
+
+      The optional agent guardrails (--claude / --cursor) need jq:
+        brew install jq
+    EOS
+  end
+
+  test do
+    assert_match "Usage", shell_output("#{bin}/ai-coding-rules-scaffold --help")
+
+    # Full install into a throwaway repo — exercises the whole template copy, not
+    # just --help, so a missing-bundle regression (e.g. dropped dotfiles like
+    # .github/workflows/lint.yml.template) fails the formula test, not the user.
+    (testpath/"proj").mkpath
+    cd testpath/"proj" do
+      system "git", "init", "-q"
+      system "git", "config", "user.email", "t@example.com"
+      system "git", "config", "user.name", "Test"
+      (testpath/"proj/package.json").write('{"name":"t"}')
+      system bin/"ai-coding-rules-scaffold", "--frontend", "--no-verify"
+      assert_path_exists testpath/"proj/.githooks/pre-commit"
+      assert_path_exists testpath/"proj/.forbidden-patterns/secrets.txt"
+      assert_path_exists testpath/"proj/.github/workflows/lint.yml"
+    end
+  end
+end


### PR DESCRIPTION
Second half of the easier-install work — **Homebrew**:

```sh
brew install sting25/tap/ai-coding-rules-scaffold
```

The tap repo ([Sting25/homebrew-tap](https://github.com/Sting25/homebrew-tap)) is **live and validated**; this PR lands the canonical formula source + docs in the main repo.

## What's here
- **`packaging/homebrew/ai-coding-rules-scaffold.rb`** — canonical formula source (installable copy lives in the tap). Stages the whole tree in `libexec`, exposes a wrapper that execs `install.sh` against the user's cwd.
- **`README.md`** — adds the `brew install` option.
- **`RELEASING.md`** — the **git tag is the single source of truth**; per-release checklist bumps the derived copies (CHANGELOG, README pin, `package.json` version, formula `url`+`sha256`) so the three version sites can't drift.

## Bug caught during validation
`libexec.install Dir["*"]` **silently skips dotfiles** — `.github/` and the dot-templates were dropped, so `install.sh` died mid-copy. `brew test` passed anyway because it only ran `--help`. Fixed to glob dotfiles, and the **test block now does a full install-into-a-repo** asserting the hook + `secrets.txt` + `.github/workflows/lint.yml` land — so the bundle bug can't recur silently (the Homebrew analogue of `cases/11` for npm).

## Verification (against the REAL published tap, not a local one)
- `brew install sting25/tap/ai-coding-rules-scaffold` → 72 files → installed hook **gates a committed secret**.
- `brew style` clean; `brew audit --new` clean; `brew test` exit 0.
- Self-lint sim clean over the formula (its 64-char `sha256` does **not** trip the secret scanner — confirms the A8 boundary-anchoring).
- Suite still **175**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)