### PR TITLE
Full code + security review: 30 findings fixed (suite 199→227)

### DIFF
--- a/.github/workflows/coverage.yml.template
+++ b/.github/workflows/coverage.yml.template
@@ -59,7 +59,10 @@ jobs:
         # `|| true` so a no-tests-collected exit doesn't mask the diff-cover
         # verdict below; diff-cover reads coverage.xml and is the gate.
         run: |
-          pip install pytest pytest-cov
+          # Pinned: an unpinned `pip install` executes whatever version is newest
+          # at run time, minutes after publish — contradicting the cooldown posture
+          # the scaffold's dependabot.yml.template documents. Dependabot bumps these.
+          pip install pytest==9.1.1 pytest-cov==7.1.0
           pytest --cov --cov-report=xml || true
 
       # ── Frontend: vitest V8 coverage → coverage/cobertura-coverage.xml ────
@@ -83,7 +86,7 @@ jobs:
       # ── Gate: every changed line must be covered ──────────────────────────
       - name: Enforce patch coverage (diff-cover)
         run: |
-          pip install diff-cover
+          pip install diff-cover==10.3.0  # pinned (see note above); Dependabot bumps
           git fetch --no-tags --depth=1 origin "$GITHUB_BASE_REF"
           REPORTS=""
           [ -f coverage.xml ] && REPORTS="$REPORTS coverage.xml"

--- a/.github/workflows/lint.yml.template
+++ b/.github/workflows/lint.yml.template
@@ -206,7 +206,13 @@ jobs:
           fail=0
           git ls-files -z '*.php' '*.phtml' | xargs -0 -r -n1 php -l >/dev/null || fail=1
           if [ -f composer.json ] && [ -f composer.lock ]; then
-            composer install --no-interaction --no-progress --prefer-dist || true
+            # --no-scripts --no-plugins: never execute a dependency's composer
+            # lifecycle scripts/plugins in CI (the same supply-chain class the
+            # frontend job's `npm ci --ignore-scripts` defends against — the
+            # runner holds GITHUB_TOKEN). phpcs is pure PHP and needs neither.
+            # Surface an install failure (fail=1) instead of `|| true`, which
+            # silently skipped phpcs and passed the job green.
+            composer install --no-interaction --no-progress --prefer-dist --no-scripts --no-plugins || fail=1
           fi
           if [ -x vendor/bin/phpcs ]; then vendor/bin/phpcs || fail=1; fi
           exit $fail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,14 @@ jobs:
   publish-npm:
     needs: test
     runs-on: ubuntu-latest
+    # HARDENING (opt-in, needs out-of-band config): this job publishes on any
+    # matching tag push — npm trusted publishing binds only org/repo/workflow,
+    # not a ref or environment, so anyone who can push a v* tag can mint a
+    # release. To gate it, add `environment: release` here, then in GitHub add
+    # required reviewers to that environment AND (optionally) set the environment
+    # in the npm trusted-publisher config; and/or add a tag-protection ruleset
+    # restricting who can create v* tags. Left un-gated by default so a fresh
+    # clone's release pipeline works without manual environment setup.
     permissions:
       contents: read
       id-token: write  # mint the OIDC token npm trusted publishing verifies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,18 +26,27 @@ jobs:
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: "3.12"
-      - run: pip install ruff
+      # Pin the linter version (supply-chain posture: the repo's own
+      # dependabot.yml justifies a cooldown so a compromised-and-yanked release
+      # isn't executed minutes after publish — an unpinned `pip install ruff`
+      # contradicted that). Bump deliberately.
+      - run: pip install ruff==0.15.22
       - name: Install actionlint
-        # Validates the rendered lint.yml is a parseable GitHub Actions
-        # workflow — guards against the job-level `if: hashFiles(...)` class
-        # of error that silently disables every job. The download script is
-        # pinned to a COMMIT SHA, not the mutable v1.7.12 tag, so a moved tag
-        # or a compromised release can't swap the script under us. The `1.7.12`
-        # arg is the actionlint version the (pinned) script then downloads.
+        # Validates the rendered lint.yml is a parseable GitHub Actions workflow
+        # — guards against the job-level `if: hashFiles(...)` class of error that
+        # silently disables every job. Download the PINNED release asset and
+        # verify its sha256 before executing it: a GitHub release asset is mutable
+        # independently of its tag, so pinning only the download SCRIPT (the prior
+        # approach) still trusted whatever tarball the release currently serves.
+        # Pin + checksum = a swapped asset fails the build instead of running in CI.
         run: |
           mkdir -p "$RUNNER_TEMP/bin"
-          # SHA is rhysd/actionlint tag v1.7.12.
-          bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/914e7df21a07ef503a81201c76d2b11c789d3fca/scripts/download-actionlint.bash) 1.7.12 "$RUNNER_TEMP/bin"
+          ver=1.7.12
+          sha=8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
+          url="https://github.com/rhysd/actionlint/releases/download/v${ver}/actionlint_${ver}_linux_amd64.tar.gz"
+          curl -fsSL "$url" -o "$RUNNER_TEMP/actionlint.tgz"
+          echo "${sha}  $RUNNER_TEMP/actionlint.tgz" | sha256sum -c -
+          tar -xzf "$RUNNER_TEMP/actionlint.tgz" -C "$RUNNER_TEMP/bin" actionlint
           echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
       - name: Static-audit our own workflows (zizmor)
         # Machine-verifies the CI hardening the scaffold claims — SHA-pinned

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Drop-in guardrails that **block bad code from being committed or merged**. One `
 - **Two layers, one implementation** — the hook and the CI job call the exact same `lib/check-*` scripts, so they can never drift apart.
 - **Agent-agnostic** — rules live in `AGENTS.md` (with a thin `CLAUDE.md` pointer); Cursor, Claude Code, Aider, and others read them directly.
 - **Tunable, not all-or-nothing** — per-path size caps and per-rule disable/warn via `.scaffold.toml`, plus inline `# scaffold-allow` for the rare legitimate exception.
