### PR TITLE
fix: agent-precheck fails closed on over-cap lines (audit B6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ versioning follows [SemVer](https://semver.org/).
   now report the unscannable line and reject the commit, at the rule's
   configured severity (a repo that downgraded the rule to `warn` still gets a
   warn, not a hard block). Regressions in `tests/cases/06` (#45g, #45h).
+- **`agent-precheck` fails closed on over-long lines (B6, medium).** The
+  agent-write PreToolUse hook dropped any line over `MAX_LINE_LENGTH` and then
+  exited 0 (allow), so a secret or a `curl|bash` padded past the cap was silently
+  permitted at write time while its short form blocked at exit 2. An unscannable
+  over-cap line now BLOCKS (exit 2) with an actionable message — the one place
+  this advisory hook fails closed rather than open, since an unscannable line is
+  not the same as a missing scanner. Regression in `tests/cases/07` (#48h). This
+  completes the over-cap fail-closed sweep across all four scanners
+  (check-secrets/check-patterns/check-hygiene/agent-precheck).
 
 ## [v0.9.0] — 2026-06-30
 

--- a/SECURITY_AUDIT.md
+++ b/SECURITY_AUDIT.md
@@ -15,7 +15,7 @@ baseline.
 | Severity | Count | Novel | Already tracked / by-design |
 |---|---|---|---|
 | high | 2 | 1 (B1 ✅) | 1 (B2 ✅ — A1 fix never reached check-hygiene) |
-| medium | 4 | 2 (B3, B4) | 2 (B5, B6) |
+| medium | 4 | 2 (B3, B4) | 2 (B5, B6 ✅) |
 | low | 6 | 4 (B8–B11) | 2 (B7 variant, B12) |
 | info / by-design | 1 | 0 | B13 |
 
@@ -136,7 +136,7 @@ baseline.
 - **Fix:** add a `*.env` case to the env arm (keeping the `.env.example` allowlist); add a
   `cases/04` fixture asserting `prod.env` is rejected, mutation-proven.
 
-**B6 — `agent-precheck` over-long-line filter still FAILS OPEN (allow): the A1 fail-closed upgrade was never applied to the agent-write layer** — `githooks/lib/agent-precheck.template:58-59,127` · **already tracked** (`SECURITY_AUDIT.md:50`; A1 header listed `:57-59`, fix said "should fail closed on the Bash path")
+**B6 — `agent-precheck` over-long-line filter still FAILS OPEN (allow): the A1 fail-closed upgrade was never applied to the agent-write layer** — `githooks/lib/agent-precheck.template:58-59,127` · **already tracked** (`SECURITY_AUDIT.md:50`; A1 header listed `:57-59`, fix said "should fail closed on the Bash path") · ✅ **FIXED** (`fix/audit-b6-agent-precheck-fail-closed`)
 - **What:** line 58 drops any line over `MAX_LINE_LENGTH` with the plain `awk 'length > n { next }'`
   and line 59 (`[ -n "$content" ] || exit 0`) then exits 0 = ALLOW. Both Claude and Cursor treat any
   non-2 exit as allow. So a secret (Claude `Write` content) or a dangerous shell command (Cursor
@@ -149,6 +149,15 @@ baseline.
 - **Fix:** give `:58` the `check-secrets` fail-closed awk, capture `rc`, and on `rc==9` emit a BLOCKED
   message + `exit 2` instead of the `exit 0` at `:59/:127`. (The A2 SIGPIPE fix on the block path was
   re-verified holding, and both JSON templates parse.)
+- **Fixed (as landed):** `:58` now runs `{ d=1; next } … END { exit (d ? 9 : 0) }`; `cap_rc==9`
+  prints a `BLOCKED by agent-precheck: … too long to scan …` message and `exit 2`, before the
+  `[ -n "$content" ] || exit 0` allow-path. This is the **one place agent-precheck blocks rather than
+  failing open** — a deliberate carve-out from the file's "never brick the session" philosophy, on the
+  grounds that an *unscannable* line differs from a *missing scanner* (jq/config still fail open) and
+  must not be less strict than the short-input block. No `printf | head` on this path, so the A2
+  SIGPIPE class doesn't apply. Locked with `tests/cases/07` #48h (secret on a >`MAX_LINE_LENGTH` line
+  → exit exactly 2 + the too-long message; mutation-reverting the template drops it to exit 0 and turns
+  only that case red). Suite **181/0**, `shellcheck -S info` clean.
 
 ### ⚪ Low
 
@@ -303,7 +312,7 @@ and the cross-grep / bash-3.2 portability sweep (no BSD-vs-GNU or bash-4-ism div
 
 Each landed with a red-then-green regression test; full suite 148/148 green.
 
-- **A1 (critical)** — `check-secrets` now FAILS CLOSED on a line over `MAX_LINE_LENGTH` (reports it + fails) instead of dropping it with a warning and exit 0. The line is still dropped before the ERE, so the ReDoS guard is unchanged. (`2f79605`; tests cases/04 #31, #31b) **`check-patterns` carries the same fix. `check-hygiene`'s conflict-marker + hidden-Unicode branches were NOT covered by this commit — that gap was finding B2, fixed separately in `fix/audit-b2-hygiene-fail-closed` (cases/06 #45g/#45h). `agent-precheck` (B6) remains open.**
+- **A1 (critical)** — `check-secrets` now FAILS CLOSED on a line over `MAX_LINE_LENGTH` (reports it + fails) instead of dropping it with a warning and exit 0. The line is still dropped before the ERE, so the ReDoS guard is unchanged. (`2f79605`; tests cases/04 #31, #31b) **`check-patterns` carries the same fix. `check-hygiene`'s conflict-marker + hidden-Unicode branches were NOT covered by this commit — that gap was finding B2, fixed separately in `fix/audit-b2-hygiene-fail-closed` (cases/06 #45g/#45h). `agent-precheck` was finding B6, fixed in `fix/audit-b6-agent-precheck-fail-closed` (cases/07 #48h) — the over-cap line there BLOCKS (exit 2) rather than reporting, since it is the agent-write layer. All four over-cap sites now fail closed.**
 - **A2 (high)** — `agent-precheck` block path no longer takes SIGPIPE (`printf … | head -3 || true`), so it reliably reaches `exit 2` and actually blocks. (`98c6d41`; cases/07 #48g asserts the exit code is exactly 2)
 - **A3 (high)** — `scaffold-allow` dropped bare `--` as a leader and now requires a start-of-line/whitespace boundary, across all five exemption sites (check-secrets, check-patterns, check-hygiene ×2, agent-precheck); over-claiming docs corrected. (`2a92e6e`; cases/04 #28b)
 - **A4 (high)** — `check-filenames` folds name+path to lowercase before matching, so `.PEM`/`.ENV`/`ID_RSA` are blocked; the `.env.example` allowlist still holds. (`16ab43b`; cases/04 #36, #36b)

--- a/githooks/lib/agent-precheck.template
+++ b/githooks/lib/agent-precheck.template
@@ -53,9 +53,24 @@ content=$(jq -r '[(.tool_input // .) | .. | strings] | join("\n")' <<<"$payload"
 [ -n "$content" ] || exit 0
 
 # Drop pathologically long lines (a minified bundle pasted into a Write) so the
-# combined ERE can't be made to hang — same guard as check-secrets.
+# combined ERE can't be made to hang — same guard as check-secrets. But an
+# over-cap line must FAIL CLOSED here (block, exit 2), not ride through as
+# "allow": a secret or a `curl|bash` padded past MAX_LINE_LENGTH would otherwise
+# be silently permitted at write time while its short form blocks. This is the
+# one place agent-precheck blocks rather than failing open — an *unscannable*
+# line is not the same as a *missing scanner* (jq/config), and consistency with
+# the short-input block wins. awk exit 9 signals "a line was dropped".
 MAX_LINE_LENGTH=${MAX_LINE_LENGTH:-50000}
-content=$(printf '%s\n' "$content" | awk -v n="$MAX_LINE_LENGTH" 'length > n { next } { print }')
+cap_rc=0
+content=$(printf '%s\n' "$content" | awk -v n="$MAX_LINE_LENGTH" 'length > n { d=1; next } { print } END { exit (d ? 9 : 0) }') || cap_rc=$?
+if [ "$cap_rc" -eq 9 ]; then
+  {
+    echo "BLOCKED by agent-precheck: a line over $MAX_LINE_LENGTH chars is too long"
+    echo "to scan for secret/shell patterns — split the content (or raise"
+    echo "MAX_LINE_LENGTH, accepting the ReDoS cost) before this write/command runs."
+  } >&2
+  exit 2
+fi
 [ -n "$content" ] || exit 0
 
 # scan_against <patternfile> <i|""> <advice line>

--- a/tests/cases/07-agent-commit.sh
+++ b/tests/cases/07-agent-commit.sh
@@ -110,6 +110,25 @@ if command -v jq >/dev/null 2>&1; then
     echo "  ✗ agent-precheck — block exited $rc, expected exactly 2 (SIGPIPE fail-open?)"
     FAIL=$((FAIL + 1))
   fi
+  # (48h) REGRESSION (over-cap fail-OPEN, audit B6): a secret embedded IN a single
+  #       line over MAX_LINE_LENGTH was dropped by the ReDoS cap and the Write
+  #       allowed at exit 0 — while the short form blocks at exit 2. It must now
+  #       BLOCK (exit 2). The secret sits ON the over-cap line, so dropping the
+  #       line drops the secret; only the over-cap fail-closed can produce exit 2
+  #       here (the line never reaches the pattern scan). --rawfile keeps the 60k
+  #       content off the CLI (Linux MAX_ARG_STRLEN), same as 48g.
+  bigf=$(mktemp)
+  { head -c 60000 /dev/zero | tr '\0' a; printf 'AWS=%s\n' "$akia"; } >"$bigf"
+  pc=$(jq -n --rawfile c "$bigf" '{tool_name:"Write",tool_input:{file_path:"big.py",content:$c}}')
+  rm -f "$bigf"
+  rc=0
+  printf '%s' "$pc" | CLAUDE_PROJECT_DIR="$PWD" bash "$PRECHECK" >"$HOOK_OUT" 2>&1 || rc=$?
+  if [ "$rc" -eq 2 ] && grep -qF "too long" "$HOOK_OUT"; then
+    echo "  ✓ agent-precheck blocks (exit 2) a secret on a >MAX_LINE_LENGTH line (over-cap fail-closed)"; PASS=$((PASS + 1))
+  else
+    echo "  ✗ agent-precheck — over-cap line exited $rc, expected exactly 2 with the too-long block message (fail-open?)"
+    sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+  fi
 else
   echo "  - skipped agent-precheck tests (jq not installed)"
 fi


### PR DESCRIPTION
## Audit finding B6 (medium) — `agent-precheck` over-long-line filter FAILS OPEN (allow)

Sibling of A1/B2, on the **agent-write layer**. `agent-precheck` dropped any line over `MAX_LINE_LENGTH` (default 50000) with the plain `awk 'length > n { next }'`, then reached `[ -n "$content" ] || exit 0` = **allow**. Both Claude Code and Cursor treat any non-2 exit as "allow", so a secret (`Write` content) or a dangerous shell command (`curl|bash`) padded onto a single over-cap line was **silently permitted at write time** — while the short form blocks at exit 2.

Rated medium (not high): the commit-time `check-secrets` on the same content already fails closed (exit 1), so this is an advisory-layer gap, not an end-to-end secret ship. But the write-time inconsistency (short blocks, padded allowed) is exactly what this layer exists to prevent.

### Fix
- `:58` awk now `{ d=1; next } … END { exit (d ? 9 : 0) }`; on `cap_rc==9` the hook prints a `BLOCKED by agent-precheck: … too long to scan …` message and **`exit 2`**, before the allow-path.
- **Deliberate carve-out:** this is the *one* place `agent-precheck` blocks rather than failing open. Its stated philosophy is "never brick the session" (jq/config missing → exit 0). An *unscannable* line is different from a *missing scanner*, and must not be less strict than the short-input block — so it blocks. Documented inline and in the audit so it isn't "simplified" back to fail-open later.
- No `printf | head` on this path, so the A2 SIGPIPE class doesn't apply.

### Test (`tests/cases/07` #48h)
- A secret embedded **on** a >`MAX_LINE_LENGTH` line → exit **exactly 2** + the too-long message. The secret sits on the over-cap line, so it's dropped before any pattern scan — only the over-cap fail-closed can produce exit 2 here.
- **Mutation-proven:** reverting only the template drops it to exit 0 (the old silent allow) and turns **only that case** red (181/0 → 180/1).
- Uses `--rawfile` to keep the 60k content off the CLI (Linux `MAX_ARG_STRLEN`), matching #48g.

### Verification
- Suite **181/0** (was 180/0, +1); `shellcheck -S info` clean; no control bytes in changed docs/test.

### Scope
Completes the over-cap fail-closed sweep across all four scanners: `check-secrets` (A1), `check-patterns` (A1), `check-hygiene` (B2, #39), `agent-precheck` (B6, this PR). `SECURITY_AUDIT.md` B6 marked ✅ and the A1 summary reconciled; `CHANGELOG.md` `[Unreleased]` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)