### PR TITLE
fix: dev-setup.sh guards core.hooksPath wiring like install.sh (audit B9/B10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,16 @@ versioning follows [SemVer](https://semver.org/).
   `install.sh` already defends. It now drops any symlink at a rendered file or
   directory before writing, so renders always land as real files in-tree.
   Regressions in `tests/cases/09` (file-symlink + dir-symlink plants).
+- **`scripts/dev-setup.sh` guards the `core.hooksPath` wiring like `install.sh`
+  (B9, B10, low).** The wiring step ran `git config core.hooksPath .githooks`
+  unconditionally, so (B9) run before `git init` it aborted with a raw `fatal:
+  not in a git directory` (exit 128) *after* every file was already rendered, and
+  (B10) it silently clobbered a pre-existing `core.hooksPath` (e.g. a Husky /
+  lefthook setup). It now mirrors `install.sh`: a `git rev-parse --git-dir` guard
+  warns and continues (exit 0) outside a git repo, and an existing non-`.githooks`
+  hooks path is preserved with a warning instead of overwritten. The summary line
+  reports the real outcome. Regressions in `tests/cases/09` (Husky path survives;
+  unset → `.githooks`; no-`git init` clone warns + exits 0).
 
 ## [v0.9.0] — 2026-06-30
 

--- a/SECURITY_AUDIT.md
+++ b/SECURITY_AUDIT.md
@@ -16,7 +16,7 @@ baseline.
 |---|---|---|---|
 | high | 2 | 1 (B1 ✅) | 1 (B2 ✅ — A1 fix never reached check-hygiene) |
 | medium | 4 | 2 (B3 ✅, B4 ✅) | 2 (B5 ✅, B6 ✅) |
-| low | 6 | 4 (B8–B11) | 2 (B7 ✅ variant, B12) |
+| low | 6 | 4 (B8, B9 ✅, B10 ✅, B11) | 2 (B7 ✅ variant, B12) |
 | info / by-design | 1 | 0 | B13 |
 
 > Two High findings were the actionable headline; **both are now ✅ FIXED**. **B1** was a genuinely
@@ -225,20 +225,29 @@ baseline.
 - **Fix:** drop the `os` field (the bash/Windows guidance already lives in `cli.js` + README), or
   replace the hard gate with a non-fatal guidance check inside `cli.js`. Security-neutral; usability only.
 
-**B9 — `dev-setup.sh` aborts with raw `fatal: not in a git directory` (exit 128) when run before `git init`, unlike `install.sh`'s graceful guard** — `scripts/dev-setup.sh:44` · **NOVEL**
+**B9 — `dev-setup.sh` aborts with raw `fatal: not in a git directory` (exit 128) when run before `git init`, unlike `install.sh`'s graceful guard** — `scripts/dev-setup.sh:44` · **NOVEL** · ✅ **FIXED** (`fix/audit-b9-b10-dev-setup-hookspath-guards`)
 - **What:** `git config core.hooksPath .githooks` runs unconditionally under `set -euo pipefail`; with
   no `.git` it exits 128 and `set -e` propagates a hard failure *after* every file is already rendered
   and chmod'd. `install.sh:387-398` handles the same case with a `git rev-parse --git-dir` guard and an
   actionable warning (exit 0).
 - **Fix:** mirror `install.sh`'s guard around line 44 (warn + exit 0 with a "run `git init` first" hint).
 
-**B10 — `dev-setup.sh` unconditionally clobbers a pre-existing `core.hooksPath` (e.g. Husky), unlike `install.sh` which preserves it** — `scripts/dev-setup.sh:44` · **NOVEL**
+**B10 — `dev-setup.sh` unconditionally clobbers a pre-existing `core.hooksPath` (e.g. Husky), unlike `install.sh` which preserves it** — `scripts/dev-setup.sh:44` · **NOVEL** · ✅ **FIXED** (`fix/audit-b9-b10-dev-setup-hookspath-guards`)
 - **What:** `install.sh:387-398` only sets `core.hooksPath` when unset or already `.githooks`, warning
   otherwise (deliberate Husky/lefthook protection). `dev-setup.sh` overwrites it unconditionally.
 - **Repro:** `git config core.hooksPath .husky` then `dev-setup.sh` → silently becomes `.githooks`;
   the `install.sh` block warns and preserves `.husky`.
 - **Fix:** read the existing value and only set when empty/`.githooks`, else warn. Low (repo-local, a
   maintainer's own scaffold clone) but a genuine parity regression.
+- **Fixed (as landed, B9 + B10 together — same `git config core.hooksPath` line):** the wiring step now
+  mirrors `install.sh:403-414` — an outer `git rev-parse --git-dir` guard (no `.git` → warn + continue
+  to exit 0, no more raw exit 128) wrapping an inner `[ -z "$existing" ] || [ "$existing" = ".githooks" ]`
+  check (a pre-existing Husky/lefthook path is preserved with a warning, not clobbered). The summary line
+  now reports the actual outcome (`-> .githooks` / `left as '…'` / `NOT set`) instead of unconditionally
+  claiming `.githooks`. Locked in `tests/cases/09`: B10-preserve (planted `core.hooksPath=.husky` survives
+  a run), B10 happy-path (unset → `.githooks`), B9 (fake clone with NO `git init` → warns + exit 0).
+  Two independent mutations prove teeth: neutralizing the git-dir guard reddens only B9; neutralizing the
+  preserve check reddens only B10-preserve. Suite **197/0**, `shellcheck -S info` clean.
 
 **B11 — RELEASING.md release-notes `awk` emits EMPTY notes when the literal `vX.Y.Z` placeholder isn't substituted (ships a blank GitHub Release), and uses an unanchored version guard** — `RELEASING.md:47-48` · **NOVEL**
 - **What:** if the maintainer copy-pastes the line without replacing `vX.Y.Z`, no heading matches, awk

--- a/scripts/dev-setup.sh
+++ b/scripts/dev-setup.sh
@@ -60,10 +60,30 @@ done
 
 chmod +x .githooks/pre-commit .githooks/commit-msg .githooks/lib/*
 
-git config core.hooksPath .githooks
+# Wire the hook — mirror install.sh's two guards. Only set core.hooksPath when it
+# is unset or already .githooks, so a pre-existing Husky/lefthook path is preserved
+# rather than silently clobbered. Guard on a real git dir (`git rev-parse
+# --git-dir`, which also covers worktrees/submodules) so a non-git checkout — a
+# tarball download, or a clone before `git init` — warns and continues instead of
+# aborting with a raw `fatal: not in a git directory` (exit 128) after every file
+# is already rendered.
+if git rev-parse --git-dir >/dev/null 2>&1; then
+  existing_hooks_path=$(git config --get core.hooksPath || true)
+  if [ -z "$existing_hooks_path" ] || [ "$existing_hooks_path" = ".githooks" ]; then
+    git config core.hooksPath .githooks
+    hooks_status="core.hooksPath -> .githooks"
+  else
+    hooks_status="core.hooksPath left as '$existing_hooks_path' (pre-existing — not clobbered)"
+    echo "warning: core.hooksPath is already '$existing_hooks_path' — leaving it alone." >&2
+    echo "         Point it at .githooks or chain the scaffold's hook into your setup." >&2
+  fi
+else
+  hooks_status="core.hooksPath NOT set (not a git repo)"
+  echo "warning: not in a git repo — run 'git config core.hooksPath .githooks' after 'git init'." >&2
+fi
 
 libs=(.githooks/lib/*)
 pats=(.forbidden-patterns/*.txt)
-echo "✓ dev hooks rendered; core.hooksPath -> .githooks"
+echo "✓ dev hooks rendered; $hooks_status"
 echo "  active: pre-commit, commit-msg, ${#libs[@]} scanners, ${#pats[@]} pattern files"
 echo "  (gitignored build artifacts — edit the *.template sources, then re-run this script)"

--- a/tests/cases/09-toolchain-clobber.sh
+++ b/tests/cases/09-toolchain-clobber.sh
@@ -442,4 +442,56 @@ else
   echo "  ✗ dev-setup followed a symlinked lib/ dir and wrote a scanner outside the repo (B4)"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
 fi
 rm -rf "$BD"
+
+# --- dev-setup.sh guards the core.hooksPath wiring like install.sh (B9 / B10) --
+# install.sh:403-414 guards the `git config core.hooksPath` step two ways;
+# dev-setup.sh ran it unconditionally. Reuse the minimal fake clone (dev-setup
+# resolves its root from its own path, so a scripts/ + templates tree is enough).
+
+# (T) B10 — a pre-existing core.hooksPath (Husky/lefthook) must be PRESERVED, not
+#     silently clobbered to .githooks. Reverting the guard sets it to .githooks
+#     (this case turns red), mutation-proving the preserve arm.
+HP=$(mktemp -d)
+_b4_fakeclone "$HP/clone"
+( cd "$HP/clone" && git config core.hooksPath .husky )
+( cd "$HP/clone" && bash scripts/dev-setup.sh ) >"$HOOK_OUT" 2>&1 || true
+if [ "$( cd "$HP/clone" && git config --get core.hooksPath )" = ".husky" ] \
+   && grep -qi "already '.husky'" "$HOOK_OUT"; then
+  echo "  ✓ dev-setup preserves a pre-existing core.hooksPath (no Husky clobber)"; PASS=$((PASS + 1))
+else
+  echo "  ✗ dev-setup clobbered a pre-existing core.hooksPath (B10)"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$HP"
+
+# (T) B10 happy path — with NO pre-existing hooksPath, dev-setup still sets
+#     .githooks (guards the fix from breaking the normal dogfooding wiring).
+HH=$(mktemp -d)
+_b4_fakeclone "$HH/clone"
+( cd "$HH/clone" && bash scripts/dev-setup.sh ) >"$HOOK_OUT" 2>&1 || true
+if [ "$( cd "$HH/clone" && git config --get core.hooksPath )" = ".githooks" ]; then
+  echo "  ✓ dev-setup sets core.hooksPath -> .githooks when unset (happy path)"; PASS=$((PASS + 1))
+else
+  echo "  ✗ dev-setup did not wire core.hooksPath on a fresh clone (B10 regression)"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$HH"
+
+# (T) B9 — run before `git init` (a non-git checkout / tarball): dev-setup must
+#     WARN and exit 0, not abort with a raw `fatal: not in a git directory`
+#     (exit 128) after every file is already rendered. Build the fake clone WITHOUT
+#     `git init`; mktemp dirs are not inside a repo, so the git-dir guard fires.
+#     Reverting the guard makes the run exit 128 (this case turns red).
+NG=$(mktemp -d)
+mkdir -p "$NG/clone/scripts" "$NG/clone/githooks/lib" "$NG/clone/forbidden-patterns"
+cp "$SCAFFOLD_DIR/scripts/dev-setup.sh" "$NG/clone/scripts/dev-setup.sh"
+printf '#!/usr/bin/env bash\n' >"$NG/clone/githooks/pre-commit.template"
+printf '#!/usr/bin/env bash\n' >"$NG/clone/githooks/commit-msg.template"
+printf '#!/usr/bin/env bash\n# scanner\n' >"$NG/clone/githooks/lib/check-secrets.template"
+printf 'pat\tdesc\n' >"$NG/clone/forbidden-patterns/secrets.txt.template"
+if ( cd "$NG/clone" && bash scripts/dev-setup.sh ) >"$HOOK_OUT" 2>&1 \
+   && grep -qi 'not in a git repo' "$HOOK_OUT"; then
+  echo "  ✓ dev-setup warns + exits 0 when run before git init (no exit 128)"; PASS=$((PASS + 1))
+else
+  echo "  ✗ dev-setup aborted instead of warning without a git dir (B9)"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$NG"
 reset_repo


### PR DESCRIPTION
## Audit B9 + B10 — `dev-setup.sh` guards the `core.hooksPath` wiring like `install.sh` (low)

Both findings live on the **same** `git config core.hooksPath .githooks` line in
the maintainer dogfooding script, which ran it unconditionally — missing two
guards `install.sh:403-414` already has. Fixed together.

- **B9** — run before `git init` (a tarball checkout, or a clone dir with no
  `.git`), the bare `git config` exits 128 under `set -euo pipefail` and **aborts
  the script after every file is already rendered/chmod'd**. `install.sh` warns and
  exits 0.
- **B10** — it **silently clobbered a pre-existing `core.hooksPath`** (e.g. a
  Husky/lefthook setup). `install.sh` only sets the value when unset or already
  `.githooks`.

### The fix
Mirrors `install.sh`: an outer `git rev-parse --git-dir` guard (also handles
worktrees/submodules) warns + continues to exit 0 outside a git repo, wrapping an
inner `[ -z "$existing" ] || [ "$existing" = ".githooks" ]` check that preserves a
pre-existing non-`.githooks` path with a warning. The completion summary now
reports the real outcome (`-> .githooks` / `left as '…'` / `NOT set`) instead of
unconditionally claiming `.githooks`.

### Tests (`tests/cases/09`, reusing the B4 minimal fake-clone helper)
- **B10-preserve** — planted `core.hooksPath=.husky` survives a run (+ warning).
- **B10 happy-path** — unset → `.githooks` (guards the fix from breaking normal wiring).
- **B9** — fake clone with **no** `git init` → warns + exit 0, not exit 128.

Two independent mutations prove teeth: neutralizing the git-dir guard reddens
**only** B9; neutralizing the preserve check reddens **only** B10-preserve; the
happy path stays green through both. Suite **197/0** (was 194/0), `shellcheck -S
info` clean, local self-lint exit 0. Marks B9 + B10 ✅ FIXED in `SECURITY_AUDIT.md`
+ `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
