### PR TITLE
refactor: extract install.sh file-write helpers to install-lib.sh

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -19,4 +19,4 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           persist-credentials: false
-      - run: shellcheck -S info install.sh uninstall.sh scripts/dev-setup.sh tests/run.sh tests/lib/common.sh tests/cases/*.sh githooks/pre-commit.template githooks/lib/check-size.template githooks/lib/check-patterns.template githooks/lib/check-filenames.template githooks/lib/check-secrets.template githooks/lib/check-hygiene.template githooks/lib/ci-changed-files.template githooks/lib/agent-precheck.template githooks/commit-msg.template
+      - run: shellcheck -S info install.sh install-lib.sh uninstall.sh scripts/dev-setup.sh tests/run.sh tests/lib/common.sh tests/cases/*.sh githooks/pre-commit.template githooks/lib/check-size.template githooks/lib/check-patterns.template githooks/lib/check-filenames.template githooks/lib/check-secrets.template githooks/lib/check-hygiene.template githooks/lib/ci-changed-files.template githooks/lib/agent-precheck.template githooks/commit-msg.template

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,16 @@ set of `install.sh` / `dev-setup.sh` robustness and parity fixes.
   Docs-only (maintainer procedure); both cases were reproduced and the fix verified
   against a crafted CHANGELOG fixture.
 
+### Changed
+- **`install.sh` file-write helpers extracted to a sourced `install-lib.sh`.**
+  Internal refactor, no behavior change: the `cp_scaffold`/`cp_safe`/`cp_pattern`
+  policy functions and the shared `_cp_replace`/`_backup`/`mkx` mechanism (~130
+  lines) moved into `install-lib.sh`, which `install.sh` now sources, dropping it
+  from 500 → 380 lines (back under the scaffold's own 500-line module cap). The
+  new file is shipped in the npm bundle (`package.json` `files`) and covered by the
+  bundle-completeness and shellcheck gates. Verified by the full suite plus an
+  end-to-end install smoke test.
+
 ## [v0.9.0] — 2026-06-30
 
 A security-hardening release. A full multi-dimension re-audit of the scaffold's

--- a/SECURITY_AUDIT.md
+++ b/SECURITY_AUDIT.md
@@ -296,8 +296,16 @@ baseline.
   to `return 1` reddens exactly this case (install aborts mid-run). Suite **199/0**, `shellcheck -S info`
   clean. The test lives in a **new `cases/12`** rather than `cases/09` because `cases/09` (and `install.sh`)
   were both at the scaffold's own 500-line module cap — extracting a new case file is the cap's intended
-  "extract a module" response, not a suppression. (Note: `install.sh` now sits at exactly 500 lines; a
-  genuine module extraction there is looming and tracked separately as a pre-existing cleanup.)
+  "extract a module" response, not a suppression.
+- **Follow-up DONE (module extraction):** the "looming" `install.sh` cap pressure this fix surfaced was
+  then resolved — the file-write policy helpers (`_cp_replace`/`_backup`/`cp_safe`/`cp_scaffold`/
+  `cp_pattern`/`mkx`, ~130 lines) were extracted verbatim into a sourced **`install-lib.sh`**, dropping
+  `install.sh` from 500 → **380 lines** (120 of headroom). Sourced via `. "$SCAFFOLD_DIR/install-lib.sh"`,
+  so `cases/11`'s bundle guard auto-detects it as REQUIRED (now 46 files checked) and it was added to
+  `package.json` `files` + the `shellcheck.yml` lint list. Behavior-preserving: suite **199/0**, plus a
+  fresh end-to-end smoke (install → hook blocks a `config.env`+AWS-key commit → `--force` backs up via the
+  sourced `_backup`). `shellcheck -S info` clean (the `FORCE` global is defaulted with `: "${FORCE:=0}"`
+  so the lib lints standalone without SC2154).
 
 ### ℹ️ By design / re-confirmed (captured, not new work)
 

--- a/install-lib.sh
+++ b/install-lib.sh
@@ -1,0 +1,145 @@
+# shellcheck shell=bash
+# install-lib.sh — file-write policy helpers for install.sh.
+#
+# SOURCED (not executed) by install.sh, so these functions run in that script's
+# shell under its `set -euo pipefail` and read its globals (FORCE). Extracted here
+# so install.sh stays under the scaffold's own 500-line module-size cap — the
+# guardrail the scaffold enforces on every project it installs into, itself
+# included. Behavior is identical to when these lived inline in install.sh.
+
+# Default the caller-provided global so this file also lints/behaves standalone.
+# install.sh always sets FORCE before sourcing, so this is a no-op there; if the
+# lib is ever sourced without it, 0 (= not --force) is the safe default.
+: "${FORCE:=0}"
+
+# --- file ownership & the install/upgrade model -----------------------------
+# Re-running install.sh is the supported UPGRADE path, so each destination is
+# copied through the policy its OWNERSHIP demands:
+#
+#   cp_scaffold  scaffold-owned CODE — scanners, libs, hooks, CI workflows. These
+#                carry security fixes, so a plain re-run REFRESHES them whenever
+#                they differ from the shipped version (no --force needed); that's
+#                how an upgrader who just re-runs install.sh actually receives the
+#                fixes. The prior bytes are recoverable from git + the scaffold,
+#                so a routine refresh writes no backup (only --force does).
+#   cp_safe      USER-OWNED files — ruff.toml, eslint config, .scaffold.toml,
+#                dependabot.yml, the rules docs, etc. A project customizes these,
+#                so they're never auto-replaced: skip unless --force (which backs
+#                up first). CLAUDE.md / AGENTS.md have their own merge handlers.
+#   cp_pattern   .forbidden-patterns/*.txt — the hard case: scaffold-SHIPPED yet
+#                user-EXTENDED (teams append their own rows). Auto-overwriting
+#                would clobber those rows, so a re-run only NOTIFIES on drift and
+#                keeps the user's file; --force backs up + replaces so the user's
+#                additions survive in .scaffold-bak for manual merge-back.
+#
+# The three policies share one write MECHANISM (_cp_replace) and one backup
+# routine (_backup), so the A7 symlink defenses live in exactly one place.
+
+# _cp_replace SRC DST — the actual write. `[ -e ]` alone is false for a DANGLING
+# symlink and follows a LIVE one, so a pre-existing symlink at a scaffold path
+# used to make `cp` follow it and write the scanner to the link's target OUTSIDE
+# the repo. We `rm -f` the destination first (dropping any symlink) so we always
+# write a real regular file IN the tree, never THROUGH a link.
+_cp_replace() {
+  local src=$1 dst=$2
+  mkdir -p "$(dirname "$dst")"
+  rm -f "$dst"
+  cp "$src" "$dst"
+}
+
+# _backup DST — copy an existing file/symlink aside to <dst>.scaffold-bak[.N]
+# before it is replaced, so no local edit is ever silently destroyed. `-P` backs
+# up a symlink AS the link, never the dereferenced target content. Returns non-zero
+# when all >99 slots are taken; callers treat that as "skip this one file, keep
+# going" (`|| return 0`) — never abort, and never overwrite without a backup.
+_backup() {
+  local dst=$1
+  local bak="${dst}.scaffold-bak" n=0
+  while [ -e "$bak" ] || [ -L "$bak" ]; do
+    n=$((n + 1))
+    if [ "$n" -gt 99 ]; then
+      echo "error: too many .scaffold-bak files for $dst — clean some up." >&2
+      echo "       Skipping this one file (left untouched); re-run after cleanup." >&2
+      return 1
+    fi
+    bak="${dst}.scaffold-bak.${n}"
+  done
+  cp -P "$dst" "$bak"
+  echo "backed up:    $dst -> $bak"
+}
+
+# cp_safe SRC DST — USER-OWNED file. Install if absent; otherwise leave it alone
+# unless --force (which backs up the differing file, then replaces it).
+cp_safe() {
+  local src=$1 dst=$2
+  if [ -e "$dst" ] || [ -L "$dst" ]; then
+    if [ "$FORCE" -eq 0 ]; then
+      if [ -L "$dst" ]; then
+        echo "skip (exists, symlink): $dst — left untouched; a scaffold path that is a symlink is suspicious. Replace it with --force."
+      else
+        echo "skip (exists): $dst  — left untouched (use --force to replace)"
+      fi
+      return
+    fi
+    # --force: back up before overwriting, but only when it actually differs. A
+    # symlink is never compared through (`-L` short-circuits) and always replaced.
+    if [ ! -L "$dst" ] && cmp -s "$src" "$dst"; then
+      return
+    fi
+    _backup "$dst" || return 0
+  fi
+  _cp_replace "$src" "$dst"
+  echo "installed:    $dst"
+}
+
+# cp_scaffold SRC DST — SCAFFOLD-OWNED code. Refreshes on diff so security fixes
+# reach upgraders on a plain re-run. Identical → silent no-op. A symlink planted
+# at a scaffold-owned path is always replaced with the real scanner (better than
+# leaving a dead link there) and never written through. No backup on a routine
+# refresh — the prior bytes are scaffold code, recoverable from git history and
+# the scaffold repo; --force still backs up first for parity with cp_safe.
+cp_scaffold() {
+  local src=$1 dst=$2
+  if [ -e "$dst" ] || [ -L "$dst" ]; then
+    # Already current? Never compare THROUGH a symlink (A7).
+    if [ ! -L "$dst" ] && cmp -s "$src" "$dst"; then
+      return
+    fi
+    [ "$FORCE" -eq 1 ] && { _backup "$dst" || return 0; }
+    _cp_replace "$src" "$dst"
+    echo "updated:      $dst (refreshed to the shipped version)"
+    return
+  fi
+  _cp_replace "$src" "$dst"
+  echo "installed:    $dst"
+}
+
+# cp_pattern SRC DST — .forbidden-patterns/*.txt. Install if absent; if it drifts
+# from the shipped version, NOTIFY (the user may have added rows; new shipped
+# rules may be worth merging) but keep the user's file. --force backs up + writes
+# the shipped version, so the user's additions survive in .scaffold-bak.
+cp_pattern() {
+  local src=$1 dst=$2
+  if [ -e "$dst" ] || [ -L "$dst" ]; then
+    if [ ! -L "$dst" ] && cmp -s "$src" "$dst"; then
+      return
+    fi
+    if [ "$FORCE" -eq 0 ]; then
+      if [ -L "$dst" ]; then
+        echo "skip (exists, symlink): $dst — left untouched; a scaffold path that is a symlink is suspicious. Replace it with --force."
+      else
+        echo "note (drift):  $dst differs from the shipped patterns — your customizations are kept. Diff against forbidden-patterns/$(basename "$dst").template for new rules to merge, or re-run with --force to replace (backs yours up to .scaffold-bak)."
+      fi
+      return
+    fi
+    _backup "$dst" || return 0
+  fi
+  _cp_replace "$src" "$dst"
+  echo "installed:    $dst"
+}
+
+# chmod +x only a real regular file. A scaffold path that cp_safe deliberately
+# SKIPPED because it's a (possibly dangling) symlink must not abort the install
+# via a chmod that follows a broken link and fails under set -e — nor should we
+# flip the mode of a skipped, user-owned file.
+mkx() { if [ -f "$1" ]; then chmod +x "$1"; fi; }

--- a/install.sh
+++ b/install.sh
@@ -82,136 +82,16 @@ if [ "$MODE" = "auto" ]; then
 fi
 
 # --- file ownership & the install/upgrade model -----------------------------
-# Re-running install.sh is the supported UPGRADE path, so each destination is
-# copied through the policy its OWNERSHIP demands:
-#
-#   cp_scaffold  scaffold-owned CODE — scanners, libs, hooks, CI workflows. These
-#                carry security fixes, so a plain re-run REFRESHES them whenever
-#                they differ from the shipped version (no --force needed); that's
-#                how an upgrader who just re-runs install.sh actually receives the
-#                fixes. The prior bytes are recoverable from git + the scaffold,
-#                so a routine refresh writes no backup (only --force does).
-#   cp_safe      USER-OWNED files — ruff.toml, eslint config, .scaffold.toml,
-#                dependabot.yml, the rules docs, etc. A project customizes these,
-#                so they're never auto-replaced: skip unless --force (which backs
-#                up first). CLAUDE.md / AGENTS.md have their own merge handlers.
-#   cp_pattern   .forbidden-patterns/*.txt — the hard case: scaffold-SHIPPED yet
-#                user-EXTENDED (teams append their own rows). Auto-overwriting
-#                would clobber those rows, so a re-run only NOTIFIES on drift and
-#                keeps the user's file; --force backs up + replaces so the user's
-#                additions survive in .scaffold-bak for manual merge-back.
-#
-# The three policies share one write MECHANISM (_cp_replace) and one backup
-# routine (_backup), so the A7 symlink defenses live in exactly one place.
-
-# _cp_replace SRC DST — the actual write. `[ -e ]` alone is false for a DANGLING
-# symlink and follows a LIVE one, so a pre-existing symlink at a scaffold path
-# used to make `cp` follow it and write the scanner to the link's target OUTSIDE
-# the repo. We `rm -f` the destination first (dropping any symlink) so we always
-# write a real regular file IN the tree, never THROUGH a link.
-_cp_replace() {
-  local src=$1 dst=$2
-  mkdir -p "$(dirname "$dst")"
-  rm -f "$dst"
-  cp "$src" "$dst"
-}
-
-# _backup DST — copy an existing file/symlink aside to <dst>.scaffold-bak[.N]
-# before it is replaced, so no local edit is ever silently destroyed. `-P` backs
-# up a symlink AS the link, never the dereferenced target content. Returns non-zero
-# when all >99 slots are taken; callers treat that as "skip this one file, keep
-# going" (`|| return 0`) — never abort, and never overwrite without a backup.
-_backup() {
-  local dst=$1
-  local bak="${dst}.scaffold-bak" n=0
-  while [ -e "$bak" ] || [ -L "$bak" ]; do
-    n=$((n + 1))
-    if [ "$n" -gt 99 ]; then
-      echo "error: too many .scaffold-bak files for $dst — clean some up." >&2
-      echo "       Skipping this one file (left untouched); re-run after cleanup." >&2
-      return 1
-    fi
-    bak="${dst}.scaffold-bak.${n}"
-  done
-  cp -P "$dst" "$bak"
-  echo "backed up:    $dst -> $bak"
-}
-
-# cp_safe SRC DST — USER-OWNED file. Install if absent; otherwise leave it alone
-# unless --force (which backs up the differing file, then replaces it).
-cp_safe() {
-  local src=$1 dst=$2
-  if [ -e "$dst" ] || [ -L "$dst" ]; then
-    if [ "$FORCE" -eq 0 ]; then
-      if [ -L "$dst" ]; then
-        echo "skip (exists, symlink): $dst — left untouched; a scaffold path that is a symlink is suspicious. Replace it with --force."
-      else
-        echo "skip (exists): $dst  — left untouched (use --force to replace)"
-      fi
-      return
-    fi
-    # --force: back up before overwriting, but only when it actually differs. A
-    # symlink is never compared through (`-L` short-circuits) and always replaced.
-    if [ ! -L "$dst" ] && cmp -s "$src" "$dst"; then
-      return
-    fi
-    _backup "$dst" || return 0
-  fi
-  _cp_replace "$src" "$dst"
-  echo "installed:    $dst"
-}
-
-# cp_scaffold SRC DST — SCAFFOLD-OWNED code. Refreshes on diff so security fixes
-# reach upgraders on a plain re-run. Identical → silent no-op. A symlink planted
-# at a scaffold-owned path is always replaced with the real scanner (better than
-# leaving a dead link there) and never written through. No backup on a routine
-# refresh — the prior bytes are scaffold code, recoverable from git history and
-# the scaffold repo; --force still backs up first for parity with cp_safe.
-cp_scaffold() {
-  local src=$1 dst=$2
-  if [ -e "$dst" ] || [ -L "$dst" ]; then
-    # Already current? Never compare THROUGH a symlink (A7).
-    if [ ! -L "$dst" ] && cmp -s "$src" "$dst"; then
-      return
-    fi
-    [ "$FORCE" -eq 1 ] && { _backup "$dst" || return 0; }
-    _cp_replace "$src" "$dst"
-    echo "updated:      $dst (refreshed to the shipped version)"
-    return
-  fi
-  _cp_replace "$src" "$dst"
-  echo "installed:    $dst"
-}
-
-# cp_pattern SRC DST — .forbidden-patterns/*.txt. Install if absent; if it drifts
-# from the shipped version, NOTIFY (the user may have added rows; new shipped
-# rules may be worth merging) but keep the user's file. --force backs up + writes
-# the shipped version, so the user's additions survive in .scaffold-bak.
-cp_pattern() {
-  local src=$1 dst=$2
-  if [ -e "$dst" ] || [ -L "$dst" ]; then
-    if [ ! -L "$dst" ] && cmp -s "$src" "$dst"; then
-      return
-    fi
-    if [ "$FORCE" -eq 0 ]; then
-      if [ -L "$dst" ]; then
-        echo "skip (exists, symlink): $dst — left untouched; a scaffold path that is a symlink is suspicious. Replace it with --force."
-      else
-        echo "note (drift):  $dst differs from the shipped patterns — your customizations are kept. Diff against forbidden-patterns/$(basename "$dst").template for new rules to merge, or re-run with --force to replace (backs yours up to .scaffold-bak)."
-      fi
-      return
-    fi
-    _backup "$dst" || return 0
-  fi
-  _cp_replace "$src" "$dst"
-  echo "installed:    $dst"
-}
-
-# chmod +x only a real regular file. A scaffold path that cp_safe deliberately
-# SKIPPED because it's a (possibly dangling) symlink must not abort the install
-# via a chmod that follows a broken link and fails under set -e — nor should we
-# flip the mode of a skipped, user-owned file.
-mkx() { if [ -f "$1" ]; then chmod +x "$1"; fi; }
+# The install/upgrade policy helpers — cp_scaffold (scaffold-owned CODE, refreshed
+# on re-run), cp_safe (USER-OWNED, never auto-replaced), cp_pattern
+# (.forbidden-patterns/*.txt, notify-on-drift), and the shared _cp_replace /
+# _backup mechanism (where the A7 symlink defenses live) plus mkx — are defined in
+# install-lib.sh. They're SOURCED (not exec'd) so they run in this shell with its
+# globals (FORCE) and `set -euo pipefail`. Extracted to keep this script under the
+# scaffold's own 500-line module-size cap; see install-lib.sh for the full policy
+# rationale.
+# shellcheck source=install-lib.sh
+. "$SCAFFOLD_DIR/install-lib.sh"
 
 # install_claude_md — CLAUDE.md is USER-OWNED project memory, not a scaffold
 # file. Never replace it (not even with --force). If absent, create it from

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "files": [
     "install.sh",
+    "install-lib.sh",
     "uninstall.sh",
     "bin/",
     "githooks/",


### PR DESCRIPTION
## Extract `install.sh` file-write helpers → `install-lib.sh`

`install.sh` was at **exactly 500 lines** — the scaffold's own dogfooded module-size
cap — with zero headroom, so the next edit would be blocked by its own guardrail
(surfaced while landing B12). This extracts the file-write helpers into a sourced
library rather than suppressing the cap.

### What moved (verbatim, ~130 lines)
`cp_scaffold` / `cp_safe` / `cp_pattern` and the shared `_cp_replace` / `_backup` /
`mkx` mechanism (where the A7 symlink defenses and the B12 backup-cap skip live) →
`install-lib.sh`. `install.sh` now sources it via `. "$SCAFFOLD_DIR/install-lib.sh"`,
so the functions run in its shell with its globals (`FORCE`) and `set -euo pipefail`.

**install.sh: 500 → 380 lines** (120 of headroom).

### No behavior change — verified
- Full suite **199/0**; `shellcheck -S info` clean.
- Fresh **end-to-end smoke**: `install --both` → hooks wired + `core.hooksPath` set;
  the installed hook blocks a `config.env`+AWS-key commit on both layers (0 commits
  land); `--force` backs `ruff.toml` up via the now-sourced `_backup`.

### Wiring (so the extraction can't silently break anything)
- `package.json` `files` += `install-lib.sh` — an unshipped source file = a broken
  `npx` install.
- `cases/11` bundle guard auto-detects it as REQUIRED via the `$SCAFFOLD_DIR` source
  ref (**now 46 files checked**) — fails closed if it's ever unshipped.
- `shellcheck.yml` lint list += `install-lib.sh` (the CI job uses an explicit file
  list, not a glob).
- `: "${FORCE:=0}"` at the top defaults the caller-provided global so the lib lints
  standalone (no SC2154) and is defensive if sourced without it.

Folds into the not-yet-tagged **v0.10.0**; the `SECURITY_AUDIT.md` follow-up note is
marked done. Closes the "extract a module from install.sh" task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
