### PR TITLE
feat(hook): warn on untracking pattern config, fail only on real deletion (#65)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- **The pre-commit hook distinguishes *untracking* a pattern file from
+  *deleting* it ([#65]).** A staged `.forbidden-patterns/*.txt` deletion used
+  to hard-fail unconditionally, but `git rm --cached` (untrack, keep the file
+  on disk, ignore it via `.git/info/exclude`) is a legitimate local-only-tooling
+  move. Every check reads its pattern config from the **working tree** — never
+  from the index — so a file still on disk keeps the scanner fully armed. The
+  hook now fails only when the file is also gone from (or unreadable on) disk,
+  and warns on a pure untrack.
+
+  This does not reopen the neutering paths closed in v0.9.0: a config that is
+  gone, gutted to zero patterns, or renamed away still fails, and server-side
+  an untracked config is absent from the repo entirely, where
+  `check-secrets --ci` fails closed. The warning says so explicitly.
+
+  Four cases cover it, mutation-proven in both directions — including one that
+  asserts the *premise* rather than the behaviour: untracking the config while
+  staging a real secret must still be caught, so the suite turns red if a check
+  ever starts reading pattern config from the index.
+
 ### Fixed
 - **`check-secrets` matches token-shaped rules case-sensitively ([#67]).**
   Every rule used to be matched with `grep -i`. The AWS key-ID rule widened to
@@ -32,6 +52,7 @@ versioning follows [SemVer](https://semver.org/).
   an un-upgraded consumer `secrets.txt` is unaffected until its patterns are
   refreshed. Suite 227 → 230, all three cases mutation-proven.
 
+[#65]: https://github.com/Sting25/ai-coding-rules-scaffold/issues/65
 [#67]: https://github.com/Sting25/ai-coding-rules-scaffold/issues/67
 
 ## [v0.11.0] — 2026-07-19

--- a/githooks/pre-commit.template
+++ b/githooks/pre-commit.template
@@ -31,8 +31,11 @@ LIB="$HOOK_DIR/lib"
 # check is fed from it. (core.quotepath is irrelevant under -z, which never
 # C-quotes; kept only for defence in depth.)
 # Refuse to let a commit silently disable the scanners by deleting their config.
-# A staged deletion of a .forbidden-patterns/*.txt makes the matching check find
-# no config and exit 0 — a one-commit way to land a secret AND neuter the scan.
+# A staged deletion of a .forbidden-patterns/*.txt that also removes the file
+# from disk makes the matching check find no config and exit 0 — a one-commit
+# way to land a secret AND neuter the scan. A staged deletion whose file is
+# still on disk (`git rm --cached`) is a different thing and only warns; see the
+# untrack-vs-delete note below.
 # Checked BEFORE the empty-staged-list exit, since a delete-only commit has an
 # empty ACMR list. Use `git commit --no-verify` if a removal is intended (uninstall).
 # `--no-renames` is load-bearing: git's default rename detection reports a
@@ -41,10 +44,40 @@ LIB="$HOOK_DIR/lib"
 # a rename as delete+add surfaces the OLD path as a D so the guard still fires.
 DELETED_CONFIG=$(git diff --cached --no-renames -z --name-only --diff-filter=D | tr '\0' '\n' | grep -E '^\.forbidden-patterns/.+\.txt$' || true)
 if [ -n "$DELETED_CONFIG" ]; then
-  echo "error: this commit deletes forbidden-pattern config, disabling the scanner:" >&2
+  # UNTRACKING is not DISABLING. `git rm --cached` stages a deletion but leaves
+  # the file on disk — the local-only-tooling pattern, paired with an entry in
+  # .git/info/exclude. Every check reads its pattern config from the WORKING
+  # TREE, never from the index: check-secrets does `done <"$CONFIG"`,
+  # check-patterns iterates `.forbidden-patterns/*.txt`, agent-precheck reads
+  # `$pfile`. (`git show ":0:"` appears in those scripts only for the CONTENT
+  # being scanned, never for the config.) So a file still on disk keeps the
+  # scanner fully armed for this and every later local commit.
+  #
+  # This does not reopen the neutering paths closed by 5ced87a / 3ef4ad9: those
+  # cover a config that is GONE, gutted to zero patterns, or renamed away, and
+  # all three still fail. Server-side the untracked config is absent from the
+  # repo entirely, where `check-secrets --ci` fails CLOSED — so the warn is
+  # local-only leniency, not a hole.
+  #
+  # Treat unreadable or non-regular as gone: the checks cannot read it either.
+  GONE_CONFIG=""
+  while IFS= read -r f; do
+    [ -n "$f" ] || continue
+    if [ ! -f "$f" ] || [ ! -r "$f" ]; then
+      GONE_CONFIG="$GONE_CONFIG$f"$'\n'
+    fi
+  done <<EOF_DELCFG
+$DELETED_CONFIG
+EOF_DELCFG
+  if [ -n "$GONE_CONFIG" ]; then
+    echo "error: this commit deletes forbidden-pattern config, disabling the scanner:" >&2
+    printf '%s' "$GONE_CONFIG" | sed 's/^/       /' >&2
+    echo "       Refusing — re-add it, or use 'git commit --no-verify' if intended." >&2
+    exit 1
+  fi
+  echo "note: forbidden-pattern config untracked but still present on disk — local scanning stays active:" >&2
   printf '%s\n' "$DELETED_CONFIG" | sed 's/^/       /' >&2
-  echo "       Refusing — re-add it, or use 'git commit --no-verify' if intended." >&2
-  exit 1
+  echo "       CI has no copy of an untracked config, so a guardrails job fails closed there." >&2
 fi
 
 STAGED_LIST=$(mktemp)

--- a/tests/cases/04-shell-config-rename.sh
+++ b/tests/cases/04-shell-config-rename.sh
@@ -57,6 +57,41 @@ assert_passes "case-sensitive: Console.log not flagged as console.log"
 git rm -q .forbidden-patterns/secrets.txt
 assert_rejects "deleting forbidden-pattern config is refused" "disabling the scanner"
 
+# 27b. UNTRACKING is not DELETING. `git rm --cached` stages a deletion but keeps
+#      the file on disk, and every check reads pattern config from the WORKING
+#      TREE — so the scanner stays fully armed. The hook must warn and PASS here,
+#      not hard-fail like case 27.
+git rm --cached -q .forbidden-patterns/secrets.txt
+if .githooks/pre-commit >"$HOOK_OUT" 2>&1; then
+  if grep -qF "still present on disk" "$HOOK_OUT"; then
+    echo "  ✓ untracking a pattern file (still on disk) warns and passes"
+    PASS=$((PASS + 1))
+  else
+    echo "  ✗ untracking a pattern file — passed but without the expected warning"
+    sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+  fi
+else
+  echo "  ✗ untracking a pattern file (still on disk) — hook rejected, expected warn+pass"
+  sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+reset_repo
+
+# 27c. THE PREMISE, ASSERTED DIRECTLY. 27b only proves the hook is lenient; it
+#      does not prove leniency is SAFE. Untrack the config AND stage a real
+#      secret in the same commit: the on-disk config must still catch it. If a
+#      check ever starts reading pattern config from the index instead of the
+#      working tree, 27b keeps passing and only this case turns red.
+git rm --cached -q .forbidden-patterns/secrets.txt
+echo "AWS=AKIA""IOSFODNN7EXAMPLE" >untracked-scan.txt
+git add untracked-scan.txt
+assert_rejects "scanner stays armed when its config is untracked but on disk" "AWS access key"
+
+# 27d. Untracked AND removed from disk is a real deletion, however it was
+#      staged — the on-disk check must not be fooled by the two-step form.
+git rm --cached -q .forbidden-patterns/secrets.txt
+rm -f .forbidden-patterns/secrets.txt
+assert_rejects "untracked AND removed from disk is still refused" "disabling the scanner"
+
 # 28. scaffold-allow only exempts when it follows a comment leader; the bare
 #     substring inside a string literal must NOT whitelist a real secret.
 echo 'note = "scaffold-allow AKIA''IOSFODNN7EXAMPLE"' >sneaky2.txt


### PR DESCRIPTION
Part 1 of #65. Part 2 (`install.sh --shell`) follows separately.

The issue's reference diff is ~108 commits stale, so this is a fresh implementation
on the current tree, not a patch application.

## The MUST-CHECK, verified first

#65 explicitly warns that this change would reopen a closed hole if any check reads
pattern config from the **index** rather than the working tree — `5ced87a` and
`3ef4ad9` hardened scanner-neutering paths after the issue's base. Checked before
writing any code:

| Check | How it loads config | Source |
|---|---|---|
| `check-secrets` | `done <"$CONFIG"` | working tree |
| `check-patterns` | `for cfg in .forbidden-patterns/*.txt` | working tree |
| `agent-precheck` | `done <"$pfile"` | working tree |

`git show ":0:"` appears in those scripts **only** for the content being scanned,
never for the config. The premise holds.

## The change

`git rm --cached` stages a deletion but leaves the file on disk — the local-only
tooling pattern, paired with `.git/info/exclude`. Since config is read from the
working tree, the scanner stays fully armed. The hook now:

- **hard-fails** when a staged-deleted config is also gone from disk (unchanged), and
- **warns and passes** on a pure untrack.

Unreadable or non-regular counts as gone, since the checks could not read it either.

### Why this is not a hole

A config that is gone, gutted to zero patterns, or renamed away still fails — those
paths are untouched. And server-side an untracked config is absent from the repo
entirely, where `check-secrets --ci` fails **closed**. The warning says so, so nobody
reads local leniency as blanket permission:

```
note: forbidden-pattern config untracked but still present on disk — local scanning stays active:
       .forbidden-patterns/secrets.txt
       CI has no copy of an untracked config, so a guardrails job fails closed there.
```

## Tests — suite 231 → 234

| Case | Asserts |
|---|---|
| 27b | untrack with the file on disk warns and **passes** |
| 27c | **the premise**: untrack the config *and* stage a real secret — still caught |
| 27d | untracked **and** removed from disk is still refused |

27c is the one that matters. 27b only proves the hook is lenient; it does not prove
leniency is *safe*. If a check ever starts reading pattern config from the index,
27b keeps passing and only 27c turns red.

### Mutation proof, both directions

```
mutation "always gone"  ->  27b, 27c red   (guard too strict — old behaviour)
mutation "never gone"   ->  27,  27d red   (guard disarmed)
restored                ->  234 passed, 0 failed
```

## Verification

- Suite **234 passed, 0 failed**
- `shellcheck -S info` clean
- `pre-commit.template` 215 lines, `04-shell-config-rename.sh` 332 — both under the
  500-line module cap

🤖 Generated with [Claude Code](https://claude.com/claude-code)