### PR TITLE
fix: check-filenames blocks binary key/keystore files (audit B7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,16 @@ versioning follows [SemVer](https://semver.org/).
   templates end in `.example`, so the `.env.example` allowlist is unaffected. Regressions
   in `tests/cases/04` (#36e/#36f block `config.env`/`prod.env`/`PROD.ENV`; #36g keeps
   `config.env.example` passing).
+- **`check-filenames` now blocks binary key/keystore files (B7, low).** The
+  filename block knew only `*.pem`, `.env*`, and the four `id_*` SSH names, so a
+  committed `server.key` / `cert.p12` / `id.pfx` / `store.jks` / `key.ppk` passed —
+  and because these are binary blobs with no PEM `-----BEGIN … PRIVATE KEY-----`
+  armor, the content scanner can't backstop them, so both layers failed open. A new
+  `*.key|*.p12|*.pfx|*.jks|*.ppk` arm now blocks them (fail-closed; the filename is
+  the only signal). `*.key` also catches the common TLS/Kubernetes spelling; the rare
+  Keynote `.key` bundle is a deliberate false-positive trade-off (rename / keep out of
+  git). Regressions in `tests/cases/04` (#36h/#36i block all five extensions +
+  case-folded `SERVER.KEY`; #36j keeps public-key `authorized_keys` passing).
 - **npm package now ships the gitleaks + dependency-review CI templates (B3).**
   `gitleaks.yml.template` and `dependency-review.yml.template` were git-tracked
   and documented ("copy it in" in the README / `install.sh`) but missing from

--- a/SECURITY_AUDIT.md
+++ b/SECURITY_AUDIT.md
@@ -16,7 +16,7 @@ baseline.
 |---|---|---|---|
 | high | 2 | 1 (B1 ✅) | 1 (B2 ✅ — A1 fix never reached check-hygiene) |
 | medium | 4 | 2 (B3 ✅, B4 ✅) | 2 (B5 ✅, B6 ✅) |
-| low | 6 | 4 (B8–B11) | 2 (B7 variant, B12) |
+| low | 6 | 4 (B8–B11) | 2 (B7 ✅ variant, B12) |
 | info / by-design | 1 | 0 | B13 |
 
 > Two High findings were the actionable headline; **both are now ✅ FIXED**. **B1** was a genuinely
@@ -189,7 +189,7 @@ baseline.
 
 ### ⚪ Low
 
-**B7 — Binary key/keystore files (`*.key`, `*.p12`, `*.pfx`, `*.jks`, `*.ppk`) bypass the filename block; the content scanner can't backstop binary key material** — `githooks/lib/check-filenames.template:43-64` · **new variant of the existing extension list**
+**B7 — Binary key/keystore files (`*.key`, `*.p12`, `*.pfx`, `*.jks`, `*.ppk`) bypass the filename block; the content scanner can't backstop binary key material** — `githooks/lib/check-filenames.template:43-64` · **new variant of the existing extension list** · ✅ **FIXED** (`fix/audit-b7-keystore-filenames`)
 - **What:** the filename block knows only `*.pem`, `.env*`, and the four `id_*` SSH names. The other
   ubiquitous private-key/keystore extensions have no arm, and the only key content rule
   (`secrets.txt.template:43` PEM armor `-----BEGIN … PRIVATE KEY-----`) never matches a binary
@@ -201,6 +201,17 @@ baseline.
   both exit 0; the **identical bytes** as `cert.pem` → `✗ … PEM file (likely private key)`, exit 1.
 - **Fix:** add `*.key|*.p12|*.pfx|*.jks|*.ppk` to the case glob (with a "key/keystore — rotate"
   message) and `cases/04` fixtures; document that binary keystores rely on the filename layer / gitleaks.
+- **Fixed (as landed):** a new `*.key|*.p12|*.pfx|*.jks|*.ppk)` arm sits beside `*.pem` in the
+  `case "$lfile"` block (extension match on the full path, `continue` like `*.pem`), emitting
+  `private key / keystore — rotate it and use a secret manager`. Since these are binary blobs with no
+  PEM armor, the content scanner cannot backstop them and the filename is the only signal — so this
+  fails **closed**. `*.key` also catches the common TLS/Kubernetes private-key spelling; the rare
+  Keynote `.key` bundle is a **deliberate false-positive trade-off** (rename / keep out of git),
+  documented inline, on the grounds that fail-closed on possible key material beats leaking one.
+  Locked with `tests/cases/04` #36h (all five extensions, each its own fixture) + #36i (case-folded
+  `SERVER.KEY`) + #36j NEGATIVE (`authorized_keys` — public-key material, no `.key` suffix — still
+  passes, guarding against a `*key*` broadening). Mutation-neutralizing the glob turns exactly the six
+  positives red and leaves #36j green. Suite **194/0**, `shellcheck -S info` clean.
 
 **B8 — `package.json` `os: ["darwin","linux"]` hard-blocks native-Windows / Git-Bash npm install, contradicting `cli.js` + README Windows support** — `package.json:36-39` · **NOVEL**
 - **What:** npm enforces `os` as `EBADPLATFORM` (hard exit 1, package not installed) when

--- a/githooks/lib/check-filenames.template
+++ b/githooks/lib/check-filenames.template
@@ -3,7 +3,8 @@
 # Reads NUL-separated file paths on stdin (produced by `git ... -z`), so
 # filenames containing newlines, tabs, or quotes can't split the list and slip
 # past the check. Rejects .env and *.env (e.g. config.env/prod.env) — allowing
-# .env.example/.sample/.template — plus *.pem and SSH private key names.
+# .env.example/.sample/.template — plus *.pem, binary key/keystore extensions
+# (*.key/.p12/.pfx/.jks/.ppk), and SSH private key names.
 #
 # Output: human-readable on tty; ::error file=...:: when --ci is passed.
 # Exit:   0 if all OK, 1 if any violation.
@@ -43,6 +44,17 @@ while IFS= read -r -d '' file; do
   case "$lfile" in
     *.pem)
       emit "$file" "PEM file (likely private key) — rotate and use a secret manager"
