### PR TITLE
fix: npm bundle ships gitleaks + dependency-review CI templates (audit B3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,15 @@ versioning follows [SemVer](https://semver.org/).
   not the same as a missing scanner. Regression in `tests/cases/07` (#48h). This
   completes the over-cap fail-closed sweep across all four scanners
   (check-secrets/check-patterns/check-hygiene/agent-precheck).
+- **npm package now ships the gitleaks + dependency-review CI templates (B3).**
+  `gitleaks.yml.template` and `dependency-review.yml.template` were git-tracked
+  and documented ("copy it in" in the README / `install.sh`) but missing from
+  the `package.json` `files` allowlist, so `npx` / `npm` consumers silently
+  lacked two security-CI gates that git-clone and Homebrew users get. Both are
+  now bundled, and the `tests/cases/11` bundle-drift guard globs every
+  `.github/workflows/*.yml.template` so it fails closed on any future
+  documented-but-unbundled workflow — the guard previously derived its required
+  set only from files `install.sh` reads, making manual-copy templates invisible.
 
 ## [v0.9.0] — 2026-06-30
 

--- a/SECURITY_AUDIT.md
+++ b/SECURITY_AUDIT.md
@@ -15,7 +15,7 @@ baseline.
 | Severity | Count | Novel | Already tracked / by-design |
 |---|---|---|---|
 | high | 2 | 1 (B1 ✅) | 1 (B2 ✅ — A1 fix never reached check-hygiene) |
-| medium | 4 | 2 (B3, B4) | 2 (B5, B6 ✅) |
+| medium | 4 | 2 (B3 ✅, B4) | 2 (B5, B6 ✅) |
 | low | 6 | 4 (B8–B11) | 2 (B7 variant, B12) |
 | info / by-design | 1 | 0 | B13 |
 
@@ -88,7 +88,7 @@ baseline.
 
 ### 🟡 Medium
 
-**B3 — npm `files` allowlist omits `gitleaks.yml.template` + `dependency-review.yml.template` that README + `install.sh` tell users to copy in; `tests/cases/11` does not catch it** — `package.json:8-32`, `tests/cases/11-npm-bundle.sh:33-37` · **NOVEL** (merges the npm-package, docs-accuracy, and test-harness finders)
+**B3 — npm `files` allowlist omits `gitleaks.yml.template` + `dependency-review.yml.template` that README + `install.sh` tell users to copy in; `tests/cases/11` does not catch it** — `package.json:8-32`, `tests/cases/11-npm-bundle.sh:33-37` · **NOVEL** (merges the npm-package, docs-accuracy, and test-harness finders) · ✅ **FIXED** (`fix/audit-b3-npm-bundle-security-templates`)
 - **What:** the two security-CI templates are git-tracked but absent from the npm `files`
   allowlist, so `npm pack` ships only `lint.yml.template` + `coverage.yml.template` from
   `.github/workflows/`. Yet `install.sh:371` prints (on every `--gitleaks-hook` run) `… see
@@ -105,6 +105,14 @@ baseline.
 - **Fix:** add both templates to `package.json` `files`, **and** extend `cases/11`'s REQUIRED set to
   glob `.github/workflows/*.yml.template` (or any README/`install.sh`-referenced template) so the
   guard fails closed on documented-but-uncopied files.
+- **Fixed (as landed):** both templates added to `package.json` `files` (bundle now ships all four
+  `.github/workflows/*.yml.template`, verified via `npm pack --dry-run`), and `cases/11`'s REQUIRED
+  set globs `.github/workflows/*.yml.template` — chosen over hardcoding the two names so the guard
+  fails closed on *any* future workflow template, not just today's two. Now checks 45 files (was 43).
+  Teeth: mutation-removing either (or both) template(s) from `files` turns `cases/11` red and **names
+  the exact missing path(s)** ("missing 2 of 45"), the class that was invisible before. Suite
+  **181/0**, `shellcheck -S info` clean. (Verified the install.sh/README references by hand:
+  `install.sh:387` names `gitleaks.yml.template`; `README.md:409,425` say "Copy it in" for both.)
 
 **B4 — `scripts/dev-setup.sh` renders scanners with bare `cp`, regressing the A7 symlink write-through fix (arbitrary out-of-repo overwrite)** — `scripts/dev-setup.sh:27-40` · **NOVEL**
 - **What:** `install.sh` writes every scaffold file through `_cp_replace` (`rm -f "$dst"` before

--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
     ".scaffold.toml.template",
     ".github/dependabot.yml.template",
     ".github/workflows/lint.yml.template",
-    ".github/workflows/coverage.yml.template"
+    ".github/workflows/coverage.yml.template",
+    ".github/workflows/gitleaks.yml.template",
+    ".github/workflows/dependency-review.yml.template"
   ],
   "engines": {
     "node": ">=14"

--- a/tests/cases/11-npm-bundle.sh
+++ b/tests/cases/11-npm-bundle.sh
@@ -21,9 +21,19 @@ else
   if ( cd "$SCAFFOLD_DIR" && npm pack --dry-run --json 2>/dev/null ) >"$C11"; then
     PACKED=$(jq -r '.[0].files[].path' "$C11" 2>/dev/null | sort -u)
 
-    # REQUIRED: every static $SCAFFOLD_DIR/<path> install.sh reads, the two
-    # dynamically-globbed dirs (${L}.txt.template / ${check}.template) expanded
-    # to their real members, plus the installer scripts and the npm wrapper.
+    # REQUIRED: every static $SCAFFOLD_DIR/<path> install.sh reads, the
+    # dynamically-globbed dirs (${L}.txt.template / ${check}.template + every
+    # workflow template) expanded to their real members, plus the installer
+    # scripts and the npm wrapper.
+    #
+    # The workflow glob is load-bearing: gitleaks.yml.template and
+    # dependency-review.yml.template are "copy it in" templates the user applies
+    # by hand (README §gitleaks/§dependency-review; install.sh only names them),
+    # so install.sh never READS them via $SCAFFOLD_DIR and the grep above can't
+    # see them. Without this glob an npm/npx user silently lacks two security-CI
+    # gates git-clone/Homebrew users get (audit B3). Globbing every
+    # .github/workflows/*.yml.template makes the guard fail closed on any
+    # documented-but-unbundled workflow — present or added later.
     REQUIRED=$(
       {
         # SC2016 off on purpose: we match the LITERAL text "$SCAFFOLD_DIR" / "${"
@@ -33,7 +43,8 @@ else
         grep -oE '\$SCAFFOLD_DIR/[^"'"'"' ]+' "$SCAFFOLD_DIR/install.sh" \
           | sed 's#\$SCAFFOLD_DIR/##' | grep -v '\${'
         ( cd "$SCAFFOLD_DIR" \
-            && ls forbidden-patterns/*.txt.template githooks/*.template githooks/lib/*.template )
+            && ls forbidden-patterns/*.txt.template githooks/*.template githooks/lib/*.template \
+                  .github/workflows/*.yml.template )
         printf '%s\n' install.sh uninstall.sh bin/cli.js
       } | sort -u
     )


### PR DESCRIPTION
## Audit finding B3 (medium, NOVEL) — npm bundle omits two security-CI templates; `cases/11` is blind to it

`gitleaks.yml.template` and `dependency-review.yml.template` are git-tracked and documented — `README.md:409,425` tell the user to "Copy it in", and `install.sh:387` names `gitleaks.yml.template` — but were **absent from `package.json` `files`**. So `npx` / `npm` consumers silently lacked two security-CI gates that git-clone and Homebrew users get (the Homebrew formula bundles the whole tree).

The bundle-drift guard `tests/cases/11` advertises *"every install.sh source file is in the npm bundle"* but derived its REQUIRED set only from paths `install.sh` **reads** via `$SCAFFOLD_DIR` plus three globbed dirs. These two are **manual-copy** templates `install.sh` only *names* — structurally out of scope — so the case stayed green over the gap. A false negative on exactly the drift check, for two security gates.

| Template | Documented | In `files` (before) | In bundle (before) |
|---|---|---|---|
| `gitleaks.yml.template` | README + install.sh | ✗ | ✗ |
| `dependency-review.yml.template` | README | ✗ | ✗ |

### Fix
- Add both templates to `package.json` `files` — `npm pack --dry-run` now ships all four `.github/workflows/*.yml.template`.
- Glob `.github/workflows/*.yml.template` into `cases/11`'s REQUIRED set. **Chose a glob over hardcoding the two names** so the guard fails closed on *any* documented-but-unbundled workflow — present or added later.

### Teeth (mutation-proven)
- `cases/11` now checks **45** files (was 43).
- Removing either/both templates from `files` turns it red and **names the exact missing path** — `✗ MISSING from npm bundle … : .github/workflows/gitleaks.yml.template`, "missing 2 of 45". This is precisely the class that was invisible before (the audit noted removing `coverage` turned it red, but the gitleaks/dependency-review omission was not).

### Verification
- Suite **181/0**; `shellcheck -S info` clean; `package.json` valid JSON; no control bytes in changed docs.
- Verified the `install.sh:387` / `README.md:409,425` references by hand before fixing (not assumed).

`SECURITY_AUDIT.md` B3 marked ✅ with a "Fixed (as landed)" note; `CHANGELOG.md` `[Unreleased]` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)