-- **Cleanly removable** — `./uninstall.sh` reverses everything and never touches the content of your own `CLAUDE.md` / `AGENTS.md`.
+- **Cleanly removable** — `uninstall.sh` reverses everything and never touches the content of your own `CLAUDE.md` / `AGENTS.md` (see [Update & uninstall](#update--uninstall) for how to run it per install method).
 
 ## Why this exists
 
@@ -42,7 +42,7 @@ That setup hits four compounding failure modes that ordinary linting alone doesn
 
 4. **Forbidden patterns recur.** Agents reach for old import paths, deprecated service names, and outdated idioms because their training data still has them. A per-stack regex deny-list (`backend.txt`, `frontend.txt`, `secrets.txt`, `shell.txt`) is the only durable fix — the agent can't be talked out of recurrent muscle memory, but the build can fail on it.
 
-This scaffold ships the **enforcement layer** that addresses all four directly. Two layers are live: commit-time (the pre-commit hook) and merge-time (the CI mirror), both running the same `lib/check-*` scripts. A third layer — agent-runtime hooks that block bad patterns *before* they're written — is deferred; see [`RECOMMENDATIONS.md`](./RECOMMENDATIONS.md) for the design space and tradeoffs.
+This scaffold ships the **enforcement layer** that addresses all four directly. Two layers are always-on: commit-time (the pre-commit hook) and merge-time (the CI mirror), both running the same `lib/check-*` scripts. A third opt-in layer — agent-runtime hooks that block bad patterns *before* they're written — ships via `install.sh --claude` (Claude Code) and `install.sh --cursor` (Cursor); see [Opt-in layers](#opt-in-layers) and [`RECOMMENDATIONS.md`](./RECOMMENDATIONS.md) for the design space and tradeoffs.
 
 What the scaffold doesn't try to solve: parallel-session collisions, context-window discipline across long projects, and spec-first workflows. Those belong to git workflow (`git worktree` per session), nested `CLAUDE.md` files, and project-specific spec docs respectively. Recommended patterns for each are documented in `AGENTS.md` and `RECOMMENDATIONS.md`.
 
@@ -91,7 +91,9 @@ npx ai-coding-rules-scaffold --both --claude  # + AI-agent guardrails (also --cu
 
 This fetches the published package and runs the same installer documented below —
 every flag in the list further down works after `npx ai-coding-rules-scaffold …`.
-Re-run it any time to upgrade (it refreshes scaffold-owned files, keeps your edits).
+To upgrade, run `npx ai-coding-rules-scaffold@latest` (the `@latest` tag forces
+npm to re-resolve the current release, bypassing any cached version — bare-spec
+`npx` on npm 7–8 can silently reuse a stale cached copy and skip the upgrade).
 Needs Node ≥ 14 and `bash` (preinstalled on macOS/Linux; use Git Bash or WSL on
 Windows). The package has zero dependencies — it's just the installer + templates.
 
@@ -323,10 +325,13 @@ Commit + CI-breaking (pre-commit hook + `lint.yml`):
 
 When a regex match is intentional — a CLI entry point that needs `print`,
 a docs example showing an AWS key prefix, a fixture with a synthetic
-credential — append `scaffold-allow` (any case, in a comment) on the
-matched line. `check-patterns` and `check-secrets` skip lines containing
-the marker; `check-filenames` and `check-size` are file-level and
-unaffected. See `forbidden-patterns/README.md` for examples.
+credential — append `scaffold-allow` (any case) after a comment leader
+(`#`, `//`, `/*`, or `<!--`) on the matched line. The marker must follow
+a comment leader; a bare `scaffold-allow` inside a string literal is NOT
+exempt. `check-patterns` and `check-secrets` skip lines containing the
+marker; `check-filenames` and `check-size` are file-level and
+unaffected. See `forbidden-patterns/README.md` for examples and the full
+leader spec.
 
 **Reviewers: every PR that adds or moves a `scaffold-allow` marker is
 suppressing a guardrail.** Treat new markers like new `# noqa`s — confirm
@@ -353,13 +358,13 @@ by       = "alex 2026-06-11"
 [rules."frontend/console.log left in code"]
 severity = "warn"          # error (default) → warn: still reported, doesn't fail
 
-[rules.case-collision]     # hygiene ids: conflict-marker, case-collision
+[rules.case-collision]     # hygiene ids: conflict-marker, case-collision, hidden-unicode
 severity = "warn"
 ```
 
 - **Rule ids.** Forbidden-pattern rules are keyed `"<patternfile-stem>/<description>"`
   (the text after the TAB in `.forbidden-patterns/<lang>.txt`). Hygiene rules
-  use `conflict-marker` / `case-collision`; the size cap uses `size`.
+  use `conflict-marker` / `case-collision` / `hidden-unicode`; the size cap uses `size`.
 - **Disable vs downgrade.** `disabled = true` turns the rule off; `severity =
   "warn"` keeps emitting the finding (a CI `::warning::`) without failing the
   build — a relaxed rule stays visible, never silent.
@@ -380,8 +385,8 @@ severity = "warn"
 Beyond the always-on hook + CI mirror, three extras are available. They're off
 by default so the scaffold stays minimal; turn them on per project.
 
-- **Agent-runtime guardrails (`install.sh --claude`).** The deferred "layer
-  three" — catching bad input *before* the agent writes it, not at commit time.
+- **Agent-runtime guardrails (`install.sh --claude`).** The opt-in third layer —
+  catching bad input *before* the agent writes it, not at commit time.
   Installs a `.claude/settings.json` that denies the agent reading credential
   files (`.env`, `*.pem`, `*.key`, `~/.ssh/**`, `~/.aws/**`, …) and a
   `PreToolUse` hook (`.githooks/lib/agent-precheck`) that scans Write/Edit/Bash
@@ -473,7 +478,7 @@ git commit -m "should be rejected"
 - **`.forbidden-patterns/*.txt`** — TAB-separated `<regex>\t<description>` lines (one per language, auto-discovered via each file's `# scaffold-extensions:` header). Add deprecated import paths, old service names, etc. Lines starting with `#` are comments; an opt-in TODO/FIXME pattern is pre-seeded as a comment.
 - **`ruff.toml`** — enables `E,F,I,W,B,UP,SIM,PTH,ANN,ASYNC,FAST,G,LOG,BLE,C90,PL,PT,RUF` plus a curated `flake8-bandit` `S` security subset. Trim `ignore = [...]` if a rule fights your style.
 - **Pre-commit hook** — `MAX_LINES=500` by default. Override per-invocation: `MAX_LINES=800 git commit`. Edit the hook to change permanently. The CI workflow reads the same env var.
-- **Adopting on an existing codebase** — the local hook scans only the files in a given commit, but the CI job scans *all* tracked files (size, patterns, filenames, and secrets alike), not just changed ones. So the first PR after adoption surfaces pre-existing debt: a file already over 500 lines, an existing `print()`, or a secret already in history all fail in CI even if the PR didn't touch them. For the size case, extract the offenders first (preferred — this is the debt the rule is meant to catch) or set `MAX_LINES` higher temporarily in both the hook and CI, then ratchet it down as you refactor.
+- **Adopting on an existing codebase** — the local hook scans only staged files. In CI, the scope splits: the **secret and credential-filename scans run whole-tree** (so a pre-existing committed secret or a bad filename surfaces on the first PR even if that PR never touched the file — catching already-committed keys is the whole point); but the **size, forbidden-pattern, and hygiene gates are scoped to the PR/push diff**, so pre-existing oversize files and existing `print()`s are grandfathered until the next time those files change. This matches the behaviour described in [Philosophy](#philosophy) above.
 
 ## Update & uninstall
 
@@ -486,13 +491,29 @@ diff ~/src/ai-coding-rules-scaffold/ruff.toml.template ruff.toml
 
 A `git pull` in the scaffold clone picks up new rules / patterns upstream.
 
-**Uninstall:**
+**Uninstall** (run from your project root — choose the path that matches how you installed):
 
-```sh
-~/src/ai-coding-rules-scaffold/uninstall.sh            # safe: only unmodified files
-~/src/ai-coding-rules-scaffold/uninstall.sh --dry-run  # preview
-~/src/ai-coding-rules-scaffold/uninstall.sh --all      # also nuke AGENTS.md, coding-rules.md, patterns
-```
+- **git-clone install:** run `uninstall.sh` directly from the clone:
+  ```sh
+  ~/src/ai-coding-rules-scaffold/uninstall.sh            # safe: only unmodified files
+  ~/src/ai-coding-rules-scaffold/uninstall.sh --dry-run  # preview
+  ~/src/ai-coding-rules-scaffold/uninstall.sh --all      # also nuke AGENTS.md, coding-rules.md, patterns
+  ```
+
+- **Homebrew install:** `uninstall.sh` is bundled in the formula's `libexec`:
+  ```sh
+  bash "$(brew --prefix)/opt/ai-coding-rules-scaffold/libexec/uninstall.sh"
+  # add --dry-run or --all as needed
+  ```
+
+- **npx install:** there is no persistent on-disk copy of the scaffold, so
+  `uninstall.sh` isn't directly available after an npx run. To uninstall,
+  clone the repo temporarily and run it from there:
+  ```sh
+  git clone https://github.com/Sting25/ai-coding-rules-scaffold /tmp/scaffold-uninstall
+  /tmp/scaffold-uninstall/uninstall.sh   # run from your project root
+  rm -rf /tmp/scaffold-uninstall
+  ```
 
 Safe mode only removes files whose content matches the current scaffold template byte-for-byte, so local edits are never lost. `AGENTS.md`, `coding-rules.md`, and `.forbidden-patterns/` are kept unless you pass `--all`. `CLAUDE.md` is treated as a regenerable pointer and removed if unchanged.
 
@@ -510,7 +531,6 @@ Safe mode only removes files whose content matches the current scaffold template
 | Logging conventions, whole-repo coverage % | Per-project decision (the shipped gate measures *patch* coverage, not a global threshold) |
 | `ruff format` (Python formatting) | Drop-in if you want; Python formatting stays opinion-light (TS/JS formatting now ships via Prettier) |
 | Spec-first workflow templates (`SPEC.md`) | Out of scope — see [`RECOMMENDATIONS.md`](./RECOMMENDATIONS.md) |
-| Claude Code agent-runtime hooks (`.claude/settings.json` `PreToolUse`) | Deferred — see [`RECOMMENDATIONS.md`](./RECOMMENDATIONS.md) for design space and tradeoffs |
 | `git worktree` orchestration for parallel agent sessions | Documented in `AGENTS.md`; not automated |
 
 ## Developing on the scaffold itself

--- a/forbidden-patterns/README.md
+++ b/forbidden-patterns/README.md
@@ -14,7 +14,7 @@ Pattern files consumed by `.githooks/lib/check-patterns` and
 | `java.txt`     | `*.java`                                           | yes            |
 | `kotlin.txt`   | `*.kt`, `*.kts`                                    | yes            |
 | `ruby.txt`     | `*.rb`, `*.rake`                                   | yes            |
-| `secrets.txt`  | all tracked text files (binaries / lockfiles excluded) | no         |
+| `secrets.txt`  | all tracked files (every staged blob, regardless of extension) | no    |
 
 `check-patterns` **auto-discovers** every `*.txt` here (except `secrets.txt`,
 which is `check-secrets`' domain). Each file declares which extensions it

--- a/forbidden-patterns/secrets.txt.template
+++ b/forbidden-patterns/secrets.txt.template
@@ -10,11 +10,13 @@
 # false-positive rate low.
 
 # Cloud / SaaS tokens — prefix-specific, very low false-positive rate
-(AKIA|ASIA)[0-9A-Z]{16}	AWS access key ID (AKIA) or temporary session key (ASIA) — rotate immediately
+(AKIA|ASIA|ABIA|ACCA)[0-9A-Z]{16}	AWS access key ID (AKIA/ABIA/ACCA) or temporary session key (ASIA) — rotate immediately
 AIza[0-9A-Za-z_-]{35}	Google API key — rotate immediately
 gh[pousr]_[A-Za-z0-9]{36,}	GitHub token — rotate immediately
 github_pat_[A-Za-z0-9_]{22,}	GitHub fine-grained personal access token — rotate immediately
 xox[baprs]-[A-Za-z0-9-]{10,}	Slack token — rotate immediately
+xapp-[0-9]-[A-Za-z0-9_-]{10,}	Slack app-level token (Socket Mode) — rotate immediately
+xoxe-[0-9]-[A-Za-z0-9_-]{20,}	Slack config/refresh token — rotate immediately
 sk-[A-Za-z0-9]{48,}	Legacy OpenAI-style API key — rotate immediately
 sk-ant-[A-Za-z0-9_-]{20,}	Anthropic API key (sk-ant-) — rotate immediately
 sk-proj-[A-Za-z0-9_-]{20,}	OpenAI project API key (sk-proj-) — rotate immediately
@@ -25,6 +27,7 @@ npm_[A-Za-z0-9]{36}	npm access token — rotate immediately
 dckr_pat_[A-Za-z0-9_-]{20,}	Docker Hub personal access token (dckr_pat_) — rotate immediately
 pypi-AgEIcHlwaS5vcmc[A-Za-z0-9_-]{50,}	PyPI upload token — rotate immediately
 (sk|rk)_(live|prod)_[A-Za-z0-9]{20,}	Stripe live/restricted key — rotate immediately
+whsec_[A-Za-z0-9]{24,}	Stripe webhook signing secret (whsec_) — lets an attacker forge signed events; rotate immediately
 hooks\.slack\.com/(services|workflows|triggers)/[A-Za-z0-9+/_-]{20,}	Slack webhook URL — rotate immediately
 dop_v1_[a-f0-9]{64}	DigitalOcean personal access token — rotate immediately
 (^|[^A-Za-z0-9])dapi[a-f0-9]{32}	Databricks API token — rotate immediately
@@ -36,8 +39,11 @@ gl(oas|dt|rtr?|ptt|agent|soat|ffct|imt|ft|wt)-[A-Za-z0-9_-]{20,}	GitLab token (O
 
 # JWT (two base64url segments each starting with eyJ, the encoding of `{"`).
 # Structural signature of a real header.payload pair — random base64 doesn't
-# decode to {" twice. Expired demo/test tokens in docs use `scaffold-allow`.
-eyJ[A-Za-z0-9_-]{17,}\.eyJ[A-Za-z0-9_-]{17,}	JWT in source — if long-lived (service key), rotate; use env vars
+# decode to {" twice. The header segment is always long, so it keeps the {17,}
+# floor; the payload floor is only {2,} because a compact claim set (`{"id":7}`
+# → eyJpZCI6N30) is short yet still a valid, leakable signed token. Expired
+# demo/test tokens in docs use `scaffold-allow`.
+eyJ[A-Za-z0-9_-]{17,}\.eyJ[A-Za-z0-9_-]{2,}	JWT in source — if long-lived (service key), rotate; use env vars
 
 # Private keys of any flavor (RSA / EC / DSA / OPENSSH / bare)
 -----BEGIN [A-Z ]*PRIVATE KEY-----	Private key in source — rotate and move to a secret manager

--- a/githooks/lib/agent-precheck.template
+++ b/githooks/lib/agent-precheck.template
@@ -108,7 +108,7 @@ scan_against() {
 
   # A comment-anchored `scaffold-allow` exempts a line, exactly like the scanners.
   hit=$(printf '%s\n' "$content" | grep -an"${iflag}"E -- "$combined" \
-          | grep -ivE '(^|[[:space:]])(#|//|/\*|<!--)[[:space:]]*scaffold-allow' || true)
+          | grep -ivE '(^[0-9]+:|[[:space:]])(#|//|/\*|<!--)[[:space:]]*scaffold-allow' || true)
   [ -n "$hit" ] || return 0
 
   {

--- a/githooks/lib/check-hygiene.template
+++ b/githooks/lib/check-hygiene.template
@@ -107,12 +107,12 @@ if [ "$CONFLICT_STATE" != disabled ]; then
     # must not pass silently: awk exit 9 ("a line was dropped") triggers a finding
     # at the rule's severity, while the in-cap lines below are still scanned.
     cap_rc=0
-    content=$(git show ":0:$file" 2>/dev/null | awk -v n="$MAX_LINE_LENGTH" 'length > n { d=1; next } { print } END { exit (d ? 9 : 0) }') || cap_rc=$?
+    content=$(git show ":0:$file" 2>/dev/null | LC_ALL=C tr -d '\000' | awk -v n="$MAX_LINE_LENGTH" 'length > n { d=1; next } { print } END { exit (d ? 9 : 0) }') || cap_rc=$?
     if [ "$cap_rc" -eq 9 ]; then
       emit "$CONFLICT_STATE" "$file" "line(s) over $MAX_LINE_LENGTH chars cannot be scanned for conflict markers — split/relocate the minified asset or raise MAX_LINE_LENGTH"
     fi
     [ -n "$content" ] || continue
-    m=$(grep -anE -- "$CONFLICT_RE" <<<"$content" | grep -ivE '(^|[[:space:]])(#|//|/\*|<!--)[[:space:]]*scaffold-allow' || true)
+    m=$(grep -anE -- "$CONFLICT_RE" <<<"$content" | grep -ivE '(^[0-9]+:|[[:space:]])(#|//|/\*|<!--)[[:space:]]*scaffold-allow' || true)
     if [ -n "$m" ]; then
       emit "$CONFLICT_STATE" "$file" "merge-conflict marker — resolve the conflict before committing"
       printf '%s\n' "$m" | head -3 | sed 's/^/    /' >&2 || true
@@ -143,14 +143,34 @@ if [ "$CASE_STATE" != disabled ]; then
 fi
 
 # --- 3. hidden Unicode (bidi / zero-width / tag) ---------------------------
-# A blob is "binary" (skip) if a NUL appears in the first 8 KB — the NULs survive
-# the pipe into wc (a bash var can't hold NUL, so we count in the pipeline).
+# A blob is "binary" (a NUL in the first 8 KB) — the NULs survive the pipe into
+# wc (a bash var can't hold NUL, so we count in the pipeline).
 is_binary() {
   local n
   # `|| true`: a missing/unreadable path (git show fails) is simply "not binary"
   # under set -e/pipefail, not a hard error.
   n=$(git show ":0:$1" 2>/dev/null | head -c 8192 | LC_ALL=C tr -dc '\000' | wc -c | tr -d ' ' || true)
   [ "${n:-0}" -gt 0 ]
+}
+
+# The binary skip below exists ONLY so real images/media/archives (which
+# legitimately contain the scanned byte sequences) don't false-positive. But a
+# lone NUL is attacker-controlled: prepending one to an agent-read text file
+# (AGENTS.md, coding-rules.md, any .md/source) used to flip is_binary and skip
+# the ONLY scan that defends those files against bidi overrides / the Rules File
+# Backdoor. So the skip now requires BOTH a binary blob AND a known binary-asset
+# EXTENSION — a text/source/agent file (or any unknown/extensionless type) is
+# scanned as text regardless of an injected NUL ($() strips NULs before the scan).
+is_binary_asset_name() {
+  case "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')" in
+    *.png|*.jpg|*.jpeg|*.gif|*.bmp|*.ico|*.webp|*.tif|*.tiff|*.heic|*.avif|*.psd|\
+    *.pdf|*.zip|*.gz|*.tgz|*.bz2|*.xz|*.zst|*.7z|*.rar|*.jar|*.war|*.ear|\
+    *.mp3|*.mp4|*.m4a|*.wav|*.avi|*.mov|*.mkv|*.flac|*.ogg|*.opus|*.webm|\
+    *.woff|*.woff2|*.ttf|*.otf|*.eot|\
+    *.so|*.dylib|*.dll|*.exe|*.bin|*.o|*.a|*.lib|*.class|*.wasm|*.pyc|*.pyo|\
+    *.parquet|*.pack|*.idx|*.db|*.sqlite|*.sqlite3|*.mo|*.dat) return 0 ;;
+  esac
+  return 1
 }
 
 HIDDEN_STATE=$(cfg rule-state hidden-unicode); [ -n "$HIDDEN_STATE" ] || HIDDEN_STATE=error
@@ -164,12 +184,14 @@ if [ "$HIDDEN_STATE" != disabled ]; then
   #   F3 A0 80-81 ··  tag block U+E0000–E007F (invisible "tag" smuggling)
   HIDDEN_RE=$'\xe2\x80[\x8b-\x8d\xaa-\xae]|\xe2\x81[\xa0\xa6-\xa9]|\xef\xbb\xbf|\xf3\xa0[\x80\x81][\x80-\xbf]'
   for file in "${FILES[@]}"; do
-    is_binary "$file" && continue
+    # Skip only a genuine binary ASSET (binary content AND a binary extension) —
+    # never a text/agent file whose "binary-ness" is one injected NUL (see above).
+    if is_binary "$file" && is_binary_asset_name "$file"; then continue; fi
     # FAIL CLOSED on an over-cap line (check-secrets parity). An unscannable line
     # in an agent-read file is exactly the Trojan-Source / Rules-File-Backdoor
     # surface this branch defends, so a dropped line is reported, not swallowed.
     cap_rc=0
-    content=$(git show ":0:$file" 2>/dev/null \
+    content=$(git show ":0:$file" 2>/dev/null | LC_ALL=C tr -d '\000' \
                 | LC_ALL=C awk -v n="$MAX_LINE_LENGTH" 'length > n { d=1; next } { print } END { exit (d ? 9 : 0) }') || cap_rc=$?
     if [ "$cap_rc" -eq 9 ]; then
       emit "$HIDDEN_STATE" "$file" "line(s) over $MAX_LINE_LENGTH chars cannot be scanned for hidden Unicode (Trojan Source / Rules File Backdoor surface) — split/relocate the minified asset or raise MAX_LINE_LENGTH"
@@ -179,7 +201,7 @@ if [ "$HIDDEN_STATE" != disabled ]; then
     # mid-file occurrence trips the EF-BB-BF branch.
     content=${content#$'\xef\xbb\xbf'}
     m=$(LC_ALL=C grep -anE -- "$HIDDEN_RE" <<<"$content" \
-          | grep -ivE '(^|[[:space:]])(#|//|/\*|<!--)[[:space:]]*scaffold-allow' || true)
+          | grep -ivE '(^[0-9]+:|[[:space:]])(#|//|/\*|<!--)[[:space:]]*scaffold-allow' || true)
     if [ -n "$m" ]; then
       emit "$HIDDEN_STATE" "$file" "hidden Unicode control char (bidi / zero-width / tag) — strip it; this is the 'Rules File Backdoor' / Trojan Source surface"
       # Never echo the raw invisible bytes back to a terminal/CI log — sanitize

--- a/githooks/lib/check-patterns.template
+++ b/githooks/lib/check-patterns.template
@@ -167,12 +167,24 @@ scan() {
     done
     [ "$keep" -eq 1 ] || continue
 
-    # Scan the staged blob, not the working-tree path (see header). awk (linear)
-    # drops over-long lines so the combined ERE never sees them (ReDoS guard).
+    # Scan the staged blob, not the working-tree path (see header). Strip NUL
+    # bytes FIRST: a C-string awk (macOS/BSD) truncates a record at an embedded
+    # NUL, so a forbidden pattern placed after a NUL byte would be silently lost —
+    # the same NUL-injection bypass the -a/--text greps below defend against.
+    # awk (linear) then drops over-long lines so the combined ERE never sees them.
     cap_rc=0
-    content=$(git show ":0:$file" 2>/dev/null | awk -v n="$MAX_LINE_LENGTH" 'length > n { d=1; next } { print } END { exit (d ? 9 : 0) }') || cap_rc=$?
+    content=$(git show ":0:$file" 2>/dev/null | LC_ALL=C tr -d '\000' | awk -v n="$MAX_LINE_LENGTH" 'length > n { d=1; next } { print } END { exit (d ? 9 : 0) }') || cap_rc=$?
     if [ "$cap_rc" -eq 9 ]; then
-      echo "warning: $file: line(s) over $MAX_LINE_LENGTH chars dropped from the scan (minified/generated?)" >&2
+      # FAIL CLOSED (check-secrets/check-hygiene parity). A forbidden pattern on a
+      # >MAX_LINE_LENGTH line was dropped before the ERE (the ReDoS guard), but an
+      # unscannable line must not pass silently as it used to (warn + exit 0).
+      over="line(s) over $MAX_LINE_LENGTH chars cannot be scanned for forbidden patterns — split/relocate the minified asset or raise MAX_LINE_LENGTH"
+      if [ "$CI_MODE" -eq 1 ]; then
+        echo "::error file=$(ghesc prop "$file")::$(ghesc data "$over")"
+      else
+        echo "✗ $file: $over"
+      fi
+      FAILED=1
     fi
     [ -n "$content" ] || continue
 
@@ -187,7 +199,7 @@ scan() {
       pat="${patterns[$i]}"
       desc="${descriptions[$i]}"
       # Exempt only a comment-anchored marker (see check-secrets).
-      m=$(grep -anE -- "$pat" <<<"$content" | grep -ivE '(^|[[:space:]])(#|//|/\*|<!--)[[:space:]]*scaffold-allow' || true)
+      m=$(grep -anE -- "$pat" <<<"$content" | grep -ivE '(^[0-9]+:|[[:space:]])(#|//|/\*|<!--)[[:space:]]*scaffold-allow' || true)
       [ -n "$m" ] || continue
       # Per-rule override: `disabled` skips the rule, `warn` reports without
       # failing, anything else (incl. missing config) enforces as `error`.

--- a/githooks/lib/check-secrets.template
+++ b/githooks/lib/check-secrets.template
@@ -13,7 +13,9 @@
 #     grep into "binary file matches" and silently suppress the match.
 #   - post-stage edits: the index blob is exactly what will be committed,
 #     independent of later working-tree edits.
-# Skips binaries, lockfiles, and the pattern config directory itself.
+# Scans every tracked file's staged blob regardless of extension (no binary or
+# lockfile skip — that skip list was a rename-bypass); only the pattern config
+# directory itself is skipped (scanning it would match the regexes it stores).
 # Pattern format: <regex><TAB><description>
 # (TAB is the field separator so regex can use literal `|` alternation.)
 #
@@ -111,7 +113,19 @@ while IFS= read -r line || [ -n "$line" ]; do
   RAW_DESCS+=("$description")
 done <"$CONFIG"
 
-[ ${#RAW_PATTERNS[@]} -eq 0 ] && exit 0
+# A present-but-EMPTY config (every pattern line deleted or commented out) is the
+# gutting analogue of deleting the file: it disables the secret scanner in a
+# single commit while dodging the orchestrator's deletion guard, which only
+# catches a full file removal. secrets.txt is the non-disableable boundary, so a
+# config that exists yet yields zero patterns fails CLOSED at BOTH gates — a fresh
+# checkout never has an empty config (install.sh always writes patterns; it is
+# ABSENCE, handled above with local leniency, that signals pre-install, not
+# emptiness). Reached only when there are files to scan (FILES non-empty above).
+if [ ${#RAW_PATTERNS[@]} -eq 0 ]; then
+  msg=".forbidden-patterns/secrets.txt has no patterns — the secret scanner is disabled. Restore its patterns (use 'git commit --no-verify' or remove the guardrails job if intended)."
+  if [ "$CI_MODE" -eq 1 ]; then echo "::error::$msg"; else echo "✗ $msg" >&2; fi
+  exit 1
+fi
 
 # Validate patterns up-front so an invalid ERE doesn't poison the combined
 # regex or produce cryptic per-file errors. See check-patterns for context.
@@ -127,7 +141,14 @@ for i in "${!RAW_PATTERNS[@]}"; do
   DESCRIPTIONS+=("${RAW_DESCS[$i]}")
 done
 
-[ ${#PATTERNS[@]} -eq 0 ] && exit 0
+# Every configured pattern was an invalid ERE and got dropped — the config is
+# corrupt and the scanner would silently scan for nothing. Fail CLOSED (same
+# reasoning as the empty-config guard above) rather than exit 0.
+if [ ${#PATTERNS[@]} -eq 0 ]; then
+  msg=".forbidden-patterns/secrets.txt has no valid patterns (all were invalid regexes) — the secret scanner is disabled. Fix the patterns (use 'git commit --no-verify' if intended)."
+  if [ "$CI_MODE" -eq 1 ]; then echo "::error::$msg"; else echo "✗ $msg" >&2; fi
+  exit 1
+fi
 
 COMBINED=""
 for p in "${PATTERNS[@]}"; do

--- a/githooks/lib/check-secrets.template
+++ b/githooks/lib/check-secrets.template
@@ -8,9 +8,11 @@
 #     grep would instead follow the link and scan the resolved file (or skip a
 #     dangling link entirely via `[ -f ]`), so a secret encoded as a symlink
 #     target would never be seen.
-#   - NUL bytes: `git show` output captured in $() drops NUL bytes and every
-#     grep here passes -a/--text, so a single embedded NUL can no longer flip
-#     grep into "binary file matches" and silently suppress the match.
+#   - NUL bytes: the blob is piped through `tr -d '\000'` BEFORE the awk
+#     length-cap (a C-string awk truncates a record at an embedded NUL, so a
+#     secret after a NUL would be lost), $() then drops any residual NULs, and
+#     every grep passes -a/--text — so a single embedded NUL can neither flip
+#     grep into "binary file matches" nor truncate the scanned content.
 #   - post-stage edits: the index blob is exactly what will be committed,
 #     independent of later working-tree edits.
 # Scans every tracked file's staged blob regardless of extension (no binary or
@@ -177,7 +179,7 @@ for file in "${FILES[@]}"; do
   # match. A missing blob (e.g. a submodule gitlink) yields empty content.
   # awk (linear) also drops over-long lines here so the ERE never sees them.
   cap_rc=0
-  content=$(git show ":0:$file" 2>/dev/null | awk -v n="$MAX_LINE_LENGTH" 'length > n { d=1; next } { print } END { exit (d ? 9 : 0) }') || cap_rc=$?
+  content=$(git show ":0:$file" 2>/dev/null | LC_ALL=C tr -d '\000' | awk -v n="$MAX_LINE_LENGTH" 'length > n { d=1; next } { print } END { exit (d ? 9 : 0) }') || cap_rc=$?
   if [ "$cap_rc" -eq 9 ]; then
     # FAIL CLOSED. The line is dropped before the ERE (so it can't hang the scan
     # — that is the ReDoS guard), but for the SECRET scanner an unscannable line
@@ -201,7 +203,7 @@ for file in "${FILES[@]}"; do
     desc="${DESCRIPTIONS[$i]}"
     # Exempt only a comment-anchored marker, so `scaffold-allow` inside a string
     # literal cannot whitelist a real secret.
-    m=$(grep -aniE -- "$pat" <<<"$content" | grep -ivE '(^|[[:space:]])(#|//|/\*|<!--)[[:space:]]*scaffold-allow' || true)
+    m=$(grep -aniE -- "$pat" <<<"$content" | grep -ivE '(^[0-9]+:|[[:space:]])(#|//|/\*|<!--)[[:space:]]*scaffold-allow' || true)
     [ -n "$m" ] || continue
     if [ "$CI_MODE" -eq 1 ]; then
       echo "::error file=$(ghesc prop "$file")::$(ghesc data "$desc")"

--- a/githooks/lib/check-secrets.template
+++ b/githooks/lib/check-secrets.template
@@ -85,10 +85,12 @@ while IFS= read -r -d '' f; do
   # binary → skipped). Instead every blob is scanned as text — $() strips NULs
   # and grep runs -a/--text — and a genuine large binary is dropped harmlessly
   # by the per-line length cap below (a no-newline blob is one over-long line).
-  # Only the pattern-config dir is skipped (scanning it would match the regexes
-  # it stores).
+  # Only the pattern-config FILES themselves are skipped (scanning them would
+  # match the regexes they store). Narrowed to *.txt: the blanket
+  # .forbidden-patterns/* skip was broader than its rationale and let any other
+  # file there (a committed creds.env, notes.md) carry a secret unscanned.
   case "$f" in
-    .forbidden-patterns/*) continue ;;
+    .forbidden-patterns/*.txt) continue ;;
   esac
   FILES+=("$f")
 done

--- a/githooks/pre-commit.template
+++ b/githooks/pre-commit.template
@@ -35,7 +35,11 @@ LIB="$HOOK_DIR/lib"
 # no config and exit 0 — a one-commit way to land a secret AND neuter the scan.
 # Checked BEFORE the empty-staged-list exit, since a delete-only commit has an
 # empty ACMR list. Use `git commit --no-verify` if a removal is intended (uninstall).
-DELETED_CONFIG=$(git diff --cached -z --name-only --diff-filter=D | tr '\0' '\n' | grep -E '^\.forbidden-patterns/.+\.txt$' || true)
+# `--no-renames` is load-bearing: git's default rename detection reports a
+# `git mv secrets.txt secrets.txt.disabled` as an R (rename), not a D, so the
+# guard's list would be empty and the neutered-config commit would pass. Treating
+# a rename as delete+add surfaces the OLD path as a D so the guard still fires.
+DELETED_CONFIG=$(git diff --cached --no-renames -z --name-only --diff-filter=D | tr '\0' '\n' | grep -E '^\.forbidden-patterns/.+\.txt$' || true)
 if [ -n "$DELETED_CONFIG" ]; then
   echo "error: this commit deletes forbidden-pattern config, disabling the scanner:" >&2
   printf '%s\n' "$DELETED_CONFIG" | sed 's/^/       /' >&2

--- a/install-lib.sh
+++ b/install-lib.sh
@@ -35,14 +35,36 @@
 # The three policies share one write MECHANISM (_cp_replace) and one backup
 # routine (_backup), so the A7 symlink defenses live in exactly one place.
 
+# _mkdir_safe DIR — create DIR as real directories, never following a symlink at
+# ANY path component. `rm -f "$dst"` in _cp_replace drops a symlink at the LEAF
+# file, but a plain `mkdir -p` follows a symlinked PARENT (e.g. a planted
+# `.githooks -> ~/.ssh` or `.github -> $HOME`), which would send every scanner /
+# hook / CI workflow — and any overwrite — THROUGH the link, outside the repo,
+# while the in-tree path stays a symlink (a silent write-through + fail-open).
+# Walk the path top-down, dropping any symlink component before descending, so we
+# always land real dirs in the tree. Mirrors scripts/dev-setup.sh's _mkdir_safe
+# (B4) but handles arbitrary depth for the shared _cp_replace mechanism.
+_mkdir_safe() {
+  local dir=$1 path= comp
+  while [ -n "$dir" ]; do
+    comp=${dir%%/*}
+    case $dir in */*) dir=${dir#*/} ;; *) dir= ;; esac
+    [ -z "$comp" ] && continue
+    path="${path:+$path/}$comp"
+    [ -L "$path" ] && rm -f "$path"
+    [ -d "$path" ] || mkdir "$path"
+  done
+}
+
 # _cp_replace SRC DST — the actual write. `[ -e ]` alone is false for a DANGLING
 # symlink and follows a LIVE one, so a pre-existing symlink at a scaffold path
 # used to make `cp` follow it and write the scanner to the link's target OUTSIDE
-# the repo. We `rm -f` the destination first (dropping any symlink) so we always
-# write a real regular file IN the tree, never THROUGH a link.
+# the repo. We drop any symlink at every parent component (_mkdir_safe) AND at the
+# leaf (`rm -f`) first, so we always write a real regular file IN the tree, never
+# THROUGH a link.
 _cp_replace() {
   local src=$1 dst=$2
-  mkdir -p "$(dirname "$dst")"
+  _mkdir_safe "$(dirname "$dst")"
   rm -f "$dst"
   cp "$src" "$dst"
 }

--- a/install-lib.sh
+++ b/install-lib.sh
@@ -45,7 +45,7 @@
 # always land real dirs in the tree. Mirrors scripts/dev-setup.sh's _mkdir_safe
 # (B4) but handles arbitrary depth for the shared _cp_replace mechanism.
 _mkdir_safe() {
-  local dir=$1 path= comp
+  local dir=$1 path='' comp
   while [ -n "$dir" ]; do
     comp=${dir%%/*}
     case $dir in */*) dir=${dir#*/} ;; *) dir= ;; esac

--- a/install.sh
+++ b/install.sh
@@ -12,6 +12,7 @@
 #   install.sh --cursor     # also install opt-in Cursor agent guardrails (.cursor/hooks.json)
 #   install.sh --commit-msg # also install the Conventional-Commits commit-msg hook
 #   install.sh --gitleaks-hook # also install opt-in local gitleaks pre-commit pass
+#   install.sh --gitleaks-ci # also install the gitleaks CI workflow (unskippable gate)
 #   install.sh --all-langs  # install every language's forbidden-pattern file
 #   install.sh --coverage-gate # also install the opt-in CI patch-coverage gate
 #   install.sh --no-install # detect missing tools but never auto-run a package manager
@@ -33,6 +34,7 @@ CLAUDE=0
 CURSOR=0
 COMMIT_MSG=0
 GITLEAKS_HOOK=0
+GITLEAKS_CI=0
 ALL_LANGS=0
 COVERAGE_GATE=0
 NO_INSTALL=0
@@ -48,10 +50,11 @@ for arg in "$@"; do
     --cursor)     CURSOR=1 ;;
     --commit-msg) COMMIT_MSG=1 ;;
     --gitleaks-hook) GITLEAKS_HOOK=1 ;;
