### PR TITLE
fix: block symlink write-through in CLAUDE.md/AGENTS.md install handlers (audit B1)

### DIFF
--- a/SECURITY_AUDIT.md
+++ b/SECURITY_AUDIT.md
@@ -27,7 +27,7 @@ baseline.
 
 ### 🟠 High
 
-**B1 — `install_claude_md` / `install_agents_md` write THROUGH a symlink (A7-class, in the two handlers the A7 fix never touched)** — `install.sh:218,233,241` · **NOVEL**
+**B1 — `install_claude_md` / `install_agents_md` write THROUGH a symlink (A7-class, in the two handlers the A7 fix never touched)** — `install.sh:218,233,241` · **NOVEL** · ✅ **FIXED** (`fix/audit-b1-claude-agents-symlink`)
 - **What:** the A7 symlink defense (`[ -e ] || [ -L ]`, `rm -f` before `cp`, `cp -P` backups)
   lives only in `_cp_replace`/`_backup`/`cp_safe`/`cp_scaffold`/`cp_pattern`. The two bespoke
   merge handlers still use the pre-A7 `[ -e ]`-only guard around a raw `cp`/`>>` redirect.
@@ -42,10 +42,18 @@ baseline.
   stays a symlink, no real file, and `head -1 "$OUT"` prints `# CLAUDE.md` (the pointer written
   outside). **Control:** the same planted dangling symlink at `coding-rules.md` (A7-defended
   `cp_safe` path) is refused (`skip (exists, symlink)`) and writes nothing outside.
-- **Fix:** give both handlers the A7 treatment — gate on `[ -e ] || [ -L ]`, `rm -f` the path
+- **Fix (proposed):** give both handlers the A7 treatment — gate on `[ -e ] || [ -L ]`, `rm -f` the path
   before a create `cp` so a real regular file lands in the repo, and for the `CLAUDE.md` append
   branch refuse (skip with the "symlink, suspicious" notice) when `[ -L CLAUDE.md ]` rather than
   redirecting through the link. Add a `tests/cases/09`-style regression for both handlers.
