### PR TITLE
chore: release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+## [v0.10.0] — 2026-07-01
+
+A packaging / robustness release that closes the remaining findings of the
+2026-06-30 packaging audit (B1–B12). Two scanner-coverage additions
+(`check-filenames` now blocks non-dotfile `*.env` files and binary
+key/keystore files), native-Windows / Git-Bash `npm` install support, and a
+set of `install.sh` / `dev-setup.sh` robustness and parity fixes.
+
 ### Security
 - **`check-hygiene` fails closed on over-long lines (B2, high).** The A1
   fail-closed fix had only reached `check-secrets`/`check-patterns`; the

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ somewhere stable:
 
 ```sh
 # Recommended: pin to a tagged release for reproducibility
-git clone --branch v0.9.0 https://github.com/Sting25/ai-coding-rules-scaffold ~/src/ai-coding-rules-scaffold
+git clone --branch v0.10.0 https://github.com/Sting25/ai-coding-rules-scaffold ~/src/ai-coding-rules-scaffold
 # Or track main if you want the latest changes
 git clone https://github.com/Sting25/ai-coding-rules-scaffold ~/src/ai-coding-rules-scaffold
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-coding-rules-scaffold",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Agent-agnostic coding-rules scaffold: pre-commit + CI guardrails (file size, forbidden patterns, secret/credential scanning, hygiene) that install into your project. Run via `npx ai-coding-rules-scaffold`.",
   "bin": {
     "ai-coding-rules-scaffold": "bin/cli.js"


### PR DESCRIPTION
## Release v0.10.0

Release-prep PR (step 1 of `RELEASING.md`): promote the changelog, bump the README
clone pin and `package.json` version. Closes the 2026-06-30 packaging audit —
**B1–B12 all fixed**; B13 is by-design.

### What changed (three files)
- `CHANGELOG.md` — `[Unreleased]` → `## [v0.10.0] — 2026-07-01`, fresh empty `[Unreleased]` on top.
- `README.md` — clone pin `v0.9.0` → `v0.10.0`.
- `package.json` — `"version"` `0.9.0` → `0.10.0`.

The Homebrew `.rb` is intentionally **not** touched here — its `sha256` can only be
computed from the tag tarball, so it's a post-tag step (`RELEASING.md` §4).

### Highlights since v0.9.0
- `check-filenames` now blocks non-dotfile `*.env` files (B5) and binary key/keystore
  files (B7) — new scanner coverage.
- Native-Windows / Git-Bash `npm` install support — dropped the `os` gate (B8).
- `dev-setup.sh` `core.hooksPath` guards mirroring `install.sh` (B9/B10); `install.sh`
  no longer aborts on a saturated backup cap (B12); `RELEASING.md` release-notes `awk`
  hardened (B11).
- Plus the earlier B2/B3/B4/B6 over-cap fail-closed + npm-bundle + dev-setup symlink fixes.

### Verification
Suite **199/0**, staged self-lint exit 0, whole-tree `check-secrets` dry-run exit 0
(per `RELEASING.md` step 3d). After merge: tag → GitHub release → `npm publish` →
Homebrew tap bump (maintainer credentials).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
