### PR TITLE
build(ci): bump actions/setup-python to v7.0.0

### DIFF
--- a/.github/workflows/coverage.yml.template
+++ b/.github/workflows/coverage.yml.template
@@ -51,7 +51,7 @@ jobs:
 
       # ── Python: pytest + coverage → coverage.xml (Cobertura) ──────────────
       - if: steps.detect.outputs.python == 'true'
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: "3.12"
       - name: Run Python tests with coverage

--- a/.github/workflows/lint.yml.template
+++ b/.github/workflows/lint.yml.template
@@ -43,7 +43,7 @@ jobs:
             echo "present=true" >> "$GITHUB_OUTPUT"
           fi
       - if: steps.detect.outputs.present == 'true'
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: "3.12"
       - if: steps.detect.outputs.present == 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: "3.12"
       # Pin the linter version (supply-chain posture: the repo's own


### PR DESCRIPTION
Completes the pin refresh started in #64, which covered `actions/checkout` and
`actions/setup-node` but left `setup-python` on v6.3.0. This is the one remaining
bump proposed by Dependabot in #63, which cannot be merged as-is (see below).

## Why the major is safe here

v7.0.0 is a major, but none of its breaking changes reach this repo:

| Breaking change | Impact here |
|---|---|
| ESM migration | Internal to the action |
| `pip-install` input removed | Not used at any call site |
| EOL Python versions dropped | 3.12 is not EOL; it is the only version requested |

All three call sites pass nothing but `python-version: "3.12"`.

## Why not just merge #63

#63 touches only the four real `.yml` files and no `*.yml.template` files, so it
trips the pin-drift guard in `test.yml`:

```
##[error]Action pin drift - these actions have differing SHAs between
real workflows and *.yml.template files (Dependabot only bumps the
real *.yml; bump the templates to match)
```

This PR bumps the real workflow **and** both templates, so the guard stays green.
#63 can be closed once this lands.

## Verification

- SHA `5fda3b95a4ea91299a34e894583c3862153e4b97` resolves to the `v7.0.0` tag via
  the GitHub API, and v7.0.0 is the current latest release.
- v7.0.0 clears the 7-day supply-chain cooldown configured in `dependabot.yml`.
- Drift guard run locally against the branch: no drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)