### PR TITLE
docs(rules): record every skip, deferral, and flag before moving on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,17 @@ versioning follows [SemVer](https://semver.org/).
   `.github/workflows/lint.yml`, both scaffold-owned and refreshed on upgrade.
 
 ### Changed
+- **New operational rule: "Record every skip, deferral, and flag before moving
+  on."** The existing "capture pre-existing issues" rule covers what a session
+  NOTICES; this covers what it DECIDES — a skipped test, a check that no-op'd
+  because its tool was absent, an unanswered question, a workaround taken "for
+  now", scope deliberately not taken. Each lands somewhere durable at the moment
+  it happens, with why and what would unblock it, because chat is not durable and
+  a PR description only counts if the item also exists outside it.
+
+  Applied to itself immediately: the four items this session deferred are filed
+  as [#82], [#83], [#84] and [#85] rather than left in PR bodies.
+
 - **The pre-commit hook distinguishes *untracking* a pattern file from
   *deleting* it ([#65]).** A staged `.forbidden-patterns/*.txt` deletion used
   to hard-fail unconditionally, but `git rm --cached` (untrack, keep the file
@@ -227,6 +238,10 @@ versioning follows [SemVer](https://semver.org/).
 [#72]: https://github.com/Sting25/ai-coding-rules-scaffold/issues/72
 [#73]: https://github.com/Sting25/ai-coding-rules-scaffold/issues/73
 [#76]: https://github.com/Sting25/ai-coding-rules-scaffold/issues/76
+[#82]: https://github.com/Sting25/ai-coding-rules-scaffold/issues/82
+[#83]: https://github.com/Sting25/ai-coding-rules-scaffold/issues/83
+[#84]: https://github.com/Sting25/ai-coding-rules-scaffold/issues/84
+[#85]: https://github.com/Sting25/ai-coding-rules-scaffold/issues/85
 
 ## [v0.11.0] — 2026-07-19
 

--- a/operational-rules.md
+++ b/operational-rules.md
@@ -286,6 +286,22 @@ _Anchor:_ a session noticed a pre-existing lint finding, labeled it
 "out of scope," and moved on; with nothing tracking it, it was
 forgotten until it resurfaced later as a failure.
 
+### Record every skip, deferral, and flag before moving on
+
+The complement to the rule above: that one covers what you NOTICE,
+this one covers what you DECIDE. A skipped test, a check that
+no-op'd because its tool was absent, a question left unanswered, a
+workaround taken "for now", scope deliberately not taken — each
+lands somewhere durable AT THE MOMENT it happens: an issue, a
+tracked fix-list, a TODO with an owner. Record why it was skipped
+and what would unblock it; a bare title is not actionable later.
+Chat is not durable — the transcript scrolls away and the next
+session starts from the code, not from what was said. A PR
+description is only durable if the item also exists outside it.
+_Anchor:_ a harness printed "skipped (tool not installed)" on every
+runner for months; the check it guarded had never once executed,
+and nothing recorded that it wasn't running.
+
 ### Surface uncertainty rather than guessing
 
 When the agent doesn't have enough context to make a decision


### PR DESCRIPTION
Adds one rule to `operational-rules.md`, and applies it to this session immediately.

## The gap

`operational-rules.md` already has **"Capture pre-existing issues; never silently drop them"** — but that rule covers what a session *notices in passing*. Nothing covered what a session *itself decides*:

- a skipped test
- a check that no-op'd because its tool wasn't installed
- a question asked and never answered
- a workaround accepted "for now"
- scope deliberately not taken

Those evaporate when the session ends.

## The rule

Each lands somewhere durable **at the moment it happens** — an issue, a tracked fix-list, a TODO with an owner — recording *why* it was skipped and *what would unblock it*, because a bare title isn't actionable later.

It names the two near-misses explicitly, since both feel like compliance:

- **Chat is not durable.** The transcript scrolls away, and the next session starts from the code, not from what was said.
- **A PR description is only durable if the item also exists outside it.** This one bit this session directly — three of the four items below were sitting in PR bodies, which is exactly where they'd have died.

The anchor is the sharpest form of the failure: a harness printing `skipped (tool not installed)` on every runner for months, guarding a check that had never once executed, with nothing recording that it wasn't running.

## Applied to itself

Not filed as intent — the four items this session deferred are now issues:

| Issue | Item |
|---|---|
| #82 | `README`/`CHANGELOG`/`RECOMMENDATIONS` fail the shipped prettier config (deferred in #80) |
| #83 | Nothing lints JS — why `eslint.config.js.template`'s own `import-x/order` violation survived unnoticed |
| #84 | `install.sh` at 497/500 lines; next change needs a module extraction, and the new file must join `package.json` `files` or `cases/11` fails closed |
| #85 | Verify the `cases/17` eslint syntax check isn't skipping on both runners |

**#85 is already answered.** The completed `test.yml` matrix shows `✓ eslint.config.js.template is syntactically valid ESM` on *both* ubuntu and macos — the skip branch fires on neither. Evidence posted on the issue and its scope reduced to the remaining judgement call: whether to harden the skip branch so a future runner-image change can't disarm the check silently. That is the rule working in the direction that matters — it turned a vague worry into either a closed question or a scoped one.

## Note

`operational-rules.md` is symlinked into `~/.claude/`, so this rule loads in every session on this machine, not just this repo. Text-only change; it passes the `self-lint.yml` prettier gate added in #80.

🤖 Generated with [Claude Code](https://claude.com/claude-code)