### PR TITLE
fix: RELEASING.md release-notes awk can't ship blank or leaky notes (audit B11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,16 @@ versioning follows [SemVer](https://semver.org/).
   and completes. `_backup` prints a "skipping this one file — re-run after cleanup"
   notice so the skip is visible. Guarded in `tests/cases/12` (100 saturated slots →
   the file keeps its local edit and the run still reaches `Done`).
+- **`RELEASING.md` release-notes extraction no longer risks a blank or leaky
+  GitHub Release (B11, low).** The `awk` that slices the CHANGELOG section for a tag
+  used an unanchored end-of-section guard (`!/vX\.Y\.Z/`), so an adjacent heading
+  containing the version as a substring (e.g. `vX.Y.Z-hotfix`) could leak its body
+  into the notes; and if the maintainer ran the snippet without substituting
+  `vX.Y.Z`, it emitted 0 bytes and `gh release create` shipped an empty-body Release
+  with no error. The guard is now anchored (`!/^## \[vX\.Y\.Z\]/`) and a
+  `[ -s /tmp/notes.md ]` check aborts loudly on empty notes before publishing.
+  Docs-only (maintainer procedure); both cases were reproduced and the fix verified
+  against a crafted CHANGELOG fixture.
 
 ## [v0.9.0] — 2026-06-30
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -43,8 +43,14 @@ The version lives in these places — all must agree on `vX.Y.Z`:
 git checkout main && git pull --ff-only
 git tag -a vX.Y.Z -m "vX.Y.Z — <one-line summary>"
 git push origin vX.Y.Z
-# Release notes = the CHANGELOG section for this version:
-awk '/^## \[vX\.Y\.Z\]/{f=1} /^## \[/{if(f && !/vX\.Y\.Z/)exit} f' CHANGELOG.md > /tmp/notes.md
+# Release notes = the CHANGELOG section for this version. The end-of-section guard
+# is ANCHORED (`^## \[vX\.Y\.Z\]`) so an adjacent heading that merely CONTAINS the
+# version as a substring (e.g. a `vX.Y.Z-hotfix`) can't leak its body into the notes.
+awk '/^## \[vX\.Y\.Z\]/{f=1} /^## \[/{if(f && !/^## \[vX\.Y\.Z\]/)exit} f' CHANGELOG.md > /tmp/notes.md
+# Fail loudly instead of shipping a BLANK release: if vX.Y.Z wasn't substituted
+# above, no heading matches, awk emits 0 bytes, and `gh release create` would
+# otherwise publish empty notes with no error.
+[ -s /tmp/notes.md ] || { echo "ERROR: empty release notes — did you substitute vX.Y.Z?" >&2; exit 1; }
 gh release create vX.Y.Z --title "vX.Y.Z — <summary>" --notes-file /tmp/notes.md
 ```
 

--- a/SECURITY_AUDIT.md
+++ b/SECURITY_AUDIT.md
@@ -16,7 +16,7 @@ baseline.
 |---|---|---|---|
 | high | 2 | 1 (B1 ✅) | 1 (B2 ✅ — A1 fix never reached check-hygiene) |
 | medium | 4 | 2 (B3 ✅, B4 ✅) | 2 (B5 ✅, B6 ✅) |
-| low | 6 | 4 (B8 ✅, B9 ✅, B10 ✅, B11) | 2 (B7 ✅ variant, B12 ✅) |
+| low | 6 | 4 (B8 ✅, B9 ✅, B10 ✅, B11 ✅) | 2 (B7 ✅ variant, B12 ✅) |
 | info / by-design | 1 | 0 | B13 |
 
 > Two High findings were the actionable headline; **both are now ✅ FIXED**. **B1** was a genuinely
@@ -256,7 +256,7 @@ baseline.
   Two independent mutations prove teeth: neutralizing the git-dir guard reddens only B9; neutralizing the
   preserve check reddens only B10-preserve. Suite **197/0**, `shellcheck -S info` clean.
 
-**B11 — RELEASING.md release-notes `awk` emits EMPTY notes when the literal `vX.Y.Z` placeholder isn't substituted (ships a blank GitHub Release), and uses an unanchored version guard** — `RELEASING.md:47-48` · **NOVEL**
+**B11 — RELEASING.md release-notes `awk` emits EMPTY notes when the literal `vX.Y.Z` placeholder isn't substituted (ships a blank GitHub Release), and uses an unanchored version guard** — `RELEASING.md:47-48` · **NOVEL** · ✅ **FIXED** (`fix/audit-b11-releasing-notes-guard`)
 - **What:** if the maintainer copy-pastes the line without replacing `vX.Y.Z`, no heading matches, awk
   emits 0 bytes, and the next command `gh release create … --notes-file /tmp/notes.md` publishes a
   blank-body Release with no error. Separately, the exit guard `!/vX\.Y\.Z/` is an unanchored substring
@@ -265,6 +265,16 @@ baseline.
 - **Fix:** anchor the guard to the heading (`!/^## \[vX\.Y\.Z\]/`) and add `[ -s /tmp/notes.md ] || {
   echo "ERROR: empty release notes" >&2; exit 1; }` before `gh release create`. Maintainer-procedure
   doc defect, recoverable post-hoc — low.
+- **Fixed (as landed):** both applied. The end-of-section guard is now
+  `!/^## \[vX\.Y\.Z\]/` (anchored, so an adjacent `## [vX.Y.Z-hotfix]`-style heading no longer leaks its
+  body), and a `[ -s /tmp/notes.md ] || { echo "ERROR: empty release notes — did you substitute
+  vX.Y.Z?"; exit 1; }` gate sits before `gh release create` so an un-substituted placeholder aborts
+  loudly instead of shipping a blank Release. **No permanent regression test:** RELEASING.md is a
+  copy-paste maintainer procedure with no shipped code path to regress, and a test that greps + evals the
+  awk out of the markdown would be brittle theater. Instead both bugs were **reproduced empirically** and
+  the fix verified against a crafted CHANGELOG fixture (unsubstituted `vX.Y.Z` → 0 bytes caught by the
+  new `-s` gate; a `v0.9.0-hotfix` sibling heading leaked under the old unanchored guard and is correctly
+  excluded under the anchored one). Suite unchanged at **199/0** (doc-only change).
 
 **B12 — `_backup` >99-cap `return 1` aborts the whole install mid-run with no rollback (a concrete trigger of the already-tracked `set -e` mid-script-abort limitation)** — `install.sh:127` · **already tracked** (`SECURITY_AUDIT.md:45`, Medium, open) · ✅ **FIXED** (`fix/audit-b12-backup-cap-skip`)
 - **What:** with 100 stale `.scaffold-bak[.N]` files for a destination, `_backup` returns 1; callers do