+    --gitleaks-ci) GITLEAKS_CI=1 ;;
     --all-langs)  ALL_LANGS=1 ;;
     --coverage-gate) COVERAGE_GATE=1 ;;
     --no-install) NO_INSTALL=1 ;;
-    --help|-h)    sed -n '2,24p' "$0"; exit 0 ;;
+    --help|-h)    sed -n '2,25p' "$0"; exit 0 ;;
     *) echo "error: unknown argument: $arg" >&2; exit 1 ;;
   esac
 done
@@ -267,7 +270,16 @@ if [ "$GITLEAKS_HOOK" -eq 1 ]; then
   if ! command -v gitleaks >/dev/null 2>&1; then
     echo "warning: gitleaks not found — the local pass fails open (skips) until you install it: https://github.com/gitleaks/gitleaks#installing"
   fi
-  echo "note: --gitleaks-hook is the LOCAL echo only. Add .github/workflows/gitleaks.yml (see gitleaks.yml.template) for the unskippable CI gate."
+  echo "note: --gitleaks-hook is the LOCAL pass only. Add --gitleaks-ci for the unskippable CI gate (.github/workflows/gitleaks.yml)."
+fi
+
+# Opt-in gitleaks CI workflow (--gitleaks-ci). The unskippable server-side gate
+# that pairs with --gitleaks-hook's local pass. A dedicated flag (mirroring
+# --coverage-gate) actually INSTALLS the workflow, so npx users — who have no
+# persistent copy of gitleaks.yml.template on disk — can wire the CI gate too.
+if [ "$GITLEAKS_CI" -eq 1 ]; then
+  cp_scaffold "$SCAFFOLD_DIR/.github/workflows/gitleaks.yml.template" ".github/workflows/gitleaks.yml"
+  echo "note: gitleaks.yml is the unskippable CI secret scan (runs even without --no-verify locally)."
 fi
 
 # Opt-in CI patch-coverage gate (--coverage-gate). Fails a PR when CHANGED lines

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "forbidden-patterns/",
     "coding-rules.md",
     "operational-rules.md",
