### PR TITLE
chore(dev): add scripts/dev-setup.sh to bootstrap local dogfooding

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -19,4 +19,4 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           persist-credentials: false
-      - run: shellcheck -S info install.sh uninstall.sh tests/run.sh tests/lib/common.sh tests/cases/*.sh githooks/pre-commit.template githooks/lib/check-size.template githooks/lib/check-patterns.template githooks/lib/check-filenames.template githooks/lib/check-secrets.template githooks/lib/check-hygiene.template githooks/lib/ci-changed-files.template githooks/lib/agent-precheck.template githooks/commit-msg.template
+      - run: shellcheck -S info install.sh uninstall.sh scripts/dev-setup.sh tests/run.sh tests/lib/common.sh tests/cases/*.sh githooks/pre-commit.template githooks/lib/check-size.template githooks/lib/check-patterns.template githooks/lib/check-filenames.template githooks/lib/check-secrets.template githooks/lib/check-hygiene.template githooks/lib/ci-changed-files.template githooks/lib/agent-precheck.template githooks/commit-msg.template

--- a/README.md
+++ b/README.md
@@ -511,6 +511,24 @@ Safe mode only removes files whose content matches the current scaffold template
 | Claude Code agent-runtime hooks (`.claude/settings.json` `PreToolUse`) | Deferred — see [`RECOMMENDATIONS.md`](./RECOMMENDATIONS.md) for design space and tradeoffs |
 | `git worktree` orchestration for parallel agent sessions | Documented in `AGENTS.md`; not automated |
 
+## Developing on the scaffold itself
+
+The scaffold can't install itself — `install.sh` refuses to run with the scaffold
+directory as the target (it would copy the `*.template` files onto their own
+sources). So a fresh clone has **no active hooks** until you bootstrap them:
+
+```sh
+scripts/dev-setup.sh
+```
+
+This renders the `*.template` sources into the gitignored `.githooks/` and
+`.forbidden-patterns/` — the same files `install.sh` writes into a consumer
+project and `self-lint.yml` renders in CI — and points `core.hooksPath` at
+`.githooks`, so commits in this repo run the scaffold's own guardrails, including
+the Conventional-Commits `commit-msg` hook. Edit a `*.template`, re-run the script
+to refresh. Only the `*.template` files are tracked; the rendered copies are
+build artifacts.
+
 ## Using this without an AI
 
 The scaffold works fine without any AI tool. Drop the files in, run the hook — same enforcement. `coding-rules.md` is just a named place to put the rules humans should read.

--- a/scripts/dev-setup.sh
+++ b/scripts/dev-setup.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# scripts/dev-setup.sh — bootstrap local dogfooding for the scaffold's OWN repo.
+#
+# The scaffold can't install itself (install.sh refuses to run with the scaffold
+# dir as the target, by design), so a fresh clone has NO active hooks. This
+# renders the *.template sources into the gitignored .githooks/ and
+# .forbidden-patterns/ — the same files install.sh writes into a consumer project
+# and self-lint.yml renders in CI — and points core.hooksPath at .githooks. After
+# running it, committing in this repo runs the scaffold's own guardrails,
+# including the opt-in commit-msg (Conventional Commits) hook.
+#
+# Idempotent: re-run any time to refresh after editing a template. The rendered
+# files are gitignored build artifacts; only the *.template sources are tracked,
+# so there is exactly one source of truth.
+
+set -euo pipefail
+
+# Resolve the repo root from this script's own location, so it works from any cwd.
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+cd "$ROOT"
+
+if [ ! -f githooks/pre-commit.template ]; then
+  echo "error: run this from a clone of ai-coding-rules-scaffold (githooks/*.template not found)" >&2
+  exit 1
+fi
+
+mkdir -p .githooks/lib .forbidden-patterns
+
+# Top-level hooks — including the opt-in commit-msg: the repo dogfoods everything
+# it ships, even the hooks that are opt-in for downstream consumers.
+cp githooks/pre-commit.template .githooks/pre-commit
+cp githooks/commit-msg.template .githooks/commit-msg
+
+# Scanner libs + language/secret pattern files.
+for t in githooks/lib/*.template; do
+  cp "$t" ".githooks/lib/$(basename "$t" .template)"
+done
+for t in forbidden-patterns/*.txt.template; do
+  cp "$t" ".forbidden-patterns/$(basename "$t" .template)"
+done
+
+chmod +x .githooks/pre-commit .githooks/commit-msg .githooks/lib/*
+
+git config core.hooksPath .githooks
+
+libs=(.githooks/lib/*)
+pats=(.forbidden-patterns/*.txt)
+echo "✓ dev hooks rendered; core.hooksPath -> .githooks"
+echo "  active: pre-commit, commit-msg, ${#libs[@]} scanners, ${#pats[@]} pattern files"
+echo "  (gitignored build artifacts — edit the *.template sources, then re-run this script)"


### PR DESCRIPTION
Makes the scaffold's own dogfooding **reproducible**. Today a fresh clone runs *none* of the scaffold's guardrails — `install.sh` refuses self-install, `self-lint.yml` only renders the scanners server-side, and nothing tracked sets `core.hooksPath`. The repo's local dogfooding "worked" only because a working copy was hand-wired once; a new contributor (or a fresh agent environment) gets nothing.

## What's here
- **`scripts/dev-setup.sh`** — renders the `*.template` sources into the gitignored `.githooks/` + `.forbidden-patterns/` (incl. the opt-in `commit-msg` hook — the repo dogfoods everything it ships) and points `core.hooksPath` at `.githooks`. Idempotent; rendered files stay gitignored build artifacts so the templates remain the single source of truth.
- **`shellcheck.yml`** — lints the new script in CI.
- **README** — new "Developing on the scaffold itself" section.

## Why a script, not committed hooks
`.githooks/` is gitignored on purpose — committing the rendered hooks would double-track the `*.template` sources and let them drift. The reproducible, trackable thing is the *bootstrap*, not its output.

## Verification
From a **truly fresh clone** (`core.hooksPath` UNSET, no `.githooks/`): after `scripts/dev-setup.sh`, pre-commit blocks a forbidden pattern + a secret, and `commit-msg` rejects a non-conventional subject while accepting a conventional one. shellcheck `-S info` clean; self-lint sim clean over the new script; suite **175**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)