### PR TITLE
fix: dev-setup.sh renders without symlink write-through (audit B4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,14 @@ versioning follows [SemVer](https://semver.org/).
   `.github/workflows/*.yml.template` so it fails closed on any future
   documented-but-unbundled workflow — the guard previously derived its required
   set only from files `install.sh` reads, making manual-copy templates invisible.
+- **`scripts/dev-setup.sh` no longer writes through a symlink (B4).** The
+  maintainer dogfooding script rendered templates with bare `cp` / `mkdir -p`,
+  so a leftover or planted symlink in the gitignored `.githooks/` /
+  `.forbidden-patterns/` dirs could redirect a rendered scanner (or the whole
+  `lib/` dir) to a target outside the repo — the A7 write-through class that
+  `install.sh` already defends. It now drops any symlink at a rendered file or
+  directory before writing, so renders always land as real files in-tree.
+  Regressions in `tests/cases/09` (file-symlink + dir-symlink plants).
 
 ## [v0.9.0] — 2026-06-30
 

--- a/SECURITY_AUDIT.md
+++ b/SECURITY_AUDIT.md
@@ -15,7 +15,7 @@ baseline.
 | Severity | Count | Novel | Already tracked / by-design |
 |---|---|---|---|
 | high | 2 | 1 (B1 ✅) | 1 (B2 ✅ — A1 fix never reached check-hygiene) |
-| medium | 4 | 2 (B3 ✅, B4) | 2 (B5, B6 ✅) |
+| medium | 4 | 2 (B3 ✅, B4 ✅) | 2 (B5, B6 ✅) |
 | low | 6 | 4 (B8–B11) | 2 (B7 variant, B12) |
 | info / by-design | 1 | 0 | B13 |
 
@@ -114,7 +114,7 @@ baseline.
   **181/0**, `shellcheck -S info` clean. (Verified the install.sh/README references by hand:
   `install.sh:387` names `gitleaks.yml.template`; `README.md:409,425` say "Copy it in" for both.)
 
-**B4 — `scripts/dev-setup.sh` renders scanners with bare `cp`, regressing the A7 symlink write-through fix (arbitrary out-of-repo overwrite)** — `scripts/dev-setup.sh:27-40` · **NOVEL**
+**B4 — `scripts/dev-setup.sh` renders scanners with bare `cp`, regressing the A7 symlink write-through fix (arbitrary out-of-repo overwrite)** — `scripts/dev-setup.sh:27-40` · **NOVEL** · ✅ **FIXED** (`fix/audit-b4-dev-setup-symlink`)
 - **What:** `install.sh` writes every scaffold file through `_cp_replace` (`rm -f "$dst"` before
   `cp`, the A7 fix). `dev-setup.sh` uses bare `cp "$t" ".githooks/lib/…"` with no prior `rm -f`, and
   `mkdir -p .githooks/lib` follows a symlinked dir. Since `.githooks/`/`.forbidden-patterns/` are
@@ -129,6 +129,17 @@ baseline.
   `mkdir -p`), or source/reuse `install.sh`'s `_cp_replace`. Scope: maintainer-only dogfooding clone,
   hence medium not high. (`self-lint.yml:43,47` also renders with bare `cp` but runs in an ephemeral
   runner with no planted symlinks.)
+- **Fixed (as landed):** `dev-setup.sh` gained two helpers mirroring `_cp_replace` — `_cp` (`rm -f
+  "$dst"` before `cp`, so a symlink at a rendered file path is dropped and a real file lands in-tree)
+  and `_mkdir_safe` (drops a symlinked dir before `mkdir -p`, so `.githooks`/`.githooks/lib`/
+  `.forbidden-patterns` can't redirect writes outside the repo). Both write-through paths were
+  **re-reproduced by hand first** (file symlink → victim's first line became `#!/usr/bin/env bash`;
+  symlinked `lib/` dir → scanner written to the outside dir), then confirmed closed. Locked with two
+  red→green regressions in `tests/cases/09` (file-symlink + dir-symlink, each driving a minimal fake
+  clone since dev-setup refuses to run outside a scaffold checkout); mutation-reverting the script
+  turns exactly those two red. Suite **183/0**, `shellcheck -S info` clean. **Not changed:**
+  `self-lint.yml`'s bare `cp` — per the audit note it runs in an ephemeral runner with no planted
+  symlinks, so it's out of scope here rather than silently swept in.
 
 **B5 — Non-dotfile env files (`config.env`, `prod.env`) bypass `check-filenames`; chains with the deferred A5 unquoted-value gap for a dual-layer leak** — `githooks/lib/check-filenames.template:54-59` · **already tracked (stale section, never carried forward)**
 - **What:** the `.env` arm matches only `.env`/`.env.*` (case-folded). `config.env`/`prod.env`/

--- a/scripts/dev-setup.sh
+++ b/scripts/dev-setup.sh
@@ -24,19 +24,38 @@ if [ ! -f githooks/pre-commit.template ]; then
   exit 1
 fi
 
-mkdir -p .githooks/lib .forbidden-patterns
+# Mirror install.sh's A7 symlink defenses (_cp_replace). .githooks/ and
+# .forbidden-patterns/ are gitignored, so a leftover or planted symlink there
+# survives across checkouts; a bare `cp` follows a symlink at a rendered path and
+# writes the scanner THROUGH the link to a target OUTSIDE the repo, and `mkdir -p`
+# follows a symlinked DIR (sending every scanner outside). Drop any symlink before
+# writing so we always land a real file/dir in the tree, never through a link.
+_mkdir_safe() {           # create a real dir, never follow a symlink into one
+  local d=$1
+  if [ -L "$d" ]; then rm -f "$d"; fi
+  mkdir -p "$d"
+}
+_cp() {                   # write a real regular file, never through a symlink
+  local src=$1 dst=$2
+  rm -f "$dst"
+  cp "$src" "$dst"
+}
+
+_mkdir_safe .githooks
+_mkdir_safe .githooks/lib
+_mkdir_safe .forbidden-patterns
 
 # Top-level hooks — including the opt-in commit-msg: the repo dogfoods everything
 # it ships, even the hooks that are opt-in for downstream consumers.
-cp githooks/pre-commit.template .githooks/pre-commit
-cp githooks/commit-msg.template .githooks/commit-msg
+_cp githooks/pre-commit.template .githooks/pre-commit
+_cp githooks/commit-msg.template .githooks/commit-msg
 
 # Scanner libs + language/secret pattern files.
 for t in githooks/lib/*.template; do
-  cp "$t" ".githooks/lib/$(basename "$t" .template)"
+  _cp "$t" ".githooks/lib/$(basename "$t" .template)"
 done
 for t in forbidden-patterns/*.txt.template; do
-  cp "$t" ".forbidden-patterns/$(basename "$t" .template)"
+  _cp "$t" ".forbidden-patterns/$(basename "$t" .template)"
 done
 
 chmod +x .githooks/pre-commit .githooks/commit-msg .githooks/lib/*

--- a/tests/cases/09-toolchain-clobber.sh
+++ b/tests/cases/09-toolchain-clobber.sh
@@ -392,4 +392,54 @@ else
   echo "  ✗ re-run churned an already-current install"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
 fi
 rm -rf "$UNO"
+
+# --- dev-setup.sh does not write THROUGH a symlink at a rendered path (B4) -----
+# scripts/dev-setup.sh renders templates into the gitignored .githooks/ /
+# .forbidden-patterns/ for the scaffold's OWN dogfooding. It used bare `cp` /
+# `mkdir -p`, so a leftover/planted symlink there (surviving across checkouts,
+# since those dirs are gitignored) made cp write a scanner THROUGH the link to an
+# outside target, or mkdir -p follow a symlinked lib/ dir — the A7 class install.sh
+# already defends. dev-setup refuses to run outside a scaffold clone, so build a
+# MINIMAL fake clone (it resolves its root from its own path) and drive it.
+_b4_fakeclone() {   # $1 = dir to build a minimal runnable dev-setup clone into
+  local d=$1
+  mkdir -p "$d/scripts" "$d/githooks/lib" "$d/forbidden-patterns"
+  cp "$SCAFFOLD_DIR/scripts/dev-setup.sh" "$d/scripts/dev-setup.sh"
+  printf '#!/usr/bin/env bash\n' >"$d/githooks/pre-commit.template"
+  printf '#!/usr/bin/env bash\n' >"$d/githooks/commit-msg.template"
+  printf '#!/usr/bin/env bash\n# scanner\n' >"$d/githooks/lib/check-secrets.template"
+  printf 'pat\tdesc\n' >"$d/forbidden-patterns/secrets.txt.template"
+  ( cd "$d" && git init --quiet && git config user.email t@t.local && git config user.name t )
+}
+
+# (T) file symlink at a rendered scanner path -> outside victim: the victim must
+#     NOT be overwritten, and the rendered path must become a real regular file.
+BF=$(mktemp -d)
+_b4_fakeclone "$BF/clone"
+printf 'PRECIOUS_DO_NOT_TOUCH\n' >"$BF/outside_target"
+mkdir -p "$BF/clone/.githooks/lib"
+ln -s "$BF/outside_target" "$BF/clone/.githooks/lib/check-secrets"
+( cd "$BF/clone" && bash scripts/dev-setup.sh ) >"$HOOK_OUT" 2>&1 || true
+if grep -q 'PRECIOUS_DO_NOT_TOUCH' "$BF/outside_target" \
+   && [ -f "$BF/clone/.githooks/lib/check-secrets" ] && [ ! -L "$BF/clone/.githooks/lib/check-secrets" ]; then
+  echo "  ✓ dev-setup replaces a symlinked rendered path with a real file (no write-through)"; PASS=$((PASS + 1))
+else
+  echo "  ✗ dev-setup wrote through a symlink or clobbered the outside target (B4)"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$BF"
+
+# (T) symlinked .githooks/lib DIR -> outside dir: mkdir -p must NOT follow it, so
+#     no scanner lands outside the repo and the rendered lib/ is a real dir.
+BD=$(mktemp -d)
+_b4_fakeclone "$BD/clone"
+mkdir -p "$BD/clone/.githooks" "$BD/outside_dir"
+ln -s "$BD/outside_dir" "$BD/clone/.githooks/lib"
+( cd "$BD/clone" && bash scripts/dev-setup.sh ) >"$HOOK_OUT" 2>&1 || true
+if [ ! -e "$BD/outside_dir/check-secrets" ] \
+   && [ -d "$BD/clone/.githooks/lib" ] && [ ! -L "$BD/clone/.githooks/lib" ]; then
+  echo "  ✓ dev-setup does not render through a symlinked lib/ dir (no outside write)"; PASS=$((PASS + 1))
+else
+  echo "  ✗ dev-setup followed a symlinked lib/ dir and wrote a scanner outside the repo (B4)"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$BD"
 reset_repo


### PR DESCRIPTION
## Audit finding B4 (medium, NOVEL) — `dev-setup.sh` regresses the A7 symlink write-through defense

`scripts/dev-setup.sh` (maintainer dogfooding — renders the `*.template` sources into the gitignored `.githooks/` / `.forbidden-patterns/`) used bare `cp` and `mkdir -p`, so it lacked the A7 defense `install.sh`'s `_cp_replace` already carries. Because those dirs are **gitignored**, a leftover or planted symlink there survives across checkouts:

- a symlink at a rendered scanner path → `cp` writes the scanner **through the link** to a target outside the repo;
- a symlinked `.githooks/lib` dir → `mkdir -p` follows it, sending **every** scanner outside the repo.

### Reproduced by hand first (verify before fixing)
| Plant | Before fix | After fix |
|---|---|---|
| `ln -s VICTIM .githooks/lib/check-secrets` | victim's first line → `#!/usr/bin/env bash` (clobbered through link) | victim intact, real file in-tree |
| `ln -s OUTSIDE_DIR .githooks/lib` | scanner written to `OUTSIDE_DIR/check-secrets` | nothing written outside, `lib/` is a real dir |

### Fix
Mirrors `_cp_replace`: `_cp` does `rm -f "$dst"` before `cp` (drops a symlinked file dst), and `_mkdir_safe` drops a symlinked dir before `mkdir -p` (guards `.githooks` / `.githooks/lib` / `.forbidden-patterns`). Renders always land as real files in-tree.

### Tests (`tests/cases/09`)
Two red→green regressions — file-symlink and dir-symlink plants — each driving a **minimal fake clone** (dev-setup refuses to run outside a scaffold checkout, so the test constructs one). Mutation-reverting the script turns exactly those two red (181/2), nothing else.

### Verification
Suite **183/0** (was 181, +2); `shellcheck -S info` clean; no control bytes in changed docs.

### Scope
`self-lint.yml`'s bare `cp` is **left as-is** — per the audit it runs in an ephemeral runner with no planted symlinks, so it's out of scope here rather than silently swept into this change. `SECURITY_AUDIT.md` B4 marked ✅; `CHANGELOG.md` `[Unreleased]` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)