+    "RECOMMENDATIONS.md",
+    "CHANGELOG.md",
     "AGENTS.md.template",
     "CLAUDE.md.pointer",
     "claude-settings.json.template",

--- a/tests/cases/02-scaffold-allow-ruff-edge.sh
+++ b/tests/cases/02-scaffold-allow-ruff-edge.sh
@@ -51,6 +51,12 @@ if MAX_LINES=100 .githooks/pre-commit >"$HOOK_OUT" 2>&1; then
   echo "  ✗ MAX_LINES=100 — hook accepted, expected reject"
   sed 's/^/      /' "$HOOK_OUT"
   FAIL=$((FAIL + 1))
+elif ! grep -qF 'extract a module' "$HOOK_OUT"; then
+  # Guard the reject reason (like assert_rejects): without it the case passed on
+  # ANY non-zero exit, so a crash unrelated to the size cap counted as a pass.
+  echo "  ✗ MAX_LINES=100 — rejected but not for the size cap (unexpected output)"
+  sed 's/^/      /' "$HOOK_OUT"
+  FAIL=$((FAIL + 1))
 else
   echo "  ✓ MAX_LINES env var override"
   PASS=$((PASS + 1))

--- a/tests/cases/03-binary-defense.sh
+++ b/tests/cases/03-binary-defense.sh
@@ -12,6 +12,21 @@ printf 'AKIA''IOSFODNN7EXAMPLE\000trailing\n' >nul.txt
 git add nul.txt
 assert_rejects "NUL byte does not hide a secret" "AWS access key"
 
