### PR TITLE
fix: check-filenames blocks non-dotfile env files (audit B5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ versioning follows [SemVer](https://semver.org/).
   not the same as a missing scanner. Regression in `tests/cases/07` (#48h). This
   completes the over-cap fail-closed sweep across all four scanners
   (check-secrets/check-patterns/check-hygiene/agent-precheck).
+- **`check-filenames` now blocks non-dotfile env files (B5, medium).** The env
+  arm matched only `.env`/`.env.*`, so `config.env`/`prod.env`/`staging.env` — which
+  end in `.env` without starting with it — committed clean; paired with an unquoted
+  `KEY=value` secret they also slipped the (deliberately deferred) quoted-only content
+  scanner, a dual-layer leak. The arm is now `.env|.env.*|*.env`; `*.env.example`-style
+  templates end in `.example`, so the `.env.example` allowlist is unaffected. Regressions
+  in `tests/cases/04` (#36e/#36f block `config.env`/`prod.env`/`PROD.ENV`; #36g keeps
+  `config.env.example` passing).
 - **npm package now ships the gitleaks + dependency-review CI templates (B3).**
   `gitleaks.yml.template` and `dependency-review.yml.template` were git-tracked
   and documented ("copy it in" in the README / `install.sh`) but missing from

--- a/SECURITY_AUDIT.md
+++ b/SECURITY_AUDIT.md
@@ -15,7 +15,7 @@ baseline.
 | Severity | Count | Novel | Already tracked / by-design |
 |---|---|---|---|
 | high | 2 | 1 (B1 ✅) | 1 (B2 ✅ — A1 fix never reached check-hygiene) |
-| medium | 4 | 2 (B3 ✅, B4 ✅) | 2 (B5, B6 ✅) |
+| medium | 4 | 2 (B3 ✅, B4 ✅) | 2 (B5 ✅, B6 ✅) |
 | low | 6 | 4 (B8–B11) | 2 (B7 variant, B12) |
 | info / by-design | 1 | 0 | B13 |
 
@@ -141,7 +141,7 @@ baseline.
   `self-lint.yml`'s bare `cp` — per the audit note it runs in an ephemeral runner with no planted
   symlinks, so it's out of scope here rather than silently swept in.
 
-**B5 — Non-dotfile env files (`config.env`, `prod.env`) bypass `check-filenames`; chains with the deferred A5 unquoted-value gap for a dual-layer leak** — `githooks/lib/check-filenames.template:54-59` · **already tracked (stale section, never carried forward)**
+**B5 — Non-dotfile env files (`config.env`, `prod.env`) bypass `check-filenames`; chains with the deferred A5 unquoted-value gap for a dual-layer leak** — `githooks/lib/check-filenames.template:54-59` · **already tracked (stale section, never carried forward)** · ✅ **FIXED** (`fix/audit-b5-nondotfile-env-filenames`)
 - **What:** the `.env` arm matches only `.env`/`.env.*` (case-folded). `config.env`/`prod.env`/
   `staging.env` match no arm, so the file commits. With an unquoted `KEY=value` secret it also evades
   the content scanner (the deliberately-deferred A5 quoted-only rule), so **both** layers pass. This is
@@ -154,6 +154,15 @@ baseline.
   for the unquoted case).
 - **Fix:** add a `*.env` case to the env arm (keeping the `.env.example` allowlist); add a
   `cases/04` fixture asserting `prod.env` is rejected, mutation-proven.
+- **Fixed (as landed):** the block arm is now `.env|.env.*|*.env)`. `*.env` catches non-dotfile env
+  files (`config.env`/`prod.env`/`staging.env`) that end in `.env` without starting with it;
+  `*.env.example`-style templates end in `.example`, so `*.env` never matches them and they keep
+  passing via case fall-through (no allowlist change needed). Locked with `tests/cases/04` #36e/#36f
+  (`config.env`, `prod.env`, and case-folded `PROD.ENV` → blocked) plus #36g NEGATIVE
+  (`config.env.example` still passes — guards against over-matching). Mutation-reverting the `*.env`
+  glob turns exactly #36e/#36f red (3 cases) and leaves #36g green. Suite **187/0**, `shellcheck -S
+  info` clean. The unquoted-value content-scanner gap (A5) remains deliberately deferred to the
+  gitleaks layer; this closes the filename layer so the two no longer fail open together.
 
 **B6 — `agent-precheck` over-long-line filter still FAILS OPEN (allow): the A1 fail-closed upgrade was never applied to the agent-write layer** — `githooks/lib/agent-precheck.template:58-59,127` · **already tracked** (`SECURITY_AUDIT.md:50`; A1 header listed `:57-59`, fix said "should fail closed on the Bash path") · ✅ **FIXED** (`fix/audit-b6-agent-precheck-fail-closed`)
 - **What:** line 58 drops any line over `MAX_LINE_LENGTH` with the plain `awk 'length > n { next }'`

--- a/githooks/lib/check-filenames.template
+++ b/githooks/lib/check-filenames.template
@@ -2,8 +2,8 @@
 # .githooks/lib/check-filenames — block committed credentials by filename.
 # Reads NUL-separated file paths on stdin (produced by `git ... -z`), so
 # filenames containing newlines, tabs, or quotes can't split the list and slip
-# past the check. Rejects .env (allowing .env.example/.sample/.template),
-# *.pem, and SSH private key names.
+# past the check. Rejects .env and *.env (e.g. config.env/prod.env) — allowing
+# .env.example/.sample/.template — plus *.pem and SSH private key names.
 #
 # Output: human-readable on tty; ::error file=...:: when --ci is passed.
 # Exit:   0 if all OK, 1 if any violation.
@@ -53,7 +53,10 @@ while IFS= read -r -d '' file; do
   lname=$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]')
   case "$lname" in
     .env.example|.env.sample|.env.template) ;;
-    .env|.env.*)
+    # `*.env` catches non-dotfile env files (config.env, prod.env, staging.env)
+    # that the `.env`/`.env.*` arms miss. `*.env.example`-style templates end in
+    # `.example`, so `*.env` never matches them — they keep passing via fall-through.
+    .env|.env.*|*.env)
       emit "$file" "environment file — use .env.example for shared config, keep secrets in env vars"
       FAILED=1
       ;;

--- a/tests/cases/04-shell-config-rename.sh
+++ b/tests/cases/04-shell-config-rename.sh
@@ -232,3 +232,29 @@ assert_passes ".env.sample (allowlisted template) is not blocked"
 printf 'FOO=bar\n' >.env.template
 git add -f .env.template
 assert_passes ".env.template (allowlisted template) is not blocked"
+
+# 36e. B5 regression — NON-dotfile env files (config.env / prod.env / staging.env)
+#      end in `.env` but do not START with `.env`, so the `.env`/`.env.*` arms miss
+#      them and (with an unquoted KEY=value secret) the deferred-A5 content scanner
+#      passes too — a dual-layer leak. The `*.env` arm closes the filename layer.
+#      Benign content isolates the filename rule; reverting the `*.env` glob turns
+#      each of these red (mutation-proven).
+printf 'FOO=bar\n' >config.env
+git add -f config.env
+assert_rejects "config.env (non-dotfile env file) is blocked" "environment file"
+
+printf 'FOO=bar\n' >prod.env
+git add -f prod.env
+assert_rejects "prod.env (non-dotfile env file) is blocked" "environment file"
+
+# 36f. Case-fold parity — PROD.ENV folds to prod.env and must block too.
+printf 'FOO=bar\n' >PROD.ENV
+git add -f PROD.ENV
+assert_rejects "PROD.ENV (non-dotfile env, uppercase) is blocked" "environment file"
+
+# 36g. NEGATIVE — a non-dotfile template (config.env.example) ends in `.example`,
+#      not `.env`, so `*.env` must NOT catch it; the allowlist philosophy holds
+#      for non-dotfile forms via fall-through. Guards the fix from over-matching.
+printf 'FOO=bar\n' >config.env.example
+git add -f config.env.example
+assert_passes "config.env.example (non-dotfile template) is not blocked"


### PR DESCRIPTION
## Audit B5 — `check-filenames` blocks non-dotfile env files (medium)

### The gap
`githooks/lib/check-filenames.template`'s env arm matched only `.env` / `.env.*`
(case-folded). Non-dotfile env files — `config.env`, `prod.env`, `staging.env` —
end in `.env` **without starting with it**, so they matched no arm and committed
clean. Paired with an unquoted `KEY=value` secret they also slip the
deliberately-deferred quoted-only content scanner (A5), so **both** the filename
and content layers fail open together — a dual-layer leak.

This was recorded years-stale at `SECURITY_AUDIT.md:469` and never carried into
the authoritative 2026-06-30 section; it had **zero test coverage**.

### The fix
The block arm is now `.env|.env.*|*.env`:

- `*.env` catches the non-dotfile forms (`config.env`, `prod.env`, …).
- `*.env.example`-style templates end in `.example`, so `*.env` never matches
  them — they keep passing via case-statement fall-through. The `.env.example`
  allowlist is unaffected; **no allowlist change needed**.

One-glob change; blast radius is a single case arm.

### Tests (mutation-proven, `tests/cases/04`)
- **#36e/#36f** — `config.env`, `prod.env`, and case-folded `PROD.ENV` are blocked.
- **#36g** NEGATIVE — `config.env.example` still passes (guards against over-matching).

Benign `FOO=bar` content isolates each fixture to the filename rule (not the
content scanner). Mutation-reverting the `*.env` glob turns **exactly** #36e/#36f
red (3 cases) and leaves #36g green — the glob is load-bearing and not over-broad.

Suite **187/0** (was 183/0), `shellcheck -S info` clean, local self-lint exit 0.

### Scope note
The A5 unquoted-value **content**-scanner gap stays deliberately deferred to the
gitleaks layer (unchanged). This PR closes the **filename** layer so the two no
longer fail open in tandem. Marks B5 ✅ FIXED in `SECURITY_AUDIT.md` + `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
