### PR TITLE
build(ci): refresh pinned action SHAs

### DIFF
--- a/.github/workflows/lint.yml.template
+++ b/.github/workflows/lint.yml.template
@@ -43,7 +43,7 @@ jobs:
             echo "present=true" >> "$GITHUB_OUTPUT"
           fi
       - if: steps.detect.outputs.present == 'true'
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: "3.12"
       - if: steps.detect.outputs.present == 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           persist-credentials: false
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: "3.12"
       - run: pip install ruff


### PR DESCRIPTION
Automated SHA-pin refresh. Checked actions/checkout (v7.x), actions/setup-python (v6.x), and actions/setup-node (v6.x); one action was stale:

- actions/setup-python: v6.2.0 (`a309ff8`) → v6.3.0 (`ece7cb0`)

Updated in `.github/workflows/lint.yml.template` and `.github/workflows/test.yml`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J4PrRBipcUzjrSEgPUZetM)_