### PR TITLE
fix: check-hygiene fails closed on over-cap lines (audit B2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Security
+- **`check-hygiene` fails closed on over-long lines (B2, high).** The A1
+  fail-closed fix had only reached `check-secrets`/`check-patterns`; the
+  conflict-marker and hidden-Unicode (Trojan Source / CVE-2021-42574 / Rules
+  File Backdoor) branches still dropped any line over `MAX_LINE_LENGTH` (50k)
+  silently and exited 0, so a bidi override or zero-width char on a minified /
+  base64 blob rode straight through the scaffold's named defense. Both branches
+  now report the unscannable line and reject the commit, at the rule's
+  configured severity (a repo that downgraded the rule to `warn` still gets a
+  warn, not a hard block). Regressions in `tests/cases/06` (#45g, #45h).
+
 ## [v0.9.0] — 2026-06-30
 
 A security-hardening release. A full multi-dimension re-audit of the scaffold's

--- a/SECURITY_AUDIT.md
+++ b/SECURITY_AUDIT.md
@@ -14,16 +14,17 @@ baseline.
 
 | Severity | Count | Novel | Already tracked / by-design |
 |---|---|---|---|
-| high | 2 | 1 (B1) | 1 (B2 — A1 fix never reached check-hygiene) |
+| high | 2 | 1 (B1 ✅) | 1 (B2 ✅ — A1 fix never reached check-hygiene) |
 | medium | 4 | 2 (B3, B4) | 2 (B5, B6) |
 | low | 6 | 4 (B8–B11) | 2 (B7 variant, B12) |
 | info / by-design | 1 | 0 | B13 |
 
-> Two High findings are the actionable headline. **B1** is a genuinely new location of the
-> already-fixed A7 symlink class. **B2** shows the A1 "fail-closed on over-cap lines" fix —
-> recorded as FIXED in the section below — was only applied to `check-secrets`/`check-patterns`
-> and **never reached `check-hygiene`'s hidden-Unicode (Trojan Source) branch**, so that gate
-> still fails OPEN. Both were re-reproduced by hand.
+> Two High findings were the actionable headline; **both are now ✅ FIXED**. **B1** was a genuinely
+> new location of the already-fixed A7 symlink class. **B2** showed the A1 "fail-closed on over-cap
+> lines" fix — recorded as FIXED in the section below — had only been applied to
+> `check-secrets`/`check-patterns` and **never reached `check-hygiene`'s hidden-Unicode (Trojan
+> Source) and conflict-marker branches**, so that gate still failed OPEN. Both were re-reproduced by
+> hand, then closed with red→green regressions.
 
 ### 🟠 High
 
@@ -55,7 +56,7 @@ baseline.
   append, dangling `AGENTS.md` create); each fails against the pre-fix handler and passes after — full
   suite **178/0**, `shellcheck -S info` clean.
 
-**B2 — `check-hygiene` fails OPEN on over-cap lines: the A1 fail-closed fix never reached the hidden-Unicode (Trojan Source) and conflict-marker branches** — `githooks/lib/check-hygiene.template:106,163` · **already tracked but mis-prioritized + contradicts the A1 "FIXED" claim**
+**B2 — `check-hygiene` fails OPEN on over-cap lines: the A1 fail-closed fix never reached the hidden-Unicode (Trojan Source) and conflict-marker branches** — `githooks/lib/check-hygiene.template:106,163` · **already tracked but mis-prioritized + contradicts the A1 "FIXED" claim** · ✅ **FIXED** (`fix/audit-b2-hygiene-fail-closed`)
 - **What:** `check-secrets.template:159` carries the A1 fix (`awk '… { d=1; next } … END { exit (d ? 9 : 0) }'`,
   then reports the un-scannable line and sets `FAILED`). `check-hygiene`'s conflict-marker (`:106`)
   and hidden-Unicode (`:163`) branches still use the plain `awk 'length > n { next } { print }'`
@@ -73,6 +74,17 @@ baseline.
   the already-present-but-dead `cap_rc`). Add an over-cap hygiene regression (bidi + conflict marker
   each on a >cap line must be reported and exit non-zero), mirroring `cases/04 #31`. Reconcile the A1
   "FIXED" summary above, which currently over-claims that `check-hygiene` fails closed.