+# 19b. Secret placed AFTER a NUL byte. Case 19 kept the secret BEFORE the NUL, so
+#      a C-string awk (macOS/BSD) that truncates the record at the NUL still saw
+#      it. A secret AFTER the NUL was silently lost by the awk length-cap stage —
+#      a real fail-open. Stripping NULs before awk (tr -d '\000') closes it.
+printf 'harmless prefix\000AKIA''IOSFODNN7EXAMPLE\n' >nulafter.txt
+git add nulafter.txt
+assert_rejects "secret AFTER a NUL byte is still scanned" "AWS access key"
+
+# 19c. scaffold-allow on a COLUMN-0 comment line (leader immediately before the
+#      marker) must exempt — the exemption anchor has to tolerate the `grep -n`
+#      "NN:" line-number prefix, or the documented start-of-line form never works.
+printf '# scaffold-allow expired demo: AKIA''IOSFODNN7EXAMPLE\n' >leadallow.txt
+git add leadallow.txt
+assert_passes "scaffold-allow on a leading (column-0) comment line is exempt"
+
 # 20. A secret carried as a symlink target must be scanned. A symlink's
 #     committed blob is its target string; the old path-based scan followed the
 #     link (or `[ -f ]`-skipped a dangling one) and never saw it. Blob scanning

--- a/tests/cases/03-binary-defense.sh
+++ b/tests/cases/03-binary-defense.sh
@@ -122,3 +122,35 @@ assert_rejects "GitLab runner token (glrt-) detected" "GitLab token"
 echo "DOCKER=dckr_""pat_abcdefghij0123456789ABCD" >q5.txt
 git add q5.txt
 assert_rejects "Docker Hub PAT (dckr_pat_) detected" "Docker Hub"
+
+# 22g. AWS ABIA/ACCA key-id prefixes (STS bearer / context creds) — the pattern
+#      previously covered only AKIA/ASIA.
+echo "AWS=ABIA""IOSFODNN7EXAMPLE" >r1.txt
+git add r1.txt
+assert_rejects "AWS ABIA key-id prefix detected" "AWS access key"
+
+# 22h. Slack app-level (xapp-) and config/refresh (xoxe-) tokens.
+echo "SLACK=xapp-""1-A01234567-abcdefghij0123456789" >r2.txt
+git add r2.txt
+assert_rejects "Slack app-level token (xapp-) detected" "Slack app-level"
+
+echo "SLACK=xoxe-""1-abcdefghij0123456789ABCDEFGHIJ" >r3.txt
+git add r3.txt
+assert_rejects "Slack config/refresh token (xoxe-) detected" "Slack config"
+
+# 22i. Stripe webhook signing secret (whsec_) — forge-signed-events risk.
+echo "STRIPE=whsec_""abcdefghij0123456789ABCDEFGH" >r4.txt
+git add r4.txt
+assert_rejects "Stripe webhook signing secret (whsec_) detected" "webhook signing"
+
+# 22j. JWT with a compact payload (short second segment) — the {17,} floor on the
+#      payload missed real minimal-claim tokens; only the header needs the floor.
+echo "JWT=eyJ""hbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ""pZCI6N30" >r5.txt
+git add r5.txt
+assert_rejects "JWT with a compact payload is detected" "JWT in source"
+
+# 22k. A non-.txt file under .forbidden-patterns/ is now scanned — the blanket
+#      dir skip let a committed creds.env there smuggle a secret unscanned.
+echo "AWS=AKIA""IOSFODNN7EXAMPLE" >.forbidden-patterns/creds.env
+git add .forbidden-patterns/creds.env
+assert_rejects "secret in .forbidden-patterns/creds.env is scanned (not skipped)" "AWS access key"

--- a/tests/cases/05-frontend-typescript.sh
+++ b/tests/cases/05-frontend-typescript.sh
@@ -96,3 +96,32 @@ if npx --no-install tsc --version >/dev/null 2>&1; then
 else
   echo "  - skipped tsc test (typescript not installed in temp repo)"
 fi
+
+# 42b. eslint block rejection. The JS-linter integration in the pre-commit
+#      orchestrator had no rejection test — eslint isn't resolvable in the temp
+#      repo, so it silently skips, meaning a regression that stops eslint
+#      findings from setting FAILED would ship green. Stub `npx` on an isolated
+#      PATH so the --version gate passes and the lint run fails, proving the
+#      block propagates a non-zero exit into the hook's failure.
+ESB=$(mktemp -d)
+cat >"$ESB/npx" <<'STUB'
+#!/bin/sh
+# `--no-install eslint --version` → ok (gate); `eslint -- <files>` → fail (lint).
+case "$*" in
+  *--version*) exit 0 ;;
+  *eslint*)    echo "eslint: problems found"; exit 1 ;;
+  *)           exit 0 ;;
+esac
+STUB
+chmod +x "$ESB/npx"
+echo 'const x = 1' >lintme.js
+git add lintme.js
+if PATH="$ESB:$PATH" .githooks/pre-commit >"$HOOK_OUT" 2>&1; then
+  echo "  ✗ eslint block — hook accepted despite an eslint failure"; FAIL=$((FAIL + 1))
+elif grep -qF "Pre-commit failed" "$HOOK_OUT"; then
+  echo "  ✓ eslint findings fail the pre-commit hook"; PASS=$((PASS + 1))
+else
+  echo "  ✗ eslint block — rejected but not via the linter path"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$ESB"
+reset_repo

--- a/tests/cases/06-hygiene-multilang.sh
+++ b/tests/cases/06-hygiene-multilang.sh
@@ -159,6 +159,24 @@ else
 fi
 reset_repo
 
+# php -l syntax-error rejection. The php -l block had only VALID .php fixtures
+# (which exercise check-hygiene's dd() pattern, not php -l itself). Runs only
+# where php is on PATH; skips cleanly otherwise, like the tsc test.
+if command -v php >/dev/null 2>&1; then
+  printf '<?php\nfunction broken( {\n' >syntaxerr.php
+  git add syntaxerr.php
+  if .githooks/pre-commit >"$HOOK_OUT" 2>&1; then
+    echo "  ✗ php -l — hook accepted a PHP syntax error"; FAIL=$((FAIL + 1))
+  elif grep -qF "PHP syntax error" "$HOOK_OUT"; then
+    echo "  ✓ php -l rejects a PHP syntax error"; PASS=$((PASS + 1))
+  else
+    echo "  ✗ php -l — rejected but without the expected message"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+  fi
+  reset_repo
+else
+  echo "  - skipped php -l test (php not installed)"
+fi
+
 # --- Multi-language forbidden patterns (config-driven check-patterns) -------
 # Each language file declares its extensions via a `# scaffold-extensions:`
 # header and is auto-discovered by check-patterns. Samples come from the

--- a/tests/cases/06-hygiene-multilang.sh
+++ b/tests/cases/06-hygiene-multilang.sh
@@ -100,6 +100,65 @@ assert_rejects "hidden Unicode on a >MAX_LINE_LENGTH line fails closed" "cannot 
 git add longconflict.txt
 assert_rejects "conflict marker on a >MAX_LINE_LENGTH line fails closed" "cannot be scanned for conflict markers"
 
