### PR TITLE
fix: drop package.json os gate that blocks Windows npm install (audit B8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,14 @@ versioning follows [SemVer](https://semver.org/).
   hooks path is preserved with a warning instead of overwritten. The summary line
   reports the real outcome. Regressions in `tests/cases/09` (Husky path survives;
   unset → `.githooks`; no-`git init` clone warns + exits 0).
+- **npm package no longer blocks native-Windows / Git-Bash installs (B8, low).**
+  `package.json` carried `os: ["darwin","linux"]`, which npm enforces as a hard
+  `EBADPLATFORM` — native Windows (Git Bash and PowerShell) reports `win32`, so the
+  install was refused outright, *before* `cli.js` could print its "run it from Git
+  Bash or WSL" hint, and in contradiction of the README's Windows support. The `os`
+  field is dropped; the runtime already degrades gracefully when `bash` is absent.
+  Guarded in `tests/cases/11` (a jq check that `package.json` has no `os` field, or
+  one that permits `win32`).
 
 ## [v0.9.0] — 2026-06-30
 

--- a/SECURITY_AUDIT.md
+++ b/SECURITY_AUDIT.md
@@ -16,7 +16,7 @@ baseline.
 |---|---|---|---|
 | high | 2 | 1 (B1 ✅) | 1 (B2 ✅ — A1 fix never reached check-hygiene) |
 | medium | 4 | 2 (B3 ✅, B4 ✅) | 2 (B5 ✅, B6 ✅) |
-| low | 6 | 4 (B8, B9 ✅, B10 ✅, B11) | 2 (B7 ✅ variant, B12) |
+| low | 6 | 4 (B8 ✅, B9 ✅, B10 ✅, B11) | 2 (B7 ✅ variant, B12) |
 | info / by-design | 1 | 0 | B13 |
 
 > Two High findings were the actionable headline; **both are now ✅ FIXED**. **B1** was a genuinely
@@ -213,7 +213,7 @@ baseline.
   passes, guarding against a `*key*` broadening). Mutation-neutralizing the glob turns exactly the six
   positives red and leaves #36j green. Suite **194/0**, `shellcheck -S info` clean.
 
-**B8 — `package.json` `os: ["darwin","linux"]` hard-blocks native-Windows / Git-Bash npm install, contradicting `cli.js` + README Windows support** — `package.json:36-39` · **NOVEL**
+**B8 — `package.json` `os: ["darwin","linux"]` hard-blocks native-Windows / Git-Bash npm install, contradicting `cli.js` + README Windows support** — `package.json:36-39` · **NOVEL** · ✅ **FIXED** (`fix/audit-b8-drop-os-gate`)
 - **What:** npm enforces `os` as `EBADPLATFORM` (hard exit 1, package not installed) when
   `process.platform` is not listed. Native Windows (Git Bash and PowerShell) reports `win32`; only WSL
   reports `linux`. Yet `cli.js:38-41` emits a "run it from Git Bash or WSL" hint and `README.md:93-94,
@@ -224,6 +224,13 @@ baseline.
   `["darwin","linux"]`.
 - **Fix:** drop the `os` field (the bash/Windows guidance already lives in `cli.js` + README), or
   replace the hard gate with a non-fatal guidance check inside `cli.js`. Security-neutral; usability only.
+- **Fixed (as landed):** the `os` array is removed from `package.json`. The runtime already handles a
+  missing shell gracefully — `cli.js:36-41` prints the "needs bash — on Windows run it from Git Bash or
+  WSL" hint on `bash` ENOENT — so the hard `os` gate was pure downside (it EBADPLATFORM-refused the
+  install before the hint could ever run) and the README's Windows promise is now true rather than
+  contradicted. Locked in `tests/cases/11` (B8): a jq assertion that `package.json` has no `os` field, or
+  one that permits `win32`; re-adding `os:[darwin,linux]` turns it red. jq-only (runs even without npm).
+  Suite **198/0**.
 
 **B9 — `dev-setup.sh` aborts with raw `fatal: not in a git directory` (exit 128) when run before `git init`, unlike `install.sh`'s graceful guard** — `scripts/dev-setup.sh:44` · **NOVEL** · ✅ **FIXED** (`fix/audit-b9-b10-dev-setup-hookspath-guards`)
 - **What:** `git config core.hooksPath .githooks` runs unconditionally under `set -euo pipefail`; with

--- a/package.json
+++ b/package.json
@@ -35,10 +35,6 @@
   "engines": {
     "node": ">=14"
   },
-  "os": [
-    "darwin",
-    "linux"
-  ],
   "keywords": [
     "pre-commit",
     "git-hooks",

--- a/tests/cases/11-npm-bundle.sh
+++ b/tests/cases/11-npm-bundle.sh
@@ -71,3 +71,21 @@ else
   fi
   rm -f "$C11"
 fi
+
+# (B8) The npm package must NOT carry an `os` allowlist that EBADPLATFORM-blocks a
+# native-Windows / Git-Bash install (win32). cli.js already emits the "run from Git
+# Bash or WSL" hint at runtime, so a hard os gate only stops the user reaching it —
+# npm refuses the install first. Assert there is no os field, or (if present) that
+# it permits win32. jq-only, so it runs even where npm is unavailable; reverting the
+# fix (re-adding os:[darwin,linux]) turns this red.
+if command -v jq >/dev/null 2>&1; then
+  os_ok=$(jq -r 'if has("os") then ((.os | index("win32")) != null) else true end' \
+            "$SCAFFOLD_DIR/package.json" 2>/dev/null)
+  if [ "$os_ok" = "true" ]; then
+    echo "  ✓ package.json os field does not block Windows/Git-Bash npm install (B8)"; PASS=$((PASS + 1))
+  else
+    echo "  ✗ package.json os EBADPLATFORM-blocks win32 — drop the field or add win32 (B8)"; FAIL=$((FAIL + 1))
+  fi
+else
+  echo "  ~ skipped B8 os-field check (jq not available)"
+fi


### PR DESCRIPTION
## Audit B8 — drop the `os` gate that blocks Windows / Git-Bash npm install (low)

`package.json` carried `os: ["darwin","linux"]`, which npm enforces as a hard
**`EBADPLATFORM`** (exit 1, nothing installed) whenever `process.platform` isn't
listed. Native Windows — both Git Bash and PowerShell — reports **`win32`** (only
WSL reports `linux`), so the `npm`/`npx` install was refused outright, **before**
`cli.js` could print its "needs bash — on Windows run it from Git Bash or WSL" hint
(`cli.js:36-41`), and in direct contradiction of the README's Git-Bash/Windows
support promise.

### The fix
Remove the `os` field. It's a redundant hard gate — the runtime already degrades
gracefully on a missing shell (the ENOENT branch prints the actionable hint).
Dropping it lets a Git-Bash user actually reach that guidance and makes the
README's Windows claim true. Security-neutral, usability only. No README change
needed (it already documents Windows support).

### Test (`tests/cases/11`, B8)
A jq assertion that `package.json` has **no** `os` field, or one that permits
`win32`. Re-adding `os:[darwin,linux]` turns it red. jq-only, so it runs even where
npm is unavailable.

Suite **198/0** (was 197/0), local self-lint exit 0. Marks B8 ✅ FIXED in
`SECURITY_AUDIT.md` + `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