+      FAILED=1
+      continue
+      ;;
+    # Binary private-key / keystore blobs (DER, PKCS#12, Java/PuTTY stores) carry
+    # no PEM `-----BEGIN … PRIVATE KEY-----` armor, so the content scanner cannot
+    # backstop them — the filename is the only signal. `*.key` also catches the
+    # common TLS/Kubernetes private-key spelling; the rare Keynote `.key` bundle
+    # is a deliberate false-positive trade-off (rename or keep it out of git),
+    # since fail-closed on possible key material beats leaking one.
+    *.key|*.p12|*.pfx|*.jks|*.ppk)
+      emit "$file" "private key / keystore — rotate it and use a secret manager"
       FAILED=1
       continue
       ;;

--- a/tests/cases/04-shell-config-rename.sh
+++ b/tests/cases/04-shell-config-rename.sh
@@ -258,3 +258,40 @@ assert_rejects "PROD.ENV (non-dotfile env, uppercase) is blocked" "environment f
 printf 'FOO=bar\n' >config.env.example
 git add -f config.env.example
 assert_passes "config.env.example (non-dotfile template) is not blocked"
+
+# 36h. B7 regression — binary key/keystore blobs (*.key / *.p12 / *.pfx / *.jks /
+#      *.ppk) carry no PEM armor, so the content scanner can't backstop them; the
+#      filename is the only signal. Benign content isolates the filename rule.
+#      Each extension gets its own fixture so a typo in any glob alternative turns
+#      exactly that case red (mutation-proven).
+echo "placeholder" >server.key
+git add -f server.key
+assert_rejects "server.key (TLS/K8s private key) is blocked" "keystore"
+
+echo "placeholder" >cert.p12
+git add -f cert.p12
+assert_rejects "cert.p12 (PKCS#12 keystore) is blocked" "keystore"
+
+echo "placeholder" >id.pfx
+git add -f id.pfx
+assert_rejects "id.pfx (PKCS#12 keystore) is blocked" "keystore"
+
+echo "placeholder" >store.jks
+git add -f store.jks
+assert_rejects "store.jks (Java keystore) is blocked" "keystore"
+
+echo "placeholder" >key.ppk
+git add -f key.ppk
+assert_rejects "key.ppk (PuTTY private key) is blocked" "keystore"
+
+# 36i. Case-fold parity — SERVER.KEY folds to server.key and must block too.
+echo "placeholder" >SERVER.KEY
+git add -f SERVER.KEY
+assert_rejects "SERVER.KEY (keystore, uppercase) is blocked" "keystore"
+
+# 36j. NEGATIVE — `authorized_keys` is PUBLIC-key material (safe to commit) and
+#      does not end in `.key`, so the `*.key` glob must NOT catch it. Guards the
+#      fix against broadening to a `*key*` substring match.
+echo "placeholder" >authorized_keys
+git add -f authorized_keys
+assert_passes "authorized_keys (public keys) is not blocked"


### PR DESCRIPTION
## Audit B7 — `check-filenames` blocks binary key/keystore files (low)

Sibling of B5 (#44) in the same file. The filename block knew only `*.pem`,
`.env*`, and the four `id_*` SSH names, so a committed `server.key` / `cert.p12`
/ `id.pfx` / `store.jks` / `key.ppk` passed. Because these are **binary blobs
with no PEM `-----BEGIN … PRIVATE KEY-----` armor**, the content scanner cannot
backstop them either — **both** the filename and content layers fail open on real
private-key/keystore material. The README already advertises "private keys / key
files", but only `.pem`-extension keys were actually caught. Zero `cases/04`
coverage.

### The fix
A new arm beside `*.pem` in the `case "$lfile"` block (extension match on the
full path, `continue` like `*.pem`):

```sh
*.key|*.p12|*.pfx|*.jks|*.ppk)
  emit "$file" "private key / keystore — rotate it and use a secret manager"
  FAILED=1; continue ;;
```

Fails **closed** — for a binary blob the filename is the only signal.

**Deliberate trade-off (documented inline):** `*.key` also catches the common
TLS/Kubernetes private-key spelling; the rare **Keynote `.key` bundle** is a
knowing false positive (rename / keep out of git). Fail-closed on possible key
material beats leaking one. Note `check-filenames` is a locked (non-overridable)
scanner, so a genuine Keynote file would need a rename rather than a config
exemption — an intentional bias toward safety.

### Tests (mutation-proven, `tests/cases/04`)
- **#36h** — all five extensions, each its own fixture (a typo in any glob
  alternative turns exactly that case red).
- **#36i** — case-folded `SERVER.KEY` blocks.
- **#36j** NEGATIVE — public-key `authorized_keys` (no `.key` suffix) still passes;
  guards against broadening to a `*key*` substring match.

Mutation-neutralizing the glob turns **exactly** the six positives red and leaves
#36j green. Benign `placeholder` content isolates each fixture to the filename
rule. Suite **194/0** (was 187/0), `shellcheck -S info` clean, local self-lint
exit 0. Marks B7 ✅ FIXED in `SECURITY_AUDIT.md` + `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