+- **Fixed (as landed):** both handlers now test `[ -L ]` **first** and SKIP with a "symlink,
+  suspicious" notice — never writing through the link, for the dangling-create, live-append, and
+  AGENTS.md-create branches alike. Chose the `cp_safe` *user-owned* policy (skip + surface) over the
+  `cp_scaffold` *replace* policy, because `CLAUDE.md`/`AGENTS.md` are explicitly never clobbered (not
+  even with `--force`); a symlink there is left untouched and reported, never silently replaced.
+  Locked with three red→green tests in `tests/cases/09` (dangling `CLAUDE.md` create, live `CLAUDE.md`
+  append, dangling `AGENTS.md` create); each fails against the pre-fix handler and passes after — full
+  suite **178/0**, `shellcheck -S info` clean.
 
 **B2 — `check-hygiene` fails OPEN on over-cap lines: the A1 fail-closed fix never reached the hidden-Unicode (Trojan Source) and conflict-marker branches** — `githooks/lib/check-hygiene.template:106,163` · **already tracked but mis-prioritized + contradicts the A1 "FIXED" claim**
 - **What:** `check-secrets.template:159` carries the A1 fix (`awk '… { d=1; next } … END { exit (d ? 9 : 0) }'`,

--- a/install.sh
+++ b/install.sh
@@ -215,6 +215,15 @@ mkx() { if [ -f "$1" ]; then chmod +x "$1"; fi; }
 # the pointer template. If present, append a marked block importing AGENTS.md
 # once, and only if no @AGENTS.md import already exists.
 install_claude_md() {
+  # A symlink at CLAUDE.md is suspicious: `[ -e ]` is false for a DANGLING link
+  # (so the create branch's cp would write the pointer THROUGH it, outside the
+  # repo) and FOLLOWS a live one (so the `>>` append would append through it).
+  # Test `-L` first and never write through it — the same A7 defense the cp_*
+  # helpers carry, which this bespoke handler had been missing (B1).
+  if [ -L "CLAUDE.md" ]; then
+    echo "skip (exists, symlink): CLAUDE.md — left untouched; a scaffold path that is a symlink is suspicious. Replace it with a real file to wire the AGENTS.md import."
+    return
+  fi
   if [ ! -e "CLAUDE.md" ]; then
     cp "$SCAFFOLD_DIR/CLAUDE.md.pointer" "CLAUDE.md"
     echo "installed:    CLAUDE.md (new — pointer to AGENTS.md)"
@@ -238,6 +247,13 @@ install_claude_md() {
 # so an existing one is never clobbered (even with --force). Skip if present;
 # create from template only when absent.
 install_agents_md() {
+  # `[ -e ]` is false for a dangling symlink, so the create branch's cp would
+  # write the template THROUGH it to an outside path. Test `-L` first and skip
+  # (same A7 defense as the cp_* helpers, missing from this handler — B1).
+  if [ -L "AGENTS.md" ]; then
+    echo "skip (exists, symlink): AGENTS.md — left untouched; a scaffold path that is a symlink is suspicious. Replace it with a real file to install the template."
+    return
+  fi
   if [ -e "AGENTS.md" ]; then
     echo "skip (exists): AGENTS.md — left untouched (your Project section is safe)"
     return

--- a/tests/cases/09-toolchain-clobber.sh
+++ b/tests/cases/09-toolchain-clobber.sh
@@ -226,6 +226,54 @@ else
 fi
 rm -rf "$USD"
 
+# --- installer does not write THROUGH a symlink at CLAUDE.md / AGENTS.md (B1) --
+# The A7 symlink defense lived only in the cp_* helpers; install_claude_md /
+# install_agents_md kept the pre-A7 `[ -e ]`-only guard, so a symlink planted at
+# CLAUDE.md/AGENTS.md made cp (or the `>>` append) write the file content to the
+# link's target OUTSIDE the repo, leaving the rules silently un-wired. Guard all
+# three branches: CLAUDE.md create (dangling link), CLAUDE.md append (live link),
+# AGENTS.md create (dangling link).
+
+# (T) CLAUDE.md DANGLING symlink -> outside path: the create branch must NOT
+#     write the pointer through the link to the outside target.
+UCD=$(mktemp -d)
+ln -s "$UCD/nonexistent_claude" "$UCD/CLAUDE.md"
+( cd "$UCD" && git init --quiet && echo '{"name":"x"}' >package.json \
+  && "$SCAFFOLD_DIR/install.sh" --frontend --no-verify ) >"$HOOK_OUT" 2>&1
+if [ ! -e "$UCD/nonexistent_claude" ]; then
+  echo "  ✓ install does not write CLAUDE.md through a dangling symlink"; PASS=$((PASS + 1))
+else
+  echo "  ✗ install wrote the CLAUDE.md pointer through a dangling symlink"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$UCD"
+
+# (T) CLAUDE.md LIVE symlink -> outside file lacking @AGENTS.md: the append
+#     branch must NOT append the import block through the link to the outside file.
+UCL=$(mktemp -d)
+printf '# outside\nOUTSIDE_USER_CONTENT\n' >"$UCL/outside_claude"
+ln -s "$UCL/outside_claude" "$UCL/CLAUDE.md"
+( cd "$UCL" && git init --quiet && echo '{"name":"x"}' >package.json \
+  && "$SCAFFOLD_DIR/install.sh" --frontend --no-verify ) >"$HOOK_OUT" 2>&1
+if ! grep -q 'ai-coding-rules-scaffold:begin' "$UCL/outside_claude"; then
+  echo "  ✓ install does not append CLAUDE.md import through a live symlink"; PASS=$((PASS + 1))
+else
+  echo "  ✗ install appended the import through a live CLAUDE.md symlink"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$UCL"
+
+# (T) AGENTS.md DANGLING symlink -> outside path: the create branch must NOT
+#     write the template through the link to the outside target.
+UAD=$(mktemp -d)
+ln -s "$UAD/nonexistent_agents" "$UAD/AGENTS.md"
+( cd "$UAD" && git init --quiet && echo '{"name":"x"}' >package.json \
+  && "$SCAFFOLD_DIR/install.sh" --frontend --no-verify ) >"$HOOK_OUT" 2>&1
+if [ ! -e "$UAD/nonexistent_agents" ]; then
+  echo "  ✓ install does not write AGENTS.md through a dangling symlink"; PASS=$((PASS + 1))
+else
+  echo "  ✗ install wrote the AGENTS.md template through a dangling symlink"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$UAD"
+
 # (T) uninstall removes ci-changed-files too (install adds 8 libs; the uninstall
 #     loop dropped this one, leaving the scaffold half-uninstalled).
 UCI=$(mktemp -d)


### PR DESCRIPTION
## What

Closes audit finding **B1**. `install_claude_md` / `install_agents_md` in `install.sh` kept the pre-A7 `[ -e ]`-only guard around a raw `cp` / `>>` append. `[ -e ]` is **false for a dangling symlink** and **follows a live one**, so a symlink planted at `CLAUDE.md` / `AGENTS.md`:

- **dangling → create branch:** `cp` wrote the pointer/template **content to the link's target outside the repo**, leaving the in-repo path a dangling symlink;
- **live `CLAUDE.md` → append branch:** `>>"CLAUDE.md"` appended the scaffold block **through the link** to the outside file.

In every case no real file was created, the scaffold rules/import were silently never wired, and the installer reported `installed:` / `merged:`. This is the **A7 symlink class** the cp_* helpers already defend — just in the two bespoke merge handlers the A7 fix never touched.

## Fix

Both handlers now test `[ -L ]` **first** and skip with a "symlink, suspicious" notice — never writing through the link, for the dangling-create, live-append, and `AGENTS.md`-create branches alike.

Chose the **`cp_safe` user-owned policy** (skip + surface) over `cp_scaffold`'s replace policy, because `CLAUDE.md` / `AGENTS.md` are explicitly never clobbered (not even with `--force`); a symlink there is left untouched and reported, never silently replaced.

## Tests

Three red→green regression tests in `tests/cases/09` (dangling `CLAUDE.md` create, live `CLAUDE.md` append, dangling `AGENTS.md` create). Each fails against the pre-fix handler and passes after.

- Full suite: **178 / 0** (was 175/0 + 3 new)
- `shellcheck -S info`: clean
- whole-tree self-lint sim: clean
- Re-reproduced by hand: all three branches now write nothing outside the repo; the control (`coding-rules.md` via `cp_safe`) was already defended.

Also flips B1 → ✅ Fixed in `SECURITY_AUDIT.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)