### PR TITLE
fix(ci): coverage gate must fail on failing tests, not just uncovered lines (#71)

### DIFF
--- a/.github/workflows/coverage.yml.template
+++ b/.github/workflows/coverage.yml.template
@@ -56,14 +56,33 @@ jobs:
           python-version: "3.12"
       - name: Run Python tests with coverage
         if: steps.detect.outputs.python == 'true'
-        # `|| true` so a no-tests-collected exit doesn't mask the diff-cover
-        # verdict below; diff-cover reads coverage.xml and is the gate.
+        # Tolerate ONLY pytest's exit 5 (no tests collected), so an empty suite
+        # doesn't mask the diff-cover verdict below. Every other non-zero code —
+        # 1 failed, 2 interrupted, 3 internal error, 4 usage — fails the job.
+        #
+        # This used to be a blanket `|| true`, which swallowed exit 1 as well, so
+        # a PR with FAILING tests produced a green check (#71). Worse than merely
+        # not gating: a failing test still executes the lines it touches and so
+        # still writes them into coverage.xml, meaning a PR whose new code is
+        # covered only by a red test PASSED the patch-coverage gate on the
+        # strength of that very test.
+        #
+        # `|| rc=$?`, not `; rc=$?`: the default shell for a `run` step is
+        # `bash -e`, under which `pytest …; rc=$?` exits at pytest before the
+        # assignment is ever reached — which would fail the job on exit 5 and
+        # undo the tolerance this block exists to provide. A command on the left
+        # of `||` is a tested command and exempt from -e.
         run: |
           # Pinned: an unpinned `pip install` executes whatever version is newest
           # at run time, minutes after publish — contradicting the cooldown posture
           # the scaffold's dependabot.yml.template documents. Dependabot bumps these.
           pip install pytest==9.1.1 pytest-cov==7.1.0
-          pytest --cov --cov-report=xml || true
+          rc=0
+          pytest --cov --cov-report=xml || rc=$?
+          if [ "$rc" -ne 0 ] && [ "$rc" -ne 5 ]; then
+            echo "pytest exited $rc — failing the job (only 5 = no tests collected is tolerated)."
+            exit "$rc"
+          fi
 
       # ── Frontend: vitest V8 coverage → coverage/cobertura-coverage.xml ────
       - if: steps.detect.outputs.frontend == 'true'
@@ -75,13 +94,19 @@ jobs:
         # --ignore-scripts: same supply-chain hardening as lint.yml. Vitest +
         # @vitest/coverage-v8 are pure JS. Jest projects: swap for your
         # `jest --coverage` command emitting cobertura.
+        #
+        # No `|| true` here either (#71) — a failing vitest run must fail the job.
+        # vitest has no distinct "nothing collected" exit code to special-case
+        # the way pytest's 5 is handled above; `--passWithNoTests` is the
+        # supported way to say an empty suite is not an error, so it exits 0 and
+        # the diff-cover step still gets its say.
         run: |
           if [ -f package-lock.json ] || [ -f npm-shrinkwrap.json ]; then
             npm ci --ignore-scripts
           else
             npm install --ignore-scripts
           fi
-          npx --no-install vitest run --coverage || true
+          npx --no-install vitest run --coverage --passWithNoTests
 
       # ── Gate: every changed line must be covered ──────────────────────────
       - name: Enforce patch coverage (diff-cover)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,34 @@ versioning follows [SemVer](https://semver.org/).
   ever starts reading pattern config from the index.
 
 ### Fixed
+- **The patch-coverage gate no longer passes a PR whose tests are failing
+  ([#71]).** `coverage.yml.template` ran both test steps with `|| true`. The
+  intent was narrow and sound — `pytest` exits 5 when it collects nothing, and
+  an empty suite should not mask the `diff-cover` verdict that is the actual
+  gate — but `|| true` swallows exit 1 just as happily, so a PR with failing
+  tests produced a green check.
+
+  It was worse than merely not gating on failure. A failing test still executes
+  the lines it touches, so those lines still land in `coverage.xml`; a PR whose
+  new code was covered only by a red test therefore **passed** the patch-coverage
+  gate on the strength of that very test. And since the job is named `coverage`
+  and may be the only one invoking `pytest`, a consumer could reasonably read it
+  as a test gate it was not.
+
+  Now only `pytest`'s exit 5 is tolerated; 1 (failed), 2 (interrupted), 3
+  (internal error) and 4 (usage error) all fail the job. `vitest` has no
+  equivalent no-tests code, so its step drops `|| true` and gains
+  `--passWithNoTests`, which handles the empty case by exiting 0.
+
+  Written as `pytest … || rc=$?`, not `pytest …; rc=$?`: a `run:` step's default
+  shell is `bash -e`, under which the latter exits at `pytest` before the
+  assignment is reached — failing the job on exit 5 and undoing the tolerance
+  the block exists to provide. `cases/16` runs the step's real shell body,
+  lifted out of the shipped YAML, under `bash -e` against a fake `pytest`, and
+  catches exactly that mistake.
+
+  Suite 239 → 245.
+
 - **`check-secrets` matches token-shaped rules case-sensitively ([#67]).**
   Every rule used to be matched with `grep -i`. The AWS key-ID rule widened to
   `(AKIA|ASIA|ABIA|ACCA)…` in v0.11.0, and `ACCA` is composed entirely of hex
@@ -80,6 +108,7 @@ versioning follows [SemVer](https://semver.org/).
 
 [#65]: https://github.com/Sting25/ai-coding-rules-scaffold/issues/65
 [#67]: https://github.com/Sting25/ai-coding-rules-scaffold/issues/67
+[#71]: https://github.com/Sting25/ai-coding-rules-scaffold/issues/71
 
 ## [v0.11.0] — 2026-07-19
 

--- a/README.md
+++ b/README.md
@@ -451,6 +451,12 @@ by default so the scaffold stays minimal; turn them on per project.
   tests"). Opt-in because forcing tests on new code is a policy a team must
   choose deliberately.
 
+  The job also **fails on failing tests**, not only on uncovered lines. That is
+  worth stating because it was not always true: the test steps ended in
+  `|| true`, so a red suite went green ([#71]). Only `pytest`'s exit 5 (no tests
+  collected) is tolerated now, and `vitest` uses `--passWithNoTests` for the
+  same case.
+
 Supply-chain hardening is **on by default** in the shipped CI + Dependabot
 config: `install.sh` drops a `.github/dependabot.yml` (weekly grouped bumps of
 the SHA-pinned Actions, with a **7-day `cooldown`** so a compromised-and-yanked
@@ -559,3 +565,5 @@ The scaffold works fine without any AI tool. Drop the files in, run the hook —
 ## License
 
 MIT — see [LICENSE](LICENSE).
+
+[#71]: https://github.com/Sting25/ai-coding-rules-scaffold/issues/71

--- a/tests/cases/16-coverage-gate.sh
+++ b/tests/cases/16-coverage-gate.sh
@@ -1,0 +1,126 @@
+# shellcheck shell=bash
+# cases/16-coverage-gate.sh — the opt-in patch-coverage workflow must fail on
+# FAILING tests, not just on uncovered lines (issue #71). Sourced into the
+# driver's shell, so the globals (PASS/FAIL/HOOK_OUT/SCAFFOLD_DIR) are in scope.
+#
+# What #71 was: the pytest and vitest steps ended in `|| true`. The intent was to
+# tolerate pytest's exit 5 (no tests collected) so an empty suite didn't mask the
+# diff-cover verdict — but `|| true` swallows exit 1 too, so a PR with failing
+# tests went green. Worse than merely not gating: a failing test still EXECUTES
+# the lines it touches and so still writes them into coverage.xml, meaning a PR
+# whose new code is covered only by a red test PASSED the patch-coverage gate on
+# the strength of that very test.
+#
+# These assertions run the step's REAL shell body, lifted out of the shipped
+# YAML, against a fake pytest with a chosen exit code. Asserting on the text
+# ("no `|| true` present") would pass against any rewrite that reintroduced the
+# hole by another route; running it cannot.
+
+echo "cases/16 — patch-coverage gate fails on failing tests (#71)"
+
+COV_TPL="$SCAFFOLD_DIR/.github/workflows/coverage.yml.template"
+
+# Lift the shell body of a `run: |` step out of the workflow, dedented. The
+# `pip install` line is dropped: the point is the exit-code logic around the
+# test command, and the test must not reach the network.
+_run_block() {
+  awk -v step="      - name: $1" '
+    $0 == step { found = 1 }
+    found && /run: \|/ { inrun = 1; next }
+    inrun {
+      if ($0 ~ /^[[:space:]]*$/) next
+      if ($0 !~ /^          /) exit
+      sub(/^          /, "")
+      if ($0 ~ /^pip install/) next
+      print
+    }
+  ' "$COV_TPL"
+}
+
+# Run a step body under `bash -e` — the default shell GitHub gives a `run:` step
+# — with a fake $2 on PATH exiting $3. Echoes the body's exit status.
+#
+# `bash -e` is load-bearing, not incidental: under -e the obvious `pytest …;
+# rc=$?` never reaches the assignment, so a fix written that way fails the job on
+# exit 5 and undoes the tolerance the block exists to provide. Running the body
+# under any other shell would hide that.
+_run_step_with_fake() {
+  local body=$1 tool=$2 code=$3
+  local d; d=$(mktemp -d)
+  printf '#!/bin/sh\nexit %s\n' "$code" >"$d/$tool"
+  chmod +x "$d/$tool"
+  # npx is invoked as `npx --no-install vitest …`; fake it as a shim that runs
+  # the tool name it was handed, so the real command line is exercised.
+  if [ "$tool" = "vitest" ]; then
+    printf '#!/bin/sh\nshift\nexec "$@"\n' >"$d/npx"
+    chmod +x "$d/npx"
+  fi
+  printf '%s\n' "$body" >"$d/step.sh"
+  local rc=0
+  ( PATH="$d:$PATH" bash -e "$d/step.sh" ) >/dev/null 2>&1 || rc=$?
+  rm -rf "$d"
+  printf '%s' "$rc"
+}
+
+PYBODY=$(_run_block "Run Python tests with coverage")
+JSBODY=$(_run_block "Run frontend tests with coverage")
+
+if [ -z "$PYBODY" ] || [ -z "$JSBODY" ]; then
+  echo "  ✗ could not lift the test steps out of coverage.yml.template (step renamed?)"; FAIL=$((FAIL + 1))
+else
+  # (T) THE BUG: pytest exit 1 (tests FAILED) must fail the job. Under the old
+  #     `|| true` this was 0 and the PR went green.
+  R=$(_run_step_with_fake "$PYBODY" pytest 1)
+  if [ "$R" -ne 0 ]; then
+    echo "  ✓ pytest exit 1 (failing tests) fails the coverage job"; PASS=$((PASS + 1))
+  else
+    echo "  ✗ failing pytest still produced a green coverage job (#71)"; FAIL=$((FAIL + 1))
+  fi
+
+  # (T) ...while exit 5 (no tests collected) is still tolerated, which is the
+  #     entire reason the original `|| true` was there. A fix that gates on
+  #     failure by ALSO failing here would have traded one bug for another.
+  R=$(_run_step_with_fake "$PYBODY" pytest 5)
+  if [ "$R" -eq 0 ]; then
+    echo "  ✓ pytest exit 5 (no tests collected) is still tolerated"; PASS=$((PASS + 1))
+  else
+    echo "  ✗ exit 5 now fails the job — the no-tests tolerance regressed (rc=$R)"; FAIL=$((FAIL + 1))
+  fi
+
+  # (T) A clean run stays clean, so diff-cover gets its say.
+  R=$(_run_step_with_fake "$PYBODY" pytest 0)
+  if [ "$R" -eq 0 ]; then
+    echo "  ✓ pytest exit 0 passes through to the diff-cover gate"; PASS=$((PASS + 1))
+  else
+    echo "  ✗ a passing pytest failed the step (rc=$R)"; FAIL=$((FAIL + 1))
+  fi
+
+  # (T) Every other non-zero code fails too — 2 interrupted, 3 internal error,
+  #     4 usage. 4 is the one that matters most in practice: a typo'd pytest
+  #     invocation collecting nothing would otherwise look like an empty suite.
+  R=$(_run_step_with_fake "$PYBODY" pytest 4)
+  if [ "$R" -ne 0 ]; then
+    echo "  ✓ pytest exit 4 (usage error) fails rather than reading as 'no tests'"; PASS=$((PASS + 1))
+  else
+    echo "  ✗ pytest usage error was swallowed — only 5 may be tolerated"; FAIL=$((FAIL + 1))
+  fi
+
+  # (T) The frontend half: a failing vitest run must fail the job as well.
+  #     vitest has no distinct no-tests-collected code, so there is nothing to
+  #     tolerate here — --passWithNoTests covers the empty case by exiting 0.
+  R=$(_run_step_with_fake "$JSBODY" vitest 1)
+  if [ "$R" -ne 0 ]; then
+    echo "  ✓ vitest exit 1 (failing tests) fails the coverage job"; PASS=$((PASS + 1))
+  else
+    echo "  ✗ failing vitest still produced a green coverage job (#71)"; FAIL=$((FAIL + 1))
+  fi
+
+  # (T) ...and the empty-suite case is handled by the flag, not by swallowing.
+  if printf '%s' "$JSBODY" | grep -qF -- "--passWithNoTests"; then
+    echo "  ✓ vitest empty suite handled by --passWithNoTests, not a swallowed exit"; PASS=$((PASS + 1))
+  else
+    echo "  ✗ vitest step lacks --passWithNoTests — an empty suite would fail the job"; FAIL=$((FAIL + 1))
+  fi
+fi
+
+reset_repo

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -49,7 +49,8 @@ for case_file in \
   "$HERE/cases/11-npm-bundle.sh" \
   "$HERE/cases/12-install-backup-cap.sh" \
   "$HERE/cases/13-devsetup-guards.sh" \
-  "$HERE/cases/14-shell-install-mode.sh"; do
+  "$HERE/cases/14-shell-install-mode.sh" \
+  "$HERE/cases/16-coverage-gate.sh"; do
   # shellcheck source=/dev/null
   . "$case_file"
 done


### PR DESCRIPTION
Closes #71.

## The hole

`coverage.yml.template` ran both test steps with `|| true`. The stated intent was narrow and sound — `pytest` exits **5** when it collects nothing, and an empty suite shouldn't mask the `diff-cover` verdict that is the actual gate — but `|| true` swallows exit **1** just as happily, so a PR with failing tests produced a green check.

Worse than merely not gating on failure, as the issue points out: a failing test still *executes* the lines it touches, so those lines still land in `coverage.xml`. A PR whose new code was covered only by a red test therefore **passed** the patch-coverage gate on the strength of that very test.

## The fix, and one correction to the suggested approach

Only `pytest`'s exit 5 is tolerated now; 1 (failed), 2 (interrupted), 3 (internal error) and 4 (usage error) fail the job. `vitest` has no equivalent no-tests code, so its step drops `|| true` and gains `--passWithNoTests`.

One deviation from the issue's suggested snippet, which is **buggy as written**:

```sh
pytest --cov --cov-report=xml; rc=$?     # ← does not work here
```

A `run:` step's default shell is `bash -e`. Measured:

```
$ bash -e -c '(exit 5); rc=$?; echo "reached, rc=$rc"'; echo "outer rc=$?"
outer rc=5          # the echo never ran
```

Under `-e` the shell exits at `pytest` before the assignment is reached — so exit 5 would fail the job, undoing the exact tolerance the block exists to provide. Shipped as `|| rc=$?` instead, since a command on the left of `||` is a tested command and exempt from `-e`.

This isn't hypothetical: mutating the fix to the `; rc=$?` form turns the exit-5 assertion red.

## Verification

Suite **239 → 245**, new `tests/cases/16-coverage-gate.sh`.

The assertions lift each step's **real shell body out of the shipped YAML** and run it under `bash -e` against a fake `pytest`/`vitest` with a chosen exit code. Asserting on the text ("no `|| true` present") would pass against any rewrite that reintroduced the hole by another route; running it cannot.

| Mutation | Result |
|---|---|
| Restore the original `\|\| true` on both steps | ✗ 4 red — failing pytest green, usage error swallowed, failing vitest green, no `--passWithNoTests` |
| Use the issue's `; rc=$?` form | ✗ exit 5 now fails the job — tolerance regressed |

Covered: exit 1 fails, exit 5 tolerated, exit 0 passes through to `diff-cover`, exit 4 fails rather than reading as "no tests", failing vitest fails, and the empty-suite case is handled by the flag rather than by swallowing.

`actionlint` clean over the rendered templates; `shellcheck -S info` clean over the CI file list; local self-lint passes with changes staged. Both runners are the authority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)