### PR TITLE
ci: automate releases via npm trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,93 @@
+name: release
+
+# Cuts a release when a version tag (vX.Y.Z) is pushed: re-runs the test suite,
+# publishes to npm via TRUSTED PUBLISHING (OIDC — no NPM_TOKEN, no 2FA prompt), and
+# creates the GitHub Release from the CHANGELOG. Maintainer CI — NOT installed into
+# consumer projects (unlike the *.yml.template files).
+#
+# One-time setup this depends on (see RELEASING.md): on npmjs.com, configure the
+# package's Trusted Publisher = GitHub Actions, org "Sting25", repo
+# "ai-coding-rules-scaffold", workflow filename "release.yml". Without it, the
+# publish step fails closed (npm rejects the OIDC exchange) — nothing half-ships.
+
+on:
+  push:
+    tags: ["v[0-9]+.[0-9]+.[0-9]+"]
+
+permissions:
+  contents: read
+
+jobs:
+  # Gate: never publish a tag whose tests don't pass. The cross-platform matrix
+  # runs on every PR; here a single fast ubuntu run guards a tag pushed directly.
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+      - run: chmod +x tests/run.sh install.sh githooks/pre-commit.template
+      - run: ./tests/run.sh
+
+  publish-npm:
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write  # mint the OIDC token npm trusted publishing verifies
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          # Node 24 bundles npm >= 11.6; trusted publishing (OIDC) needs npm
+          # >= 11.5.1, so the bundled npm is already new enough — no ad-hoc upgrade.
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+          # Zero-dep package: nothing to cache. Disabling it also removes the
+          # cache-poisoning surface on this publish-triggered workflow.
+          package-manager-cache: false
+      - name: Verify the tag matches package.json version
+        # A tag whose version disagrees with package.json would publish the wrong
+        # version string — fail closed before touching the registry.
+        run: |
+          tag_ver="${GITHUB_REF_NAME#v}"
+          pkg_ver="$(node -p "require('./package.json').version")"
+          if [ "$tag_ver" != "$pkg_ver" ]; then
+            echo "::error::tag $GITHUB_REF_NAME does not match package.json version $pkg_ver"
+            exit 1
+          fi
+      - name: Publish to npm (OIDC trusted publishing, provenance auto)
+        # No NODE_AUTH_TOKEN: npm auto-detects the OIDC environment and exchanges
+        # it for a short-lived credential. Provenance is generated automatically.
+        run: npm publish
+
+  github-release:
+    needs: publish-npm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # create the GitHub Release
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Build release notes from the CHANGELOG section
+        # Slice the `## [vX.Y.Z]` section up to the next `## [` heading. Matched by
+        # literal prefix (not regex) so the tag can't inject a pattern, and fails
+        # closed on an empty slice (a missing/mis-titled section) rather than
+        # shipping a blank release — the B11 lesson, enforced in CI.
+        run: |
+          awk -v h="## [${GITHUB_REF_NAME}]" '
+            index($0, h) == 1 { f = 1; print; next }
+            /^## \[/ { if (f) exit }
+            f { print }
+          ' CHANGELOG.md > "$RUNNER_TEMP/notes.md"
+          if [ ! -s "$RUNNER_TEMP/notes.md" ]; then
+            echo "::error::no CHANGELOG section found for $GITHUB_REF_NAME"
+            exit 1
+          fi
+      - name: Create the GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --notes-file "$RUNNER_TEMP/notes.md"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -37,36 +37,56 @@ The version lives in these places — all must agree on `vX.Y.Z`:
    - Open the PR, wait for CI green on **both** runners, merge (`--merge`, never
      `--auto` — this repo has no branch protection).
 
-## 2. Tag + GitHub release
+## 2. Push the tag — CI publishes (npm + GitHub release)
+
+Once the prep PR is merged, tag `main` and push. The **`release.yml`** workflow
+does the rest: runs the test suite, publishes to npm via **trusted publishing
+(OIDC — no `NPM_TOKEN`, no 2FA prompt)** with provenance, and creates the GitHub
+Release from the CHANGELOG section for the tag.
 
 ```sh
 git checkout main && git pull --ff-only
 git tag -a vX.Y.Z -m "vX.Y.Z — <one-line summary>"
-git push origin vX.Y.Z
+git push origin vX.Y.Z          # triggers release.yml
+gh run watch                    # or watch the Actions tab
+```
+
+On success: `npm view ai-coding-rules-scaffold version` shows `X.Y.Z` (with a
+provenance badge) and `gh release list` shows `vX.Y.Z` marked **Latest**. The
+workflow fails **closed** if the tag doesn't match `package.json` (a tag pushed
+without the prep bump aborts before touching the registry) or if the CHANGELOG
+section is missing/empty (no blank release ships).
+
+### One-time setup (per package — already done for this one)
+
+OIDC publishing depends on a **Trusted Publisher** registered on npmjs.com. Do
+this ONCE per package (all fields case-sensitive, exact):
+
+npmjs.com → the package → **Settings → Trusted Publisher → GitHub Actions**:
+- **Organization or user:** `Sting25`
+- **Repository:** `ai-coding-rules-scaffold`
+- **Workflow filename:** `release.yml`
+- **Allowed actions:** `npm publish`
+
+No token is stored anywhere. GitHub mints a short-lived OIDC token scoped to this
+repo + workflow file; npm verifies it against the config above. (Requires npm
+≥ 11.5.1 / Node ≥ 22.14 — the workflow pins Node 24, which bundles a new-enough npm.)
+
+### Manual fallback (only if Actions is unavailable)
+
+```sh
+git tag -a vX.Y.Z -m "vX.Y.Z — <summary>" && git push origin vX.Y.Z
 # Release notes = the CHANGELOG section for this version. The end-of-section guard
 # is ANCHORED (`^## \[vX\.Y\.Z\]`) so an adjacent heading that merely CONTAINS the
 # version as a substring (e.g. a `vX.Y.Z-hotfix`) can't leak its body into the notes.
 awk '/^## \[vX\.Y\.Z\]/{f=1} /^## \[/{if(f && !/^## \[vX\.Y\.Z\]/)exit} f' CHANGELOG.md > /tmp/notes.md