+# 45i. NUL-byte bypass: prepending a NUL to an agent-read text file flipped
+#      is_binary and skipped the hidden-Unicode scan — the ONLY defense for .md /
+#      source files against bidi smuggling. The skip now needs a binary EXTENSION
+#      too, so a .md with an injected NUL is still scanned (NULs stripped by $()).
+{ printf '\x00'; printf 'run this: %s rm -rf /\n' "$bidi"; } >nulbidi.md
+git add nulbidi.md
+assert_rejects "NUL-prepended agent file is still scanned for hidden Unicode" "hidden Unicode"
+
+# 45j. NEGATIVE: a genuine binary ASSET (binary content AND a binary extension)
+#      is still skipped, so images don't false-positive on the scanned bytes.
+{ printf '\x00\x00PNG'; printf 'x %s y' "$bidi"; } >logo.png
+git add logo.png
+assert_passes "real binary image asset is skipped (no hidden-Unicode false positive)"
+
+# 45k. Mid-file BOM (U+FEFF away from column 0) — a leading BOM is allowed but a
+#      mid-file one is a hidden-Unicode finding; this arm had no positive fixture.
+bom=$(printf '\xef\xbb\xbf')
+printf 'const x = 1;%s // trailing\n' "$bom" >midbom.js
+git add midbom.js
+assert_rejects "mid-file BOM is rejected (leading-BOM allowance not abused)" "hidden Unicode"
+
+# 45l. Plain bidi override (U+202E) on a normal-length line — 45g only covered the
+#      over-cap fail-closed path, never a direct bidi rejection.
+printf 'let user = "admin"; %s\n' "$bidi" >plainbidi.js
+git add plainbidi.js
+assert_rejects "plain bidi override (U+202E) is rejected" "hidden Unicode"
+
+# 45m. Tag-block smuggling (U+E0001, bytes F3 A0 80 81) — the invisible "tag"
+#      instruction-smuggling arm of HIDDEN_RE had no fixture.
+tag=$(printf '\xf3\xa0\x80\x81')
+printf 'safe instruction%s hidden tag\n' "$tag" >tagsmuggle.md
+git add tagsmuggle.md
+assert_rejects "tag-block hidden Unicode (U+E0001) is rejected" "hidden Unicode"
+
+# 45n. diff3 common-ancestor conflict marker (|||||||) — CONFLICT_RE matches three
+#      shapes but only <<< / >>> had a fixture. A diff3 resolve can leave the base
+#      marker behind after the user removes the <<< / >>> lines.
+printf 'a\n||||||| merged common ancestors\nb\n' >diff3conflict.txt
+git add diff3conflict.txt
+assert_rejects "diff3 ||||||| conflict marker is rejected" "merge-conflict marker"
+
+# 45o. check-patterns over-cap FAIL CLOSED (invoked directly — the end-to-end
+#      hook masks this because check-secrets independently rejects any over-cap
+#      line). A forbidden pattern on a >MAX_LINE_LENGTH line used to be dropped
+#      with only a warning + exit 0 (fail-OPEN); it must now fail closed like the
+#      other scanners. `print(` (backend.txt) sits on a 60k-char line.
+{ printf 'print("x") '; head -c 60000 /dev/zero | tr '\0' a; echo; } >longpat.py
+git add longpat.py
+if printf '%s\0' longpat.py | .githooks/lib/check-patterns >"$HOOK_OUT" 2>&1; then
+  echo "  ✗ check-patterns over-cap — exited 0 (fail-open), expected reject"
+  sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+elif grep -qF "cannot be scanned for forbidden patterns" "$HOOK_OUT"; then
+  echo "  ✓ check-patterns fails closed on an over-cap line"; PASS=$((PASS + 1))
+else
+  echo "  ✗ check-patterns over-cap — rejected but missing the expected message"
+  sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+reset_repo
+
 # --- Multi-language forbidden patterns (config-driven check-patterns) -------
 # Each language file declares its extensions via a `# scaffold-extensions:`
 # header and is auto-discovered by check-patterns. Samples come from the

--- a/tests/cases/07-agent-commit.sh
+++ b/tests/cases/07-agent-commit.sh
@@ -159,6 +159,26 @@ if bash "$CMHOOK" "$mf" >"$HOOK_OUT" 2>&1; then
 else
   echo "  ✗ commit-msg rejected a merge commit"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
 fi
+# 51b. Git's OTHER auto-generated subjects must be exempt too — only "Merge " had
+#      coverage, so a regression dropping these would break `git revert` /
+#      `git rebase --autosquash` on every consumer repo, undetected.
+for exempt in "Revert \"feat(api): add pagination\"" "fixup! feat(api): add pagination" \
+              "squash! feat(api): add pagination" "Reapply \"feat(api): add pagination\""; do
+  printf '%s\n' "$exempt" >"$mf"
+  if bash "$CMHOOK" "$mf" >"$HOOK_OUT" 2>&1; then
+    echo "  ✓ commit-msg exempts auto-generated subject: ${exempt%% *}"; PASS=$((PASS + 1))
+  else
+    echo "  ✗ commit-msg rejected an exempt subject: $exempt"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+  fi
+done
+# 51c. The `!` breaking-change marker on a valid type is accepted (only plain
+#      `feat(api): ...` was exercised, never the `feat!:` shape).
+printf 'feat!: drop the legacy endpoint\n' >"$mf"
+if bash "$CMHOOK" "$mf" >"$HOOK_OUT" 2>&1; then
+  echo "  ✓ commit-msg accepts a feat!: breaking-change subject"; PASS=$((PASS + 1))
+else
+  echo "  ✗ commit-msg rejected a valid feat!: subject"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
 # A valid-shape subject over 100 chars is rejected for length (commitlint parity).
 printf 'feat(api): %s\n' "$(printf 'a%.0s' $(seq 1 100))" >"$mf"
 if bash "$CMHOOK" "$mf" >"$HOOK_OUT" 2>&1; then

--- a/tests/cases/08-overrides-gitleaks.sh
+++ b/tests/cases/08-overrides-gitleaks.sh
@@ -88,6 +88,24 @@ echo "AKIA""IOSFODNN7EXAMPLE" >creds.txt
 git add .scaffold.toml creds.txt
 assert_rejects "override: secret scanner is NOT disablable via .scaffold.toml" "AWS access key"
 
+# 58b. GUTTING secrets.txt to zero patterns (keeping the file present) is the
+#      neutering analogue of deleting it — it dodges the orchestrator's deletion
+#      guard, which only catches a full removal. A commit that empties the config
+#      AND lands a secret must fail CLOSED (check-secrets empty-config guard).
+printf '# all patterns removed\n# (gutted)\n' >.forbidden-patterns/secrets.txt
+echo "AKIA""IOSFODNN7EXAMPLE" >creds.txt
+git add .forbidden-patterns/secrets.txt creds.txt
+assert_rejects "gutting secrets.txt to zero patterns fails closed" "the secret scanner is disabled"
+
+# 58c. RENAMING secrets.txt (git mv) makes git report an R, not a D — the
+#      deletion guard used default rename detection and saw an empty D list, so
+#      the neutered-config commit passed. `--no-renames` surfaces the old path as
+#      a deletion so the guard fires.
+git mv .forbidden-patterns/secrets.txt .forbidden-patterns/secrets.txt.disabled
+echo "AKIA""IOSFODNN7EXAMPLE" >creds.txt
+git add creds.txt
+assert_rejects "renaming secrets.txt away is caught by the deletion guard" "deletes forbidden-pattern config"
+
 # 59. scaffold-audit (installed by install.sh) lists active overrides. The CI
 #     guardrails job runs this so a disabled rule is visible in the build log.
 printf '[rules."backend/Use structlog (or the project'\''s logger), not print()"]\ndisabled = true\n' >.scaffold.toml

--- a/tests/cases/08-overrides-gitleaks.sh
+++ b/tests/cases/08-overrides-gitleaks.sh
@@ -23,6 +23,26 @@ seq 1 501 | sed 's/^/# /' >big2.py
 git add .scaffold.toml big2.py
 assert_passes "override: [rules.size] disabled skips the size cap"
 
+# 53b. [rules.size] severity = "warn" reports an oversize file but does NOT fail
+#      the build. The size scanner's own warn arm had no fixture — only disabled
+#      (53) and per-glob caps (52) — so a regression in either direction (warn
+#      silently failing, or error silently demoted) would ship green.
+printf '[rules.size]\nseverity = "warn"\n' >.scaffold.toml
+seq 1 501 | sed 's/^/# /' >bigwarn.py
+git add .scaffold.toml bigwarn.py
+if .githooks/pre-commit >"$HOOK_OUT" 2>&1; then
+  if grep -qF "(warn — .scaffold.toml override)" "$HOOK_OUT" && grep -qF "bigwarn.py" "$HOOK_OUT"; then
+    echo "  ✓ override: [rules.size] severity=warn reports without failing"; PASS=$((PASS + 1))
+  else
+    echo "  ✗ override: size warn passed but emitted no warn notice for the file"
+    sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+  fi
+else
+  echo "  ✗ override: [rules.size] severity=warn — hook failed, expected pass-with-warning"
+  sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+reset_repo
+
 # 54. A disabled forbidden-pattern rule lets its match through.
 cat >.scaffold.toml <<'EOF'
 [rules."backend/Use structlog (or the project's logger), not print()"]

--- a/tests/cases/09-toolchain-clobber.sh
+++ b/tests/cases/09-toolchain-clobber.sh
@@ -226,6 +226,28 @@ else
 fi
 rm -rf "$USD"
 
+# (T) symlinked scaffold DIRECTORY (.githooks -> outside dir): install's cp_*
+#     helpers dropped a symlink at the LEAF file but `mkdir -p "$(dirname)"` still
+#     FOLLOWED a symlinked PARENT, writing every scanner THROUGH the link outside
+#     the repo, clobbering a pre-existing outside file and leaving the in-repo
+#     .githooks a symlink (silent write-through + fail-open). _mkdir_safe now drops
+#     a symlink at every path component. Assert: outside file untouched, and the
+#     in-repo .githooks is a REAL dir holding a real pre-commit.
+USG=$(mktemp -d)
+mkdir -p "$USG/repo" "$USG/outside/lib"
+printf 'PRECIOUS_DO_NOT_TOUCH\n' >"$USG/outside/lib/check-secrets"
+ln -s "$USG/outside" "$USG/repo/.githooks"
+( cd "$USG/repo" && git init --quiet && echo '{"name":"x"}' >package.json \
+  && "$SCAFFOLD_DIR/install.sh" --frontend --no-verify ) >"$HOOK_OUT" 2>&1
+if grep -q 'PRECIOUS_DO_NOT_TOUCH' "$USG/outside/lib/check-secrets" \
+   && [ -d "$USG/repo/.githooks" ] && [ ! -L "$USG/repo/.githooks" ] \
+   && [ -f "$USG/repo/.githooks/pre-commit" ] && [ ! -L "$USG/repo/.githooks/pre-commit" ]; then
+  echo "  ✓ install does not write through a symlinked scaffold DIR (no outside clobber)"; PASS=$((PASS + 1))
+else
+  echo "  ✗ install followed a symlinked .githooks dir and wrote scanners outside the repo"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$USG"
+
 # --- installer does not write THROUGH a symlink at CLAUDE.md / AGENTS.md (B1) --
 # The A7 symlink defense lived only in the cp_* helpers; install_claude_md /
 # install_agents_md kept the pre-A7 `[ -e ]`-only guard, so a symlink planted at
@@ -392,106 +414,4 @@ else
   echo "  ✗ re-run churned an already-current install"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
 fi
 rm -rf "$UNO"
