### PR TITLE
chore(install): extract the post-install toolchain check into install-verify.sh (#84)

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -19,4 +19,4 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
-      - run: shellcheck -S info install.sh install-lib.sh uninstall.sh scripts/dev-setup.sh tests/run.sh tests/lib/common.sh tests/cases/*.sh githooks/pre-commit.template githooks/lib/check-size.template githooks/lib/check-patterns.template githooks/lib/check-filenames.template githooks/lib/check-secrets.template githooks/lib/check-hygiene.template githooks/lib/ci-changed-files.template githooks/lib/agent-precheck.template githooks/commit-msg.template
+      - run: shellcheck -S info install.sh install-lib.sh install-verify.sh uninstall.sh scripts/dev-setup.sh tests/run.sh tests/lib/common.sh tests/cases/*.sh githooks/pre-commit.template githooks/lib/check-size.template githooks/lib/check-patterns.template githooks/lib/check-filenames.template githooks/lib/check-secrets.template githooks/lib/check-hygiene.template githooks/lib/ci-changed-files.template githooks/lib/agent-precheck.template githooks/commit-msg.template

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,26 @@ versioning follows [SemVer](https://semver.org/).
   `.github/workflows/lint.yml`, both scaffold-owned and refreshed on upgrade.
 
 ### Changed
+- **`install.sh`'s post-install toolchain check moved to `install-verify.sh`
+  ([#84]).** `install.sh` had reached 497 lines against the scaffold's own
+  500-line module-size cap — a cap it enforces on every project it installs
+  into, so the installer has to obey it too. The next change to that file would
+  have had to either shrink something or weaken the check, and weakening a
+  guardrail to fit is the one move this repo's rules rule out.
+
+  The extracted module is the whole post-install toolchain step
+  (`js_install_cmd`, `py_install_cmd`, `offer`, and the `--no-verify`-gated
+  body), now behind a single `run_toolchain_verify` call. It is SOURCED, not
+  executed, on exactly the same contract as `install-lib.sh`: it runs in
+  `install.sh`'s shell with its globals (`MODE`, `VERIFY`, `NO_INSTALL`) and its
+  `set -euo pipefail`. Behavior is unchanged; `install.sh` drops to 419 lines.
+
+  `tests/cases/11-npm-bundle.sh` derives its required-file list by grepping
+  `install.sh` for `$SCAFFOLD_DIR/...` paths, so the new module became a
+  required npm-bundle entry the moment it was sourced — `package.json` `files`
+  is updated to match, and `shellcheck.yml`'s explicit file list too, since that
+  list names root scripts individually rather than globbing.
+
 - **New operational rule: "Record every skip, deferral, and flag before moving
   on."** The existing "capture pre-existing issues" rule covers what a session
   NOTICES; this covers what it DECIDES — a skipped test, a check that no-op'd

--- a/install-verify.sh
+++ b/install-verify.sh
@@ -1,0 +1,111 @@
+# shellcheck shell=bash
+# install-verify.sh — the post-install toolchain check.
+#
+# The scaffold ships CONFIGS and ENFORCEMENT; the actual tools
+# (ruff/eslint/tsc/prettier/test runner/shellcheck) are project dependencies.
+# This module detects what is missing and OFFERS to install it.
+#
+# SOURCED (not exec'd) by install.sh, exactly like install-lib.sh, so it runs in
+# that shell with its globals (MODE, VERIFY, NO_INSTALL) and its `set -euo
+# pipefail`. It was extracted from install.sh because that file had reached 497
+# of the scaffold's own 500-line module-size cap (issue #84) — the cap is
+# dogfooded, so the installer has to obey it like every other module.
+#
+# Defaults mirror install-lib.sh's `: "${FORCE:=0}"` so this file still behaves
+# if it is ever sourced without install.sh having set the globals first.
+: "${MODE:=both}"
+: "${VERIFY:=1}"
+: "${NO_INSTALL:=0}"
+
+# Set by run_toolchain_verify, read by offer. Deliberately a global, not a
+# local: offer is a sibling function, so dynamic scope is what carries it.
+CAN_AUTORUN=0
+
+# Detect the project's package manager from lockfiles / available binaries.
+js_install_cmd() {
+  if [ -f pnpm-lock.yaml ] && command -v pnpm >/dev/null 2>&1; then echo "pnpm add -D"
+  elif [ -f yarn.lock ] && command -v yarn >/dev/null 2>&1; then echo "yarn add -D"
+  else echo "npm i -D"; fi
+}
+py_install_cmd() {
+  if { [ -f uv.lock ] || grep -qs '\[tool.uv\]' pyproject.toml 2>/dev/null; } && command -v uv >/dev/null 2>&1; then
+    echo "uv add --dev"
+  else echo "pip install"; fi
+}
+
+# offer <label> <presence-test-command> <install-base> <packages>
+# Prints ✓ when present; otherwise offers to install (auto-run only if safe).
+offer() {
+  local label=$1 testcmd=$2 base=$3 pkgs=$4 reply
+  if eval "$testcmd" >/dev/null 2>&1; then
+    echo "  ✓ $label installed"
+    return
+  fi
+  if [ "$CAN_AUTORUN" -eq 1 ]; then
+    printf "  ? %s not installed — install now with '%s %s'? [y/N] " "$label" "$base" "$pkgs"
+    read -r reply || reply=""
+    case "$reply" in
+      [yY]|[yY][eE][sS])
+        # shellcheck disable=SC2086  # word-split the package list deliberately
+        if $base $pkgs; then echo "  ✓ $label installed"; else echo "  ✗ $label install failed — run: $base $pkgs"; fi ;;
+      *) echo "  - skipped — run: $base $pkgs" ;;
+    esac
+  else
+    echo "  ! $label not installed — run: $base $pkgs"
+  fi
+}
+
+# run_toolchain_verify — the whole post-install check, called once by install.sh
+# after the "Done" line. Auto-running a package manager only happens when SAFE:
+# interactive TTY, not --no-verify, not in CI, and --no-install not set.
+# Otherwise it just prints the command (the scaffold's prior, non-mutating
+# behavior) so CI and piped/scripted runs never install.
+run_toolchain_verify() {
+  CAN_AUTORUN=0
+  if [ "$VERIFY" -eq 1 ] && [ "$NO_INSTALL" -eq 0 ] && [ -t 0 ] && [ -z "${CI:-}" ]; then
+    CAN_AUTORUN=1
+  fi
+
+  if [ "$VERIFY" -eq 1 ]; then
+    echo ""
+    echo "Checking toolchain (the scaffold configures these; you supply the binaries):"
+    case "$MODE" in
+      python|both)
+        PYI=$(py_install_cmd)
+        offer "ruff" "command -v ruff" "$PYI" "ruff"
+        # ruff present: also confirm the config actually loads (2+ = config error).
+        if command -v ruff >/dev/null 2>&1; then
+          ruff_exit=0; ruff check --quiet . >/dev/null 2>&1 || ruff_exit=$?
+          [ "$ruff_exit" -ge 2 ] && echo "  ✗ ruff config errored (exit $ruff_exit) — check ruff.toml"
+        fi
+        offer "pytest + coverage" "command -v pytest" "$PYI" "pytest pytest-cov"
+        ;;
+    esac
+    case "$MODE" in
+      frontend|both)
+        JSI=$(js_install_cmd)
+        offer "eslint" "npx --no-install eslint --version" "$JSI" "eslint @eslint/js typescript-eslint eslint-plugin-import-x eslint-plugin-unused-imports"
+        offer "typescript (tsc)" "npx --no-install tsc --version" "$JSI" "typescript"
+        offer "prettier" "npx --no-install prettier --version" "$JSI" "prettier"
+        offer "vitest" "npx --no-install vitest --version" "$JSI" "vitest @vitest/coverage-v8"
+        # The 'frontend' CI job loads eslint.config.js (and its plugins) from the
+        # lockfile. If you skip the eslint prompt above, that job fails with an
+        # actionable error until you install the deps AND commit the lockfile.
+        echo "  → commit package-lock.json after installing eslint deps, or CI's frontend job will fail."
+        ;;
+    esac
+    case "$MODE" in
+      shell)
+        # Print-only, never an auto-install offer. `offer` runs a package manager,
+        # and shellcheck has no single canonical one across platforms
+        # (brew/apt/dnf/cargo/pkg all differ) — unlike ruff (pip) and eslint (npm),
+        # where the manifest we just detected names the installer unambiguously.
+        if command -v shellcheck >/dev/null 2>&1; then
+          echo "  ✓ shellcheck installed"
+        else
+          echo "  ! shellcheck not installed — see https://www.shellcheck.net (brew install shellcheck / apt install shellcheck)"
+        fi
+        ;;
+    esac
+  fi
+}

--- a/install.sh
+++ b/install.sh
@@ -397,92 +397,14 @@ echo ""
 echo "Done (mode: $MODE)."
 
 # Post-install toolchain check — the scaffold ships CONFIGS and ENFORCEMENT, but
-# the actual tools (ruff/eslint/tsc/prettier/test runner) are project deps. This
-# step detects what's missing and OFFERS to install it. Auto-running a package
-# manager only happens when SAFE: interactive TTY, not --no-verify, not in CI,
-# and --no-install not set. Otherwise it just prints the command (the scaffold's
-# prior, non-mutating behavior) so CI and piped/scripted runs never install.
-CAN_AUTORUN=0
-if [ "$VERIFY" -eq 1 ] && [ "$NO_INSTALL" -eq 0 ] && [ -t 0 ] && [ -z "${CI:-}" ]; then
-  CAN_AUTORUN=1
-fi
-
-# Detect the project's package manager from lockfiles / available binaries.
-js_install_cmd() {
-  if [ -f pnpm-lock.yaml ] && command -v pnpm >/dev/null 2>&1; then echo "pnpm add -D"
-  elif [ -f yarn.lock ] && command -v yarn >/dev/null 2>&1; then echo "yarn add -D"
-  else echo "npm i -D"; fi
-}
-py_install_cmd() {
-  if { [ -f uv.lock ] || grep -qs '\[tool.uv\]' pyproject.toml 2>/dev/null; } && command -v uv >/dev/null 2>&1; then
-    echo "uv add --dev"
-  else echo "pip install"; fi
-}
-
-# offer <label> <presence-test-command> <install-base> <packages>
-# Prints ✓ when present; otherwise offers to install (auto-run only if safe).
-offer() {
-  local label=$1 testcmd=$2 base=$3 pkgs=$4 reply
-  if eval "$testcmd" >/dev/null 2>&1; then
-    echo "  ✓ $label installed"
-    return
-  fi
-  if [ "$CAN_AUTORUN" -eq 1 ]; then
-    printf "  ? %s not installed — install now with '%s %s'? [y/N] " "$label" "$base" "$pkgs"
-    read -r reply || reply=""
-    case "$reply" in
-      [yY]|[yY][eE][sS])
-        # shellcheck disable=SC2086  # word-split the package list deliberately
-        if $base $pkgs; then echo "  ✓ $label installed"; else echo "  ✗ $label install failed — run: $base $pkgs"; fi ;;
-      *) echo "  - skipped — run: $base $pkgs" ;;
-    esac
-  else
-    echo "  ! $label not installed — run: $base $pkgs"
-  fi
-}
-
-if [ "$VERIFY" -eq 1 ]; then
-  echo ""
-  echo "Checking toolchain (the scaffold configures these; you supply the binaries):"
-  case "$MODE" in
-    python|both)
-      PYI=$(py_install_cmd)
-      offer "ruff" "command -v ruff" "$PYI" "ruff"
-      # ruff present: also confirm the config actually loads (2+ = config error).
-      if command -v ruff >/dev/null 2>&1; then
-        ruff_exit=0; ruff check --quiet . >/dev/null 2>&1 || ruff_exit=$?
-        [ "$ruff_exit" -ge 2 ] && echo "  ✗ ruff config errored (exit $ruff_exit) — check ruff.toml"
-      fi
-      offer "pytest + coverage" "command -v pytest" "$PYI" "pytest pytest-cov"
-      ;;
-  esac
-  case "$MODE" in
-    frontend|both)
-      JSI=$(js_install_cmd)
-      offer "eslint" "npx --no-install eslint --version" "$JSI" "eslint @eslint/js typescript-eslint eslint-plugin-import-x eslint-plugin-unused-imports"
-      offer "typescript (tsc)" "npx --no-install tsc --version" "$JSI" "typescript"
-      offer "prettier" "npx --no-install prettier --version" "$JSI" "prettier"
-      offer "vitest" "npx --no-install vitest --version" "$JSI" "vitest @vitest/coverage-v8"
-      # The 'frontend' CI job loads eslint.config.js (and its plugins) from the
-      # lockfile. If you skip the eslint prompt above, that job fails with an
-      # actionable error until you install the deps AND commit the lockfile.
-      echo "  → commit package-lock.json after installing eslint deps, or CI's frontend job will fail."
-      ;;
-  esac
-  case "$MODE" in
-    shell)
-      # Print-only, never an auto-install offer. `offer` runs a package manager,
-      # and shellcheck has no single canonical one across platforms
-      # (brew/apt/dnf/cargo/pkg all differ) — unlike ruff (pip) and eslint (npm),
-      # where the manifest we just detected names the installer unambiguously.
-      if command -v shellcheck >/dev/null 2>&1; then
-        echo "  ✓ shellcheck installed"
-      else
-        echo "  ! shellcheck not installed — see https://www.shellcheck.net (brew install shellcheck / apt install shellcheck)"
-      fi
-      ;;
-  esac
-fi
+# the actual tools (ruff/eslint/tsc/prettier/test runner) are project deps. That
+# whole step lives in install-verify.sh: it was extracted from this file once
+# this file hit 497 of the scaffold's own 500-line module cap (issue #84). Same
+# SOURCED-not-exec'd contract as install-lib.sh above, so it runs in this shell
+# with MODE / VERIFY / NO_INSTALL and `set -euo pipefail` already in effect.
+# shellcheck source=install-verify.sh
+. "$SCAFFOLD_DIR/install-verify.sh"
+run_toolchain_verify
 
 echo ""
 echo "Next:"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "files": [
     "install.sh",
     "install-lib.sh",
+    "install-verify.sh",
     "uninstall.sh",
     "bin/",
     "githooks/",


### PR DESCRIPTION
Closes #84.

## Why

`install.sh` was at **497 of 500** lines against the scaffold's own module-size
cap — the same cap it installs into every consumer project. With three lines of
headroom, the next change to that file would have had to shrink something or
weaken the check. Weakening a guardrail to fit is precisely what
`operational-rules.md` rules out, so the file gets a module extraction instead.

## What

The whole post-install toolchain step moves to a new `install-verify.sh`:
`js_install_cmd`, `py_install_cmd`, `offer`, and the `--no-verify`-gated body,
now behind one `run_toolchain_verify` call.

Same **sourced, not exec'd** contract as `install-lib.sh` — it runs in
`install.sh`'s shell with its globals (`MODE`, `VERIFY`, `NO_INSTALL`) and its
`set -euo pipefail` already in effect, and it carries the same
`: "${VAR:=default}"` standalone-safety defaults `install-lib.sh` uses.

`install.sh`: **497 → 419** lines. `install-verify.sh`: 111.

## Packaging

`tests/cases/11-npm-bundle.sh` derives its required-file list by grepping
`install.sh` for `$SCAFFOLD_DIR/...` paths, so the new module became a required
npm-bundle entry the moment it was sourced. Updated to match:

- `package.json` `files` — or `cases/11` fails closed.
- `.github/workflows/shellcheck.yml` — that list names root scripts
  individually rather than globbing, so a new root script gets no shellcheck
  coverage unless it is added explicitly.

The Homebrew formula needs no change: it globs the whole tree rather than
enumerating files.

## Verification

- `./tests/run.sh` → **260 passed, 0 failed** (unchanged from baseline).
- Scaffold self-lint run over the **staged index blobs** (check-size,
  check-patterns, check-filenames, check-secrets, check-hygiene) → clean.
- `shellcheck -S info install.sh install-lib.sh install-verify.sh` → clean
  locally; CI's shellcheck is the authority.
- Behavior is a pure move — no assertion changed, so no new test accompanies
  it; `cases/09` already exercises this code path through `install.sh`'s stdout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)