### PR TITLE
fix: install.sh skips one over-backup-capped file instead of aborting (audit B12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,15 @@ versioning follows [SemVer](https://semver.org/).
   field is dropped; the runtime already degrades gracefully when `bash` is absent.
   Guarded in `tests/cases/11` (a jq check that `package.json` has no `os` field, or
   one that permits `win32`).
+- **`install.sh` no longer aborts mid-run when one file's backup slots are full
+  (B12, low).** When all 100 `.scaffold-bak[.N]` slots for a `--force`-replaced file
+  were taken, `_backup` returned non-zero and the bare caller aborted the whole
+  script under `set -e` — leaving hooks unwired, before `core.hooksPath` was set,
+  with no summary. The three call sites now skip that one file (leaving the user's
+  version untouched — no backup means no safe overwrite) and the install continues
+  and completes. `_backup` prints a "skipping this one file — re-run after cleanup"
+  notice so the skip is visible. Guarded in `tests/cases/12` (100 saturated slots →
+  the file keeps its local edit and the run still reaches `Done`).
 
 ## [v0.9.0] — 2026-06-30
 

--- a/SECURITY_AUDIT.md
+++ b/SECURITY_AUDIT.md
@@ -16,7 +16,7 @@ baseline.
 |---|---|---|---|
 | high | 2 | 1 (B1 ✅) | 1 (B2 ✅ — A1 fix never reached check-hygiene) |
 | medium | 4 | 2 (B3 ✅, B4 ✅) | 2 (B5 ✅, B6 ✅) |
-| low | 6 | 4 (B8 ✅, B9 ✅, B10 ✅, B11) | 2 (B7 ✅ variant, B12) |
+| low | 6 | 4 (B8 ✅, B9 ✅, B10 ✅, B11) | 2 (B7 ✅ variant, B12 ✅) |
 | info / by-design | 1 | 0 | B13 |
 
 > Two High findings were the actionable headline; **both are now ✅ FIXED**. **B1** was a genuinely
@@ -266,13 +266,28 @@ baseline.
   echo "ERROR: empty release notes" >&2; exit 1; }` before `gh release create`. Maintainer-procedure
   doc defect, recoverable post-hoc — low.
 
-**B12 — `_backup` >99-cap `return 1` aborts the whole install mid-run with no rollback (a concrete trigger of the already-tracked `set -e` mid-script-abort limitation)** — `install.sh:127` · **already tracked** (`SECURITY_AUDIT.md:45`, Medium, open)
+**B12 — `_backup` >99-cap `return 1` aborts the whole install mid-run with no rollback (a concrete trigger of the already-tracked `set -e` mid-script-abort limitation)** — `install.sh:127` · **already tracked** (`SECURITY_AUDIT.md:45`, Medium, open) · ✅ **FIXED** (`fix/audit-b12-backup-cap-skip`)
 - **What:** with 100 stale `.scaffold-bak[.N]` files for a destination, `_backup` returns 1; callers do
   `_backup "$dst" || return 1`; under `set -euo pipefail` the bare top-level `cp_*` call aborts the
   script. On a first install this happens before the `core.hooksPath` wiring, leaving hooks unwired with
   no rollback/summary. Fails closed (nothing half-trusted) and is visible (error + exit 1).
 - **Fix:** on the >99 case, warn-and-skip the backup for that one file (`return 0`) instead of `return 1`,
   or make callers tolerate it; add an EXIT-trap summary of what was/wasn't installed.
+- **Fixed (as landed):** took the "callers tolerate it" path (not `return 0` from `_backup` itself, which
+  would fall through to `_cp_replace` and overwrite the file with **no** backup = silent data loss). All
+  three sites (`cp_safe`, `cp_scaffold`, `cp_pattern`) now do `_backup "$dst" || return 0`: on the cap the
+  caller SKIPS that one file — leaving the user's version untouched (no backup ⇒ no safe overwrite) — and
+  the run continues to wire hooks and print `Done`. `_backup` emits a two-line "skipping this one file …
+  re-run after cleanup" notice, so the skip is visible; the install still exits 0 (a loud-but-non-fatal
+  degrade, matching the finding's "make callers tolerate it"). The EXIT-trap install summary was **not**
+  added — it is a larger structural change with new global state, out of scope for this low-severity abort
+  fix. Locked in `tests/cases/12` (B12): saturate all 100 `ruff.toml.scaffold-bak[.N]` slots, `--force`
+  re-install → the cap trips, `ruff.toml` keeps its local edit, and the run still reaches `Done`. Reverting
+  to `return 1` reddens exactly this case (install aborts mid-run). Suite **199/0**, `shellcheck -S info`
+  clean. The test lives in a **new `cases/12`** rather than `cases/09` because `cases/09` (and `install.sh`)
+  were both at the scaffold's own 500-line module cap — extracting a new case file is the cap's intended
+  "extract a module" response, not a suppression. (Note: `install.sh` now sits at exactly 500 lines; a
+  genuine module extraction there is looming and tracked separately as a pre-existing cleanup.)
 
 ### ℹ️ By design / re-confirmed (captured, not new work)
 

--- a/install.sh
+++ b/install.sh
@@ -118,14 +118,17 @@ _cp_replace() {
 
 # _backup DST — copy an existing file/symlink aside to <dst>.scaffold-bak[.N]
 # before it is replaced, so no local edit is ever silently destroyed. `-P` backs
-# up a symlink AS the link, never the dereferenced target content.
+# up a symlink AS the link, never the dereferenced target content. Returns non-zero
+# when all >99 slots are taken; callers treat that as "skip this one file, keep
+# going" (`|| return 0`) — never abort, and never overwrite without a backup.
 _backup() {
   local dst=$1
   local bak="${dst}.scaffold-bak" n=0
   while [ -e "$bak" ] || [ -L "$bak" ]; do
     n=$((n + 1))
     if [ "$n" -gt 99 ]; then
-      echo "error: too many .scaffold-bak files for $dst — clean some up" >&2
+      echo "error: too many .scaffold-bak files for $dst — clean some up." >&2
+      echo "       Skipping this one file (left untouched); re-run after cleanup." >&2
       return 1
     fi
     bak="${dst}.scaffold-bak.${n}"
@@ -152,7 +155,7 @@ cp_safe() {
     if [ ! -L "$dst" ] && cmp -s "$src" "$dst"; then
       return
     fi
-    _backup "$dst" || return 1
+    _backup "$dst" || return 0
   fi
   _cp_replace "$src" "$dst"
   echo "installed:    $dst"
@@ -171,7 +174,7 @@ cp_scaffold() {
     if [ ! -L "$dst" ] && cmp -s "$src" "$dst"; then
       return
     fi
-    [ "$FORCE" -eq 1 ] && { _backup "$dst" || return 1; }
+    [ "$FORCE" -eq 1 ] && { _backup "$dst" || return 0; }
     _cp_replace "$src" "$dst"
     echo "updated:      $dst (refreshed to the shipped version)"
     return
@@ -198,7 +201,7 @@ cp_pattern() {
       fi
       return
     fi
-    _backup "$dst" || return 1
+    _backup "$dst" || return 0
   fi
   _cp_replace "$src" "$dst"
   echo "installed:    $dst"

--- a/tests/cases/12-install-backup-cap.sh
+++ b/tests/cases/12-install-backup-cap.sh
@@ -1,0 +1,30 @@
+# shellcheck shell=bash
+# cases/12-install-backup-cap.sh — install.sh's _backup >99-cap must not abort the
+# whole run (audit B12). Sourced into the driver's shell, so the globals
+# (PASS/FAIL/HOOK_OUT/SCAFFOLD_DIR) and helpers (reset_repo) are already in scope.
+# Split out of cases/09 (which is at the 500-line module cap) rather than weakened.
+
+echo "cases/12 — install backup-cap skip (B12)"
+
+# With all 100 .scaffold-bak[.N] slots taken for one --force'd file, _backup used
+# to `return 1`; the bare cp_safe call then aborted the entire script under set -e,
+# leaving hooks unwired with no summary. It now SKIPS that one file — leaving the
+# user's version untouched (no backup ⇒ no safe overwrite) — and finishes the rest.
+B12=$(mktemp -d)
+( cd "$B12" && git init --quiet && echo '{"name":"x"}' >package.json && echo 'name="x"' >pyproject.toml \
+  && "$SCAFFOLD_DIR/install.sh" --both --no-verify >/dev/null 2>&1 )
+# Make ruff.toml (a user-owned cp_safe file) differ so --force will try to back it up.
+echo '# LOCAL EDIT B12' >>"$B12/ruff.toml"
+# Saturate the backup slots: base + .1..99 = 100 existing ⇒ the cap trips.
+: >"$B12/ruff.toml.scaffold-bak"
+for i in $(seq 1 99); do : >"$B12/ruff.toml.scaffold-bak.$i"; done
+if ( cd "$B12" && "$SCAFFOLD_DIR/install.sh" --both --force --no-verify ) >"$HOOK_OUT" 2>&1 \
+   && grep -q 'too many .scaffold-bak' "$HOOK_OUT" \
+   && grep -q 'Done' "$HOOK_OUT" \
+   && grep -q 'LOCAL EDIT B12' "$B12/ruff.toml"; then
+  echo "  ✓ install skips an over-backup-capped file and completes (no mid-run abort) (B12)"; PASS=$((PASS + 1))
+else
+  echo "  ✗ install aborted on the backup cap or clobbered the capped file (B12)"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$B12"
+reset_repo

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -46,7 +46,8 @@ for case_file in \
   "$HERE/cases/08-overrides-gitleaks.sh" \
   "$HERE/cases/09-toolchain-clobber.sh" \
   "$HERE/cases/10-ci-diff-scope.sh" \
-  "$HERE/cases/11-npm-bundle.sh"; do
+  "$HERE/cases/11-npm-bundle.sh" \
+  "$HERE/cases/12-install-backup-cap.sh"; do
   # shellcheck source=/dev/null
   . "$case_file"
 done


### PR DESCRIPTION
## Audit B12 — `_backup` >99-cap must not abort the whole install (low)

When all 100 `.scaffold-bak[.N]` slots for a `--force`-replaced file were taken,
`_backup` returned non-zero and the bare `cp_*` caller **aborted the entire install
under `set -euo pipefail`** — leaving hooks unwired (this happens *before* the
`core.hooksPath` wiring), with no rollback or summary.

### The fix
All three call sites (`cp_safe`, `cp_scaffold`, `cp_pattern`) now do
`_backup "$dst" || return 0`: on the cap the caller **skips that one file** —
leaving the user's version untouched — and the run continues to wire hooks and
print `Done`.

Deliberately **not** `return 0` from `_backup` itself: that would fall through to
`_cp_replace` and overwrite the file with no backup = silent data loss. No backup
⇒ no safe overwrite, so skipping is the fail-safe choice. `_backup` prints a
two-line "skipping this one file — re-run after cleanup" notice, so the skip is
visible; the install still exits 0 (a loud-but-non-fatal degrade, per the finding's
"make callers tolerate it"). The EXIT-trap install summary the finding floated is
**out of scope** (larger structural change, new global state) for this low fix.

### Test — new `tests/cases/12-install-backup-cap.sh`
Saturate all 100 `ruff.toml.scaffold-bak[.N]` slots, `--force` re-install → the cap
trips, `ruff.toml` keeps its local edit, and the run still reaches `Done`. Reverting
to `return 1` reddens exactly this case (verified).

**Why a new case file:** `cases/09` *and* `install.sh` were both at the scaffold's
own **500-line module cap**, so the size guardrail (correctly) blocked adding the
test to `cases/09`. Extracting a new case file is the cap's intended "extract a
module" response — not a `.scaffold.toml` suppression. `install.sh` now sits at
exactly 500 lines; a genuine module extraction there is looming and is flagged as a
separate pre-existing cleanup (not done here — out of scope for B12).

Suite **199/0**, `shellcheck -S info` clean, local self-lint exit 0. Marks B12 ✅
FIXED in `SECURITY_AUDIT.md` + `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