-
-# --- dev-setup.sh does not write THROUGH a symlink at a rendered path (B4) -----
-# scripts/dev-setup.sh renders templates into the gitignored .githooks/ /
-# .forbidden-patterns/ for the scaffold's OWN dogfooding. It used bare `cp` /
-# `mkdir -p`, so a leftover/planted symlink there (surviving across checkouts,
-# since those dirs are gitignored) made cp write a scanner THROUGH the link to an
-# outside target, or mkdir -p follow a symlinked lib/ dir — the A7 class install.sh
-# already defends. dev-setup refuses to run outside a scaffold clone, so build a
-# MINIMAL fake clone (it resolves its root from its own path) and drive it.
-_b4_fakeclone() {   # $1 = dir to build a minimal runnable dev-setup clone into
-  local d=$1
-  mkdir -p "$d/scripts" "$d/githooks/lib" "$d/forbidden-patterns"
-  cp "$SCAFFOLD_DIR/scripts/dev-setup.sh" "$d/scripts/dev-setup.sh"
-  printf '#!/usr/bin/env bash\n' >"$d/githooks/pre-commit.template"
-  printf '#!/usr/bin/env bash\n' >"$d/githooks/commit-msg.template"
-  printf '#!/usr/bin/env bash\n# scanner\n' >"$d/githooks/lib/check-secrets.template"
-  printf 'pat\tdesc\n' >"$d/forbidden-patterns/secrets.txt.template"
-  ( cd "$d" && git init --quiet && git config user.email t@t.local && git config user.name t )
-}
-
-# (T) file symlink at a rendered scanner path -> outside victim: the victim must
-#     NOT be overwritten, and the rendered path must become a real regular file.
-BF=$(mktemp -d)
-_b4_fakeclone "$BF/clone"
-printf 'PRECIOUS_DO_NOT_TOUCH\n' >"$BF/outside_target"
-mkdir -p "$BF/clone/.githooks/lib"
-ln -s "$BF/outside_target" "$BF/clone/.githooks/lib/check-secrets"
-( cd "$BF/clone" && bash scripts/dev-setup.sh ) >"$HOOK_OUT" 2>&1 || true
-if grep -q 'PRECIOUS_DO_NOT_TOUCH' "$BF/outside_target" \
-   && [ -f "$BF/clone/.githooks/lib/check-secrets" ] && [ ! -L "$BF/clone/.githooks/lib/check-secrets" ]; then
-  echo "  ✓ dev-setup replaces a symlinked rendered path with a real file (no write-through)"; PASS=$((PASS + 1))
-else
-  echo "  ✗ dev-setup wrote through a symlink or clobbered the outside target (B4)"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
-fi
-rm -rf "$BF"
-
-# (T) symlinked .githooks/lib DIR -> outside dir: mkdir -p must NOT follow it, so
-#     no scanner lands outside the repo and the rendered lib/ is a real dir.
-BD=$(mktemp -d)
-_b4_fakeclone "$BD/clone"
-mkdir -p "$BD/clone/.githooks" "$BD/outside_dir"
-ln -s "$BD/outside_dir" "$BD/clone/.githooks/lib"
-( cd "$BD/clone" && bash scripts/dev-setup.sh ) >"$HOOK_OUT" 2>&1 || true
-if [ ! -e "$BD/outside_dir/check-secrets" ] \
-   && [ -d "$BD/clone/.githooks/lib" ] && [ ! -L "$BD/clone/.githooks/lib" ]; then
-  echo "  ✓ dev-setup does not render through a symlinked lib/ dir (no outside write)"; PASS=$((PASS + 1))
-else
-  echo "  ✗ dev-setup followed a symlinked lib/ dir and wrote a scanner outside the repo (B4)"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
-fi
-rm -rf "$BD"
-
-# --- dev-setup.sh guards the core.hooksPath wiring like install.sh (B9 / B10) --
-# install.sh:403-414 guards the `git config core.hooksPath` step two ways;
-# dev-setup.sh ran it unconditionally. Reuse the minimal fake clone (dev-setup
-# resolves its root from its own path, so a scripts/ + templates tree is enough).
-
-# (T) B10 — a pre-existing core.hooksPath (Husky/lefthook) must be PRESERVED, not
-#     silently clobbered to .githooks. Reverting the guard sets it to .githooks
-#     (this case turns red), mutation-proving the preserve arm.
-HP=$(mktemp -d)
-_b4_fakeclone "$HP/clone"
-( cd "$HP/clone" && git config core.hooksPath .husky )
-( cd "$HP/clone" && bash scripts/dev-setup.sh ) >"$HOOK_OUT" 2>&1 || true
-if [ "$( cd "$HP/clone" && git config --get core.hooksPath )" = ".husky" ] \
-   && grep -qi "already '.husky'" "$HOOK_OUT"; then
-  echo "  ✓ dev-setup preserves a pre-existing core.hooksPath (no Husky clobber)"; PASS=$((PASS + 1))
-else
-  echo "  ✗ dev-setup clobbered a pre-existing core.hooksPath (B10)"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
-fi
-rm -rf "$HP"
-
-# (T) B10 happy path — with NO pre-existing hooksPath, dev-setup still sets
-#     .githooks (guards the fix from breaking the normal dogfooding wiring).
-HH=$(mktemp -d)
-_b4_fakeclone "$HH/clone"
-( cd "$HH/clone" && bash scripts/dev-setup.sh ) >"$HOOK_OUT" 2>&1 || true
-if [ "$( cd "$HH/clone" && git config --get core.hooksPath )" = ".githooks" ]; then
-  echo "  ✓ dev-setup sets core.hooksPath -> .githooks when unset (happy path)"; PASS=$((PASS + 1))
-else
-  echo "  ✗ dev-setup did not wire core.hooksPath on a fresh clone (B10 regression)"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
-fi
-rm -rf "$HH"
-
-# (T) B9 — run before `git init` (a non-git checkout / tarball): dev-setup must
-#     WARN and exit 0, not abort with a raw `fatal: not in a git directory`
-#     (exit 128) after every file is already rendered. Build the fake clone WITHOUT
-#     `git init`; mktemp dirs are not inside a repo, so the git-dir guard fires.
-#     Reverting the guard makes the run exit 128 (this case turns red).
-NG=$(mktemp -d)
-mkdir -p "$NG/clone/scripts" "$NG/clone/githooks/lib" "$NG/clone/forbidden-patterns"
-cp "$SCAFFOLD_DIR/scripts/dev-setup.sh" "$NG/clone/scripts/dev-setup.sh"
-printf '#!/usr/bin/env bash\n' >"$NG/clone/githooks/pre-commit.template"
-printf '#!/usr/bin/env bash\n' >"$NG/clone/githooks/commit-msg.template"
-printf '#!/usr/bin/env bash\n# scanner\n' >"$NG/clone/githooks/lib/check-secrets.template"
-printf 'pat\tdesc\n' >"$NG/clone/forbidden-patterns/secrets.txt.template"
-if ( cd "$NG/clone" && bash scripts/dev-setup.sh ) >"$HOOK_OUT" 2>&1 \
-   && grep -qi 'not in a git repo' "$HOOK_OUT"; then
-  echo "  ✓ dev-setup warns + exits 0 when run before git init (no exit 128)"; PASS=$((PASS + 1))
-else
-  echo "  ✗ dev-setup aborted instead of warning without a git dir (B9)"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
-fi
-rm -rf "$NG"
 reset_repo

--- a/tests/cases/09-toolchain-clobber.sh
+++ b/tests/cases/09-toolchain-clobber.sh
@@ -296,6 +296,25 @@ else
 fi
 rm -rf "$UAD"
 
+# (T) --gitleaks-ci installs the CI workflow (symmetric with --coverage-gate) so
+#     npx users, who have no on-disk copy of gitleaks.yml.template, can wire the
+#     unskippable CI gate; uninstall then removes it (no half-uninstall).
+UGC=$(mktemp -d)
+( cd "$UGC" && git init --quiet && echo '{"name":"x"}' >package.json \
+  && "$SCAFFOLD_DIR/install.sh" --frontend --gitleaks-ci --no-verify >/dev/null 2>&1 )
+if [ -f "$UGC/.github/workflows/gitleaks.yml" ] \
+   && cmp -s "$SCAFFOLD_DIR/.github/workflows/gitleaks.yml.template" "$UGC/.github/workflows/gitleaks.yml"; then
+  ( cd "$UGC" && "$SCAFFOLD_DIR/uninstall.sh" >/dev/null 2>&1 )
+  if [ ! -e "$UGC/.github/workflows/gitleaks.yml" ]; then
+    echo "  ✓ --gitleaks-ci installs gitleaks.yml and uninstall removes it"; PASS=$((PASS + 1))
+  else
+    echo "  ✗ uninstall left gitleaks.yml behind (half-uninstall)"; FAIL=$((FAIL + 1))
+  fi
+else
+  echo "  ✗ --gitleaks-ci did not install .github/workflows/gitleaks.yml"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$UGC"
+
 # (T) uninstall removes ci-changed-files too (install adds 8 libs; the uninstall
 #     loop dropped this one, leaving the scaffold half-uninstalled).
 UCI=$(mktemp -d)

--- a/tests/cases/11-npm-bundle.sh
+++ b/tests/cases/11-npm-bundle.sh
@@ -66,6 +66,20 @@ else
       echo "  ✗ npm bundle is missing $missing of $n required source file(s)"
       FAIL=$((FAIL + 1))
     fi
+
+    # Docs referenced by SHIPPED/INSTALLED files (pytest.ini.template,
+    # coverage.yml.template, agent-precheck, README relative links) but not read
+    # via $SCAFFOLD_DIR, so the grep above can't see them. They were absent from
+    # the tarball, leaving npx users with dangling "see RECOMMENDATIONS.md" links.
+    docs_missing=0
+    for d in RECOMMENDATIONS.md CHANGELOG.md; do
+      grep -qxF "$d" <<<"$PACKED" || { echo "  ✗ referenced doc missing from npm bundle: $d"; docs_missing=$((docs_missing + 1)); }
+    done
+    if [ "$docs_missing" -eq 0 ]; then
+      echo "  ✓ referenced docs (RECOMMENDATIONS.md, CHANGELOG.md) are bundled"; PASS=$((PASS + 1))
+    else
+      echo "  ✗ npm bundle is missing $docs_missing referenced doc(s)"; FAIL=$((FAIL + 1))
+    fi
   else
     echo "  ✗ npm pack --dry-run failed"; sed 's/^/      /' "$C11"; FAIL=$((FAIL + 1))
   fi