### PR DESCRIPTION
## Audit B11 — `RELEASING.md` release-notes `awk` (low, docs-only)

The `awk` that slices the CHANGELOG section for a tag had two defects:

- **Empty notes** — run with the literal `vX.Y.Z` placeholder unsubstituted, no
  heading matches, `awk` emits 0 bytes, and the next `gh release create --notes-file
  /tmp/notes.md` publishes a **blank-body Release with no error**.
- **Unanchored guard** — the end-of-section test `!/vX\.Y\.Z/` is a substring match,
  so an adjacent heading that merely *contains* the version (e.g. `## [vX.Y.Z-hotfix]`)
  fails to terminate the section and **leaks its body** into the notes (latent — today's
  flat SemVer tags never collide).

### The fix (both)
- Anchor the guard: `!/vX\.Y\.Z/` → `!/^## \[vX\.Y\.Z\]/`.
- Add `[ -s /tmp/notes.md ] || { echo "ERROR: empty release notes …"; exit 1; }` before
  `gh release create`, so an un-substituted placeholder aborts loudly.

### Verification
Docs-only — a copy-paste maintainer procedure with no shipped code path to regress, so
**no permanent test** (a grep+eval-the-markdown test would be brittle theater). Both bugs
were **reproduced empirically** and the fix verified against a crafted CHANGELOG fixture:

| Case | Old behavior | New behavior |
|------|-------------|-------------|
| Unsubstituted `vX.Y.Z` | 0 bytes → blank Release | `-s` gate aborts with an error |
| `v0.9.0-hotfix` sibling heading | leaked into notes | correctly excluded |
| Normal `v0.9.0` section | correct | correct (unchanged) |

Suite unchanged at **199/0**, local self-lint exit 0. Marks B11 ✅ FIXED in
`SECURITY_AUDIT.md` + `CHANGELOG.md`. **This closes the last actionable finding** of the
2026-06-30 packaging audit — B1–B12 all fixed; B13 is by-design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
