### PR TITLE
build(ci): bump actions/setup-python to v6.3.0 (all pins)

### DIFF
--- a/.github/workflows/coverage.yml.template
+++ b/.github/workflows/coverage.yml.template
@@ -51,7 +51,7 @@ jobs:
 
       # ── Python: pytest + coverage → coverage.xml (Cobertura) ──────────────
       - if: steps.detect.outputs.python == 'true'
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: "3.12"
       - name: Run Python tests with coverage

--- a/.github/workflows/lint.yml.template
+++ b/.github/workflows/lint.yml.template
@@ -43,7 +43,7 @@ jobs:
             echo "present=true" >> "$GITHUB_OUTPUT"
           fi
       - if: steps.detect.outputs.present == 'true'
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: "3.12"
       - if: steps.detect.outputs.present == 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           persist-credentials: false
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: "3.12"
       - run: pip install ruff


### PR DESCRIPTION
Supersedes #43, which bumped only `test.yml` + `lint.yml.template` and **missed `coverage.yml.template`** — that partial bump leaves `setup-python` at two SHAs, which the `test.yml` pin-drift guard fails closed on (why #43's tests went red).

Bumps all **three** references to v6.3.0 (`ece7cb06…`, current latest). pin-drift clean (1 SHA/action), actionlint + zizmor clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)