--- a/tests/cases/13-devsetup-guards.sh
+++ b/tests/cases/13-devsetup-guards.sh
@@ -1,0 +1,110 @@
+# shellcheck shell=bash
+# cases/13-devsetup-guards.sh — scripts/dev-setup.sh symlink write-through (B4)
+# and core.hooksPath wiring guards (B9/B10). Split out of cases/09 to keep both
+# files under the scaffold's own 500-line module cap. Sourced into the driver's
+# shell (uses $SCAFFOLD_DIR, $WORK, $HOOK_OUT, PASS/FAIL, reset_repo from common).
+# shellcheck disable=SC2164
+cd "$WORK"
+
+# --- dev-setup.sh does not write THROUGH a symlink at a rendered path (B4) -----
+# scripts/dev-setup.sh renders templates into the gitignored .githooks/ /
+# .forbidden-patterns/ for the scaffold's OWN dogfooding. It used bare `cp` /
+# `mkdir -p`, so a leftover/planted symlink there (surviving across checkouts,
+# since those dirs are gitignored) made cp write a scanner THROUGH the link to an
+# outside target, or mkdir -p follow a symlinked lib/ dir — the A7 class install.sh
+# already defends. dev-setup refuses to run outside a scaffold clone, so build a
+# MINIMAL fake clone (it resolves its root from its own path) and drive it.
+_b4_fakeclone() {   # $1 = dir to build a minimal runnable dev-setup clone into
+  local d=$1
+  mkdir -p "$d/scripts" "$d/githooks/lib" "$d/forbidden-patterns"
+  cp "$SCAFFOLD_DIR/scripts/dev-setup.sh" "$d/scripts/dev-setup.sh"
+  printf '#!/usr/bin/env bash\n' >"$d/githooks/pre-commit.template"
+  printf '#!/usr/bin/env bash\n' >"$d/githooks/commit-msg.template"
+  printf '#!/usr/bin/env bash\n# scanner\n' >"$d/githooks/lib/check-secrets.template"
+  printf 'pat\tdesc\n' >"$d/forbidden-patterns/secrets.txt.template"
+  ( cd "$d" && git init --quiet && git config user.email t@t.local && git config user.name t )
+}
+
+# (T) file symlink at a rendered scanner path -> outside victim: the victim must
+#     NOT be overwritten, and the rendered path must become a real regular file.
+BF=$(mktemp -d)
+_b4_fakeclone "$BF/clone"
+printf 'PRECIOUS_DO_NOT_TOUCH\n' >"$BF/outside_target"
+mkdir -p "$BF/clone/.githooks/lib"
+ln -s "$BF/outside_target" "$BF/clone/.githooks/lib/check-secrets"
+( cd "$BF/clone" && bash scripts/dev-setup.sh ) >"$HOOK_OUT" 2>&1 || true
+if grep -q 'PRECIOUS_DO_NOT_TOUCH' "$BF/outside_target" \
+   && [ -f "$BF/clone/.githooks/lib/check-secrets" ] && [ ! -L "$BF/clone/.githooks/lib/check-secrets" ]; then
+  echo "  ✓ dev-setup replaces a symlinked rendered path with a real file (no write-through)"; PASS=$((PASS + 1))
+else
+  echo "  ✗ dev-setup wrote through a symlink or clobbered the outside target (B4)"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$BF"
+
+# (T) symlinked .githooks/lib DIR -> outside dir: mkdir -p must NOT follow it, so
+#     no scanner lands outside the repo and the rendered lib/ is a real dir.
+BD=$(mktemp -d)
+_b4_fakeclone "$BD/clone"
+mkdir -p "$BD/clone/.githooks" "$BD/outside_dir"
+ln -s "$BD/outside_dir" "$BD/clone/.githooks/lib"
+( cd "$BD/clone" && bash scripts/dev-setup.sh ) >"$HOOK_OUT" 2>&1 || true
+if [ ! -e "$BD/outside_dir/check-secrets" ] \
+   && [ -d "$BD/clone/.githooks/lib" ] && [ ! -L "$BD/clone/.githooks/lib" ]; then
+  echo "  ✓ dev-setup does not render through a symlinked lib/ dir (no outside write)"; PASS=$((PASS + 1))
+else
+  echo "  ✗ dev-setup followed a symlinked lib/ dir and wrote a scanner outside the repo (B4)"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$BD"
+
+# --- dev-setup.sh guards the core.hooksPath wiring like install.sh (B9 / B10) --
+# install.sh:403-414 guards the `git config core.hooksPath` step two ways;
+# dev-setup.sh ran it unconditionally. Reuse the minimal fake clone (dev-setup
+# resolves its root from its own path, so a scripts/ + templates tree is enough).
+
+# (T) B10 — a pre-existing core.hooksPath (Husky/lefthook) must be PRESERVED, not
+#     silently clobbered to .githooks. Reverting the guard sets it to .githooks
+#     (this case turns red), mutation-proving the preserve arm.
+HP=$(mktemp -d)
+_b4_fakeclone "$HP/clone"
+( cd "$HP/clone" && git config core.hooksPath .husky )
+( cd "$HP/clone" && bash scripts/dev-setup.sh ) >"$HOOK_OUT" 2>&1 || true
+if [ "$( cd "$HP/clone" && git config --get core.hooksPath )" = ".husky" ] \
+   && grep -qi "already '.husky'" "$HOOK_OUT"; then
+  echo "  ✓ dev-setup preserves a pre-existing core.hooksPath (no Husky clobber)"; PASS=$((PASS + 1))
+else
+  echo "  ✗ dev-setup clobbered a pre-existing core.hooksPath (B10)"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$HP"
+
+# (T) B10 happy path — with NO pre-existing hooksPath, dev-setup still sets
+#     .githooks (guards the fix from breaking the normal dogfooding wiring).
+HH=$(mktemp -d)
+_b4_fakeclone "$HH/clone"
+( cd "$HH/clone" && bash scripts/dev-setup.sh ) >"$HOOK_OUT" 2>&1 || true
+if [ "$( cd "$HH/clone" && git config --get core.hooksPath )" = ".githooks" ]; then
+  echo "  ✓ dev-setup sets core.hooksPath -> .githooks when unset (happy path)"; PASS=$((PASS + 1))
+else
+  echo "  ✗ dev-setup did not wire core.hooksPath on a fresh clone (B10 regression)"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$HH"
+
+# (T) B9 — run before `git init` (a non-git checkout / tarball): dev-setup must
+#     WARN and exit 0, not abort with a raw `fatal: not in a git directory`
+#     (exit 128) after every file is already rendered. Build the fake clone WITHOUT
+#     `git init`; mktemp dirs are not inside a repo, so the git-dir guard fires.
+#     Reverting the guard makes the run exit 128 (this case turns red).
+NG=$(mktemp -d)
+mkdir -p "$NG/clone/scripts" "$NG/clone/githooks/lib" "$NG/clone/forbidden-patterns"
+cp "$SCAFFOLD_DIR/scripts/dev-setup.sh" "$NG/clone/scripts/dev-setup.sh"
+printf '#!/usr/bin/env bash\n' >"$NG/clone/githooks/pre-commit.template"
+printf '#!/usr/bin/env bash\n' >"$NG/clone/githooks/commit-msg.template"
+printf '#!/usr/bin/env bash\n# scanner\n' >"$NG/clone/githooks/lib/check-secrets.template"
+printf 'pat\tdesc\n' >"$NG/clone/forbidden-patterns/secrets.txt.template"
+if ( cd "$NG/clone" && bash scripts/dev-setup.sh ) >"$HOOK_OUT" 2>&1 \
+   && grep -qi 'not in a git repo' "$HOOK_OUT"; then
+  echo "  ✓ dev-setup warns + exits 0 when run before git init (no exit 128)"; PASS=$((PASS + 1))
+else
+  echo "  ✗ dev-setup aborted instead of warning without a git dir (B9)"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$NG"
+reset_repo

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -47,7 +47,8 @@ for case_file in \
   "$HERE/cases/09-toolchain-clobber.sh" \
   "$HERE/cases/10-ci-diff-scope.sh" \
   "$HERE/cases/11-npm-bundle.sh" \
-  "$HERE/cases/12-install-backup-cap.sh"; do
+  "$HERE/cases/12-install-backup-cap.sh" \
+  "$HERE/cases/13-devsetup-guards.sh"; do
   # shellcheck source=/dev/null
   . "$case_file"
 done

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -150,6 +150,8 @@ remove_if_unmodified ".githooks/commit-msg"          "$SCAFFOLD_DIR/githooks/com
 remove_if_unmodified ".githooks/lib/check-gitleaks"  "$SCAFFOLD_DIR/githooks/lib/check-gitleaks.template"
 # Opt-in CI patch-coverage gate (only present if installed with --coverage-gate).
 remove_if_unmodified ".github/workflows/coverage.yml" "$SCAFFOLD_DIR/.github/workflows/coverage.yml.template"
+# Opt-in gitleaks CI workflow (only present if installed with --gitleaks-ci).
+remove_if_unmodified ".github/workflows/gitleaks.yml" "$SCAFFOLD_DIR/.github/workflows/gitleaks.yml.template"
 
 # Likely-customized files — only with --all
 if [ "$REMOVE_ALL" -eq 1 ]; then


### PR DESCRIPTION
Multi-agent code + security review of the scaffold. An 8-dimension workflow produced 35 raw findings; each survivor was adversarially verified by an independent refuter + reproducer (empirical repro in a temp repo, and a check that it isn't a re-report of the previously-closed audits). Result: **30 confirmed, 2 disputed** — all confirmed fixed here, plus a new bug found while fixing one of them.

Every new test is mutation-proven. Suite **199 → 227/0**. shellcheck + actionlint clean; all module files under the scaffold's own 500-line cap (a test file was split, not suppressed).

## HIGH
- **Directory-symlink write-through in `install.sh`** — the cp_* symlink defenses dropped a symlink at the destination *leaf* but `mkdir -p "$(dirname)"` still followed a symlinked *parent* (`.githooks -> ~/.ssh`), writing every scanner/hook/workflow outside the repo and clobbering files there, while the in-tree path stayed a symlink (silent fail-open). Ported the multi-level `_mkdir_safe` guard that `dev-setup.sh` already had (B4) but the user-facing installer lacked.
- **Two one-commit ways to neuter the secret scanner** — gutting `secrets.txt` to zero patterns (present-but-empty) and `git mv`-renaming it both dodged the deletion guard. Empty/all-invalid config now fails **closed** at both hook and CI; the deletion guard uses `--no-renames`.

## New bug (not in the review set, found while fixing C5)
- **macOS/BSD awk NUL-truncation** — the shared awk length-cap stage truncates a record at an embedded NUL, so a secret placed *after* a NUL byte was silently lost by check-secrets/patterns/hygiene alike. Fixed with `tr -d '\000'` before awk in all four scan pipelines.

## Medium / low
- Hidden-Unicode (Trojan Source) scan skipped any blob with a NUL — a NUL prepended to an agent-read `.md` dodged the only defense; the skip now needs a binary *extension* too.
- `scaffold-allow` `^` anchor was dead after `grep -n` (never matched column-0 comments) — fixed across all 5 scanners.
- `check-patterns` over-cap now fails closed (was warn + exit 0).
- secrets.txt coverage: +ABIA/ACCA, Slack xapp-/xoxe-, Stripe whsec_, JWT payload floor {17,}→{2,}; narrowed the `.forbidden-patterns/*` scan-skip to `*.txt`.
- CI: PHP composer `--no-scripts --no-plugins`; actionlint asset sha256-verified; ruff/pytest/diff-cover pinned; release.yml env-gating documented (opt-in, to avoid perturbing the live tokenless publish).
- Packaging: RECOMMENDATIONS.md + CHANGELOG.md added to npm `files`; new `--gitleaks-ci` flag installs the CI workflow (uninstall removes it).
- README drift: adopting-section CI scope, agent-runtime "deferred" → shipped, npx `@latest` upgrade, hygiene ids, comment-leader wording, per-channel uninstall.
- Coverage added for 8 previously-untested branches (commit-msg exemptions, size warn, MAX_LINES guard, mid-file BOM / bidi / tag-block / diff3 markers, eslint + php-l blocks).

## Disputed — deliberately not "fixed"
- Template-only action pins: already documented in `SECURITY_AUDIT.md` and pins are current — no live impact.
- "All five linter blocks untestable": headline false (tsc runs in CI); added the real residual (eslint + php-l rejection tests). prettier/phpcs remain lightly covered (noted for follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)