-# Fail loudly instead of shipping a BLANK release: if vX.Y.Z wasn't substituted
-# above, no heading matches, awk emits 0 bytes, and `gh release create` would
-# otherwise publish empty notes with no error.
 [ -s /tmp/notes.md ] || { echo "ERROR: empty release notes — did you substitute vX.Y.Z?" >&2; exit 1; }
 gh release create vX.Y.Z --title "vX.Y.Z — <summary>" --notes-file /tmp/notes.md
+npm publish   # ⚠ manual publish needs a 2FA OTP or a bypass-enabled granular token
+              #   (npm mandate). Trusted publishing above avoids both — prefer it.
 ```
 
-Confirm it's latest: `gh release list` shows `vX.Y.Z` marked **Latest**.
-
-## 3. Publish to npm
-
-```sh
-npm publish            # needs `npm login` first; npm may prompt for a 2FA OTP
-npm view ai-coding-rules-scaffold version   # confirm it shows X.Y.Z
-```
-
-The package has zero dependencies, so there's no lockfile to manage. `npx
-ai-coding-rules-scaffold` resolves the new version automatically.
-
-## 4. Update the Homebrew tap
+## 3. Update the Homebrew tap
 
 The formula's `url` points at the GitHub source tarball for the tag; bump the
 `url` + recompute the `sha256`:
@@ -93,7 +113,7 @@ brew uninstall ai-coding-rules-scaffold                      # clean up
 > `brew tap-new you/localtest --no-git`, copy the `.rb` into its `Formula/`, then
 > `brew style you/localtest/ai-coding-rules-scaffold`. Untap when done.
 
-## 5. Smoke-test both registries
+## 4. Smoke-test both registries
 
 ```sh
 # npm
@@ -102,10 +122,11 @@ npx -y ai-coding-rules-scaffold@X.Y.Z --help
 brew install sting25/tap/ai-coding-rules-scaffold && ai-coding-rules-scaffold --help
 ```
 
-## Future: automate
+## Future: automate the Homebrew tap too
 
-This is currently manual on purpose (it needs the maintainer's npm + GitHub
-auth). A `release.yml` triggered on tag push could publish to npm (with an
-`NPM_TOKEN` secret) and open a PR to the tap bumping `url`/`sha256` (with a
-tap-scoped PAT) — deriving every copy from the tag so steps 3–4 can't drift.
-Worth adding once the cadence justifies the secret setup.
+npm publish + the GitHub Release are automated (`release.yml`, OIDC — no secret).
+The one remaining manual step is the Homebrew tap bump (§3): it needs a
+**cross-repo push** to `Sting25/homebrew-tap`, which the default `GITHUB_TOKEN`
+can't do — so a follow-on job would need a tap-scoped PAT (or deploy key) secret
+to compute the `sha256` from the tag tarball and push the formula. Deferred until
+it's worth managing that one secret; it's the only token the pipeline would hold.


### PR DESCRIPTION
## Automated, tokenless releases

Adds `.github/workflows/release.yml`. On a `vX.Y.Z` tag push it: runs the test suite →
publishes to npm via **trusted publishing (OIDC — no `NPM_TOKEN`, no 2FA prompt)** with
provenance → creates the GitHub Release from the CHANGELOG. This retires the manual
publish that just cost an hour of 2FA/token pain (npm now mandates 2FA-or-bypass-token
for *manual* publishes, and the maintainer's passkey produces no typed OTP — OIDC avoids
all of it).

### Passes the repo's own gates with **zero suppressions**
The tricky part was staying clean under this repo's `zizmor` + `actionlint` CI. Both
findings got **real fixes**, not `# zizmor: ignore`:
| Finding | Real fix (not a suppression) |
|---|---|
| `adhoc-packages` (`npm install -g`) | **Node 24** bundles npm 11.6 ≥ the 11.5.1 OIDC needs → drop the ad-hoc install entirely |
| `cache-poisoning` (setup-node on a publish trigger) | `package-manager-cache: false` — the documented remediation (zero deps, nothing to cache) |

### Hardening
- Least privilege: top-level `contents: read`; `id-token: write` only on the publish job; `contents: write` only on the release job.
- Actions SHA-pinned (reuses the repo's checkout pin; fresh setup-node pin; no pin-drift).
- Fails **closed**: tag must equal `package.json` version; release notes use the B11-hardened anchored + non-empty CHANGELOG slice (no blank release ships).
- Not shipped to consumers (real `.yml`, not a `*.yml.template`; not in `package.json` `files`).

### One-time setup this needs (documented in RELEASING.md)
npmjs.com → package → **Settings → Trusted Publisher → GitHub Actions**: org `Sting25`,
repo `ai-coding-rules-scaffold`, workflow `release.yml`, allowed action `npm publish`.
No secret is stored anywhere.

RELEASING.md is rewritten: "push the tag, CI publishes" is now the primary path; the manual
`awk`/`gh`/`npm publish` sequence is the fallback. Homebrew tap bump stays manual (cross-repo
push needs a PAT — flagged as the one deferred automation). Suite **199/0**; release.yml is
`zizmor`/`actionlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