+- **Fixed (as landed):** both awk passes now carry `{ d=1; next } … END { exit (d ? 9 : 0) }`, the
+  conflict-marker branch's dead `cap_rc` is wired live, and the previously-`|| true` hidden-Unicode
+  branch now captures `cap_rc`. On `cap_rc==9` each branch emits via the existing `emit "$STATE"` —
+  so the over-cap finding inherits the rule's configured severity (a repo that downgraded
+  `hidden-unicode`/`conflict-marker` to `warn` gets a warn, not a surprise hard-block; the default
+  `error` sets `FAILED`). This is the one deliberate divergence from `check-secrets`, which hard-errors
+  inline because it is non-overridable. Locked with two red→green regressions in `tests/cases/06`
+  (#45g bidi-on-over-cap, #45h conflict-marker-on-over-cap); the expected-substring guard gives them
+  teeth — mutation-reverting the template leaves the commit rejected by `check-secrets` but drops the
+  hygiene fail-closed message, turning exactly those two cases red and no others. Full suite **180/0**,
+  `shellcheck -S info` clean. The A1 summary below is reconciled accordingly.
 
 ### 🟡 Medium
 
@@ -291,7 +303,7 @@ and the cross-grep / bash-3.2 portability sweep (no BSD-vs-GNU or bash-4-ism div
 
 Each landed with a red-then-green regression test; full suite 148/148 green.
 
-- **A1 (critical)** — `check-secrets` now FAILS CLOSED on a line over `MAX_LINE_LENGTH` (reports it + fails) instead of dropping it with a warning and exit 0. The line is still dropped before the ERE, so the ReDoS guard is unchanged. (`2f79605`; tests cases/04 #31, #31b)
+- **A1 (critical)** — `check-secrets` now FAILS CLOSED on a line over `MAX_LINE_LENGTH` (reports it + fails) instead of dropping it with a warning and exit 0. The line is still dropped before the ERE, so the ReDoS guard is unchanged. (`2f79605`; tests cases/04 #31, #31b) **`check-patterns` carries the same fix. `check-hygiene`'s conflict-marker + hidden-Unicode branches were NOT covered by this commit — that gap was finding B2, fixed separately in `fix/audit-b2-hygiene-fail-closed` (cases/06 #45g/#45h). `agent-precheck` (B6) remains open.**
 - **A2 (high)** — `agent-precheck` block path no longer takes SIGPIPE (`printf … | head -3 || true`), so it reliably reaches `exit 2` and actually blocks. (`98c6d41`; cases/07 #48g asserts the exit code is exactly 2)
 - **A3 (high)** — `scaffold-allow` dropped bare `--` as a leader and now requires a start-of-line/whitespace boundary, across all five exemption sites (check-secrets, check-patterns, check-hygiene ×2, agent-precheck); over-claiming docs corrected. (`2a92e6e`; cases/04 #28b)
 - **A4 (high)** — `check-filenames` folds name+path to lowercase before matching, so `.PEM`/`.ENV`/`ID_RSA` are blocked; the `.env.example` allowlist still holds. (`16ab43b`; cases/04 #36, #36b)

--- a/githooks/lib/check-hygiene.template
+++ b/githooks/lib/check-hygiene.template
@@ -102,9 +102,15 @@ CONFLICT_STATE=$(cfg rule-state conflict-marker); [ -n "$CONFLICT_STATE" ] || CO
 if [ "$CONFLICT_STATE" != disabled ]; then
   CONFLICT_RE='^(<{7}|>{7}|\|{7})( |$)'
   for file in "${FILES[@]}"; do
+    # FAIL CLOSED on an over-cap line (check-secrets parity). The line is dropped
+    # before the marker scan — that is the ReDoS guard — but an unscannable line
+    # must not pass silently: awk exit 9 ("a line was dropped") triggers a finding
+    # at the rule's severity, while the in-cap lines below are still scanned.
     cap_rc=0
-    content=$(git show ":0:$file" 2>/dev/null | awk -v n="$MAX_LINE_LENGTH" 'length > n { next } { print }') || cap_rc=$?
-    [ "$cap_rc" -eq 0 ] || true
+    content=$(git show ":0:$file" 2>/dev/null | awk -v n="$MAX_LINE_LENGTH" 'length > n { d=1; next } { print } END { exit (d ? 9 : 0) }') || cap_rc=$?
+    if [ "$cap_rc" -eq 9 ]; then
+      emit "$CONFLICT_STATE" "$file" "line(s) over $MAX_LINE_LENGTH chars cannot be scanned for conflict markers — split/relocate the minified asset or raise MAX_LINE_LENGTH"
+    fi
     [ -n "$content" ] || continue
     m=$(grep -anE -- "$CONFLICT_RE" <<<"$content" | grep -ivE '(^|[[:space:]])(#|//|/\*|<!--)[[:space:]]*scaffold-allow' || true)
     if [ -n "$m" ]; then
@@ -159,8 +165,15 @@ if [ "$HIDDEN_STATE" != disabled ]; then
   HIDDEN_RE=$'\xe2\x80[\x8b-\x8d\xaa-\xae]|\xe2\x81[\xa0\xa6-\xa9]|\xef\xbb\xbf|\xf3\xa0[\x80\x81][\x80-\xbf]'
   for file in "${FILES[@]}"; do
     is_binary "$file" && continue
+    # FAIL CLOSED on an over-cap line (check-secrets parity). An unscannable line
+    # in an agent-read file is exactly the Trojan-Source / Rules-File-Backdoor
+    # surface this branch defends, so a dropped line is reported, not swallowed.
+    cap_rc=0
     content=$(git show ":0:$file" 2>/dev/null \
-                | LC_ALL=C awk -v n="$MAX_LINE_LENGTH" 'length > n { next } { print }' || true)
+                | LC_ALL=C awk -v n="$MAX_LINE_LENGTH" 'length > n { d=1; next } { print } END { exit (d ? 9 : 0) }') || cap_rc=$?
+    if [ "$cap_rc" -eq 9 ]; then
+      emit "$HIDDEN_STATE" "$file" "line(s) over $MAX_LINE_LENGTH chars cannot be scanned for hidden Unicode (Trojan Source / Rules File Backdoor surface) — split/relocate the minified asset or raise MAX_LINE_LENGTH"
+    fi
     [ -n "$content" ] || continue
     # A legitimate leading BOM is allowed; strip one before scanning so only a
     # mid-file occurrence trips the EF-BB-BF branch.

--- a/tests/cases/06-hygiene-multilang.sh
+++ b/tests/cases/06-hygiene-multilang.sh
@@ -82,6 +82,24 @@ else
 fi
 reset_repo
 
+# 45g. FAIL CLOSED: a hidden-Unicode char (bidi override U+202E) on a line over
+#      MAX_LINE_LENGTH used to ride through — the ReDoS cap dropped the line, no
+#      signal, exit 0 (audit B2, the Trojan-Source bypass). The line is still
+#      dropped before the scan, but the unscannable line is now reported and the
+#      commit rejected. The expected-substring guard gives this teeth: without the
+#      fix check-secrets still rejects the 60k-char line, but the hidden-Unicode
+#      fail-closed message is absent. (U+202E built at runtime to keep this file ASCII.)
+bidi=$(printf '\xe2\x80\xae')
+{ printf 'legit start %s' "$bidi"; head -c 60000 /dev/zero | tr '\0' a; echo; } >longbidi.md
+git add longbidi.md
+assert_rejects "hidden Unicode on a >MAX_LINE_LENGTH line fails closed" "cannot be scanned for hidden Unicode"
+
+# 45h. FAIL CLOSED: the conflict-marker branch has the same over-cap hole. A
+#      marker on a >MAX_LINE_LENGTH line is reported rather than silently dropped.
+{ printf '<<<<<<< HEAD '; head -c 60000 /dev/zero | tr '\0' a; echo; } >longconflict.txt
+git add longconflict.txt
+assert_rejects "conflict marker on a >MAX_LINE_LENGTH line fails closed" "cannot be scanned for conflict markers"
+
 # --- Multi-language forbidden patterns (config-driven check-patterns) -------
 # Each language file declares its extensions via a `# scaffold-extensions:`
 # header and is auto-discovered by check-patterns. Samples come from the


### PR DESCRIPTION
## Audit finding B2 (high) — `check-hygiene` fails OPEN on over-cap lines

The A1 over-cap **fail-closed** fix reached `check-secrets` / `check-patterns` but never reached `check-hygiene`. Its **conflict-marker** and **hidden-Unicode (Trojan Source / CVE-2021-42574 / Rules File Backdoor)** branches still used the plain `awk 'length > n { next }'` drop — an over-cap line was silently dropped, no signal, exit 0. So a bidi override or zero-width character on a minified / base64 blob (one line over `MAX_LINE_LENGTH`, default 50000) rode straight through the scaffold's named defense in agent-read files. The `cap_rc=0 … || true` scaffolding at `:105/:107` was dead code (plain awk always exits 0).

### Fix
- Both awk passes now carry `{ d=1; next } … END { exit (d ? 9 : 0) }`, wiring the previously-dead `cap_rc` (conflict branch) and replacing the `|| true` (hidden-Unicode branch).
- On `cap_rc==9` each branch emits the over-cap finding via the **existing `emit "$STATE"`**, so it inherits the rule's configured severity. A repo that downgraded `hidden-unicode`/`conflict-marker` to `warn` gets a warn, not a surprise hard-block; the default `error` sets `FAILED`.
- **Deliberate divergence from `check-secrets`**, which hard-errors inline: `check-secrets` is a non-overridable security boundary, `check-hygiene` rules are overridable — so the over-cap signal should track the rule's severity rather than always hard-fail.

### Tests (`tests/cases/06`)
- **#45g** — hidden-Unicode (bidi U+202E) on a >`MAX_LINE_LENGTH` line is reported + rejected.
- **#45h** — conflict marker on a >`MAX_LINE_LENGTH` line is reported + rejected.
- **Mutation-proven teeth:** reverting only the template leaves the commit rejected by `check-secrets` but drops the hygiene fail-closed message, turning **exactly those two cases red** (via the expected-substring guard) while the other 178 hold.

### Verification
- Full suite **180/0** (was 178/0, +2).
- `shellcheck -S info` clean.
- No raw control bytes introduced into the changed docs/test (U+202E is text in the audit and a `\xe2\x80\xae` escape in the test).

### Docs
- `SECURITY_AUDIT.md`: B2 marked ✅ FIXED with a "Fixed (as landed)" note; the A1 "FIXED" summary reconciled (it had over-claimed that `check-hygiene` fails closed).
- `CHANGELOG.md`: `[Unreleased]` → Security entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)