### PR TITLE
docs: add "fix the file, not the guardrail" rule (operational-rules.md)

### DIFF
--- a/operational-rules.md
+++ b/operational-rules.md
@@ -119,6 +119,21 @@ trace back.
 "complete"; downstream pipelines built on the missing-rows-without-error
 state spent days untangling the resulting derived corruption.
 
+### Fix the file, not the guardrail — don't weaken a check to pass
+When a check goes red — a secret/pattern/size/hygiene scan, a lint
+or type error, a failing test — the default is to fix the offending
+FILE, not to weaken the check. Suppressions (`scaffold-allow`, a
+`.scaffold.toml` disable/downgrade, a loosened pattern, a skip-list
+entry, `--no-verify`) are a last resort: only for a genuine false
+positive AND only when fixing the file truly isn't possible, and
+then narrowly and with a recorded reason. A check weakened to turn
+green silently lowers the bar for every later commit and every
+consumer that inherits it — catching the thing was the point. If the
+check itself is wrong, fix the check and add a test; don't bypass it.
+*Anchor:* a guardrail flagged a file; exempting it was one line and
+fixing it a few — but an exemption, unlike a fix, never expires, so
+suppressions accrete until the scanner no longer scans.
+
 ### Hold shared-resource locks for contiguous work, not per operation
 When multiple processes contend for a single shared resource (GPU,
 DB connection from a small pool, hardware port, file lock),


### PR DESCRIPTION
## What

Adds a standing rule to `operational-rules.md` (Engineering section, after "No silent failures"):

> **Fix the file, not the guardrail — don't weaken a check to pass.** When a check goes red, the default is to fix the offending file, not to weaken the check. Suppressions (`scaffold-allow`, a `.scaffold.toml` disable/downgrade, a loosened pattern, a skip-list entry, `--no-verify`) are a last resort: only for a genuine false positive **and** only when fixing the file isn't possible, then narrowly and with a recorded reason. If the check itself is wrong, fix the check and add a test; don't bypass it.

## Why

Generalizes the narrower `--no-verify` / "fix the hook" note in `AGENTS.md` and the `scaffold-allow` caveats in `forbidden-patterns/README.md` into one place, and is the human-facing complement to audit finding **B13** (the engine *allows* disabling security rules; the rule says don't). A scaffold is its guardrails — an exemption, unlike a fix, never expires, so suppressions accrete until the scanner no longer scans.

Note: `operational-rules.md` is symlinked into the maintainer's global rules, so this also becomes a global working rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)