### PR TITLE
feat: scaffold-doctor — report guardrails that are installed but not running

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -19,4 +19,4 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
-      - run: shellcheck -S info install.sh install-lib.sh install-verify.sh uninstall.sh scripts/dev-setup.sh tests/run.sh tests/lib/common.sh tests/cases/*.sh githooks/pre-commit.template githooks/lib/check-size.template githooks/lib/check-patterns.template githooks/lib/check-filenames.template githooks/lib/check-secrets.template githooks/lib/check-hygiene.template githooks/lib/ci-changed-files.template githooks/lib/agent-precheck.template githooks/commit-msg.template
+      - run: shellcheck -S info install.sh install-lib.sh install-verify.sh scaffold-doctor.sh uninstall.sh scripts/dev-setup.sh tests/run.sh tests/lib/common.sh tests/cases/*.sh githooks/pre-commit.template githooks/lib/check-size.template githooks/lib/check-patterns.template githooks/lib/check-filenames.template githooks/lib/check-secrets.template githooks/lib/check-hygiene.template githooks/lib/ci-changed-files.template githooks/lib/agent-precheck.template githooks/commit-msg.template

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ versioning follows [SemVer](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- **`scaffold-doctor.sh` — checks whether an installed scaffold is armed, not
+  just present.** `install.sh` reports what it *wrote*; that's a different
+  question from whether the guardrails it wrote actually *run*, and the gap
+  between the two is where this scaffold's worst bugs have lived: issue #76
+  was a `grep -r` that silently scanned one file instead of a tree, and issue
+  #72 was a check whose call site got reset on upgrade while the check script
+  stayed on disk as decoration. Both were present and neither was running,
+  and nothing said so.
+
+  The doctor never reports "file exists." For each guardrail it reports
+  whether the mechanism that makes it execute is in place, as `✓` armed, `✗`
+  gap (installed but inert — a commit that should be blocked isn't), or `!`
+  note (a deliberate off-switch, or an opt-in surface not opted into; notes
+  never affect the exit status). It covers `core.hooksPath` wiring — the
+  single highest-value check, since `install.sh` deliberately leaves a
+  foreign hooksPath such as Husky's `.husky` alone and only warns, so
+  "installed but never wired" is a state `install.sh` itself can leave
+  behind — the hook entry point's executable bit, the five shipped
+  `lib/check-*` scripts, `.forbidden-patterns/` and `secrets.txt` (measured
+  on a real fixture: once `secrets.txt` is absent, staging a genuine
+  `AKIA…` AWS access key ID and running the hook exits 0 with no output at
+  all), the opt-in `check-gitleaks`/`agent-precheck` surfaces and their
+  external tool dependencies, `.githooks/local.d/` project-local checks
+  (where the executable bit is the on/off switch, so a disabled entry is a
+  note, never a gap), and `.scaffold.toml` overrides going silently ignored
+  when `lib/scaffold-config` is missing.
+
+  Exit status: `0` with no gaps, `1` with at least one, `2` on usage error or
+  outside a git repository. Run it directly (`./scaffold-doctor.sh`, from
+  anywhere inside the working tree) or via `npx ai-coding-rules-scaffold
+  doctor`; `--quiet` prints only gaps plus the summary line, for CI or
+  pre-flight use.
+
 - **Shell-only install mode (`install.sh --shell`) ([#65]).** For projects with
   no Python or TS/JS manifest — plain bash/sh, `shellcheck`-linted — installs
   the git hooks, guard checks, and the shell-relevant plus language-agnostic

--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ Scripts (stay in the scaffold repo):
 |---|---|
 | `install.sh` | Copy templates into your project, wire `core.hooksPath`, detect/offer the toolchain |
 | `uninstall.sh` | Remove unmodified scaffold files, unwire the hook |
+| `scaffold-doctor.sh` | Check whether an installed project's guardrails are armed, not just present — see [Check whether it's armed](#check-whether-its-armed) |
 
 ## AI agent integration
 
@@ -478,6 +479,33 @@ git add some_module.py
 git commit -m "should be rejected"
 # → hook prints: ✗ some_module.py: Use structlog (or the project's logger), not print()
 ```
+
+## Check whether it's armed
+
+`install.sh` reports what it *wrote*. Whether the guardrails actually *run* is
+a different question, and the gap between the two is where this scaffold's
+worst bugs have lived — a foreign `core.hooksPath` (Husky, lefthook, …) that
+`install.sh` deliberately leaves alone and only warns about, a hook file
+missing its executable bit that git skips without a word, a `secrets.txt`
+that went missing and left `check-secrets` exiting 0 silently. Measured on a
+real fixture: with that file gone, a genuine `AKIA…` AWS access key commits
+clean, with no output at all.
+
+`scaffold-doctor.sh` checks each guardrail's arming mechanism, not just its
+presence on disk:
+
+```sh
+./scaffold-doctor.sh            # from anywhere inside the working tree
+./scaffold-doctor.sh --quiet    # gaps + summary only — for CI / pre-flight use
+npx ai-coding-rules-scaffold doctor
+```
+
+Each line is `✓` armed, `✗` gap (installed but inert — a commit that should
+be blocked isn't), or `!` note (a deliberate off-switch, or an opt-in surface
+never opted into — a project that never installed gitleaks is healthy, not
+broken). Notes never affect the exit status. Exit `0` means no gaps, `1`
+means at least one guardrail is installed but not running, `2` means a usage
+error or "not a git repository".
 
 ## Customize per project
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -2,10 +2,12 @@
 'use strict';
 
 // Thin wrapper so `npx ai-coding-rules-scaffold` runs the same install.sh the
-// git-clone path uses. The installer is pure bash and reads its templates from
-// its own directory ($SCAFFOLD_DIR), writing only into the caller's cwd — so we
-// exec it from the package root (read-only node_modules location) with cwd left
-// at the user's project. Args pass straight through (--both, --frontend, etc.).
+// git-clone path uses (and, for `doctor`, scaffold-doctor.sh alongside it).
+// Both are pure bash and read their own files relative to $SCAFFOLD_DIR,
+// writing/reading only the caller's cwd — so we exec from the package root
+// (read-only node_modules location) with cwd left at the user's project. Args
+// pass straight through (--both, --frontend, --quiet, etc.) with no parsing
+// beyond picking which script to run.
 //
 // No npm dependencies on purpose: this uses only Node built-ins, so the package
 // installs instantly and there is no lockfile / supply-chain surface to audit.
@@ -15,11 +17,24 @@ const path = require('path');
 const fs = require('fs');
 
 const pkgRoot = path.resolve(__dirname, '..');
-const installer = path.join(pkgRoot, 'install.sh');
 
-if (!fs.existsSync(installer)) {
+// `doctor` is the one subcommand this CLI dispatches on; everything else
+// passes straight through to install.sh unexamined (no allowlist, no flag
+// parsing here — see below). It would be more consistent for install.sh to
+// grow a `--doctor` flag and keep this file a pure passthrough, but
+// install.sh is already pinned at its 500-line module cap (issue #84), so a
+// second script gets a second entry point instead of a bigger install.sh.
+const args = process.argv.slice(2);
+const isDoctor = args[0] === 'doctor';
+const script = isDoctor ? 'scaffold-doctor.sh' : 'install.sh';
+const scriptArgs = isDoctor ? args.slice(1) : args;
+const target = path.join(pkgRoot, script);
+
+if (!fs.existsSync(target)) {
   process.stderr.write(
-    'ai-coding-rules-scaffold: install.sh is missing from the package at ' +
+    'ai-coding-rules-scaffold: ' +
+      script +
+      ' is missing from the package at ' +
       pkgRoot +
       '.\nThis is a packaging bug — please report it at ' +
       'https://github.com/Sting25/ai-coding-rules-scaffold/issues\n'
@@ -27,7 +42,7 @@ if (!fs.existsSync(installer)) {
   process.exit(1);
 }
 
-const result = spawnSync('bash', [installer, ...process.argv.slice(2)], {
+const result = spawnSync('bash', [target, ...scriptArgs], {
   stdio: 'inherit',
   cwd: process.cwd(),
 });
@@ -36,8 +51,8 @@ if (result.error) {
   if (result.error.code === 'ENOENT') {
     process.stderr.write(
       'ai-coding-rules-scaffold: `bash` was not found on PATH.\n' +
-        'This installer needs bash — preinstalled on macOS/Linux; on Windows ' +
-        'run it from Git Bash or WSL.\n'
+        'This needs bash — preinstalled on macOS/Linux; on Windows run it ' +
+        'from Git Bash or WSL.\n'
     );
   } else {
     process.stderr.write('ai-coding-rules-scaffold: ' + result.error.message + '\n');
@@ -45,6 +60,6 @@ if (result.error) {
   process.exit(1);
 }
 
-// Propagate the installer's exit code (0 ok, non-zero on failure) so CI and
-// scripted callers see the real status.
+// Propagate the child script's exit code (0 ok, non-zero on failure) so CI
+// and scripted callers see the real status.
 process.exit(result.status === null ? 1 : result.status);

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "install-lib.sh",
     "install-verify.sh",
     "uninstall.sh",
+    "scaffold-doctor.sh",
     "bin/",
     "githooks/",
     "forbidden-patterns/",

--- a/scaffold-doctor.sh
+++ b/scaffold-doctor.sh
@@ -1,0 +1,284 @@
+#!/usr/bin/env bash
+# scaffold-doctor.sh — is this project's scaffold ARMED, or merely installed?
+#
+# install.sh reports what it WROTE. That is a different question from whether
+# the guardrails actually RUN, and the gap between the two is where this
+# scaffold's worst bugs have lived: issue #76 was a `grep -r` that silently
+# scanned one file instead of a tree, and issue #72 was a check whose call site
+# got reset on upgrade while the check script stayed on disk as decoration.
+# Both were PRESENT and both were NOT RUNNING, and nothing said so.
+#
+# So this script never reports "file exists". It reports, for each guardrail,
+# whether the thing that makes it execute is in place:
+#
+#   ✓  armed        — it runs, and it has the data it needs to do work
+#   ✗  gap          — installed but inert; a commit that should be blocked isn't
+#   !  note         — deliberate off-switch, or optional surface not opted into
+#
+# Exit status: 0 when there are no gaps, 1 when there are, 2 on usage error.
+# Notes never affect the exit status — a project that never opted into gitleaks
+# is healthy, and a doctor that cried wolf about it would stop being read.
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+usage: scaffold-doctor.sh [--quiet]
+
+Checks that an installed project's scaffold guardrails are armed, not just
+present. Run it from anywhere inside the project's git working tree.
+
+  --quiet   print only gaps and the summary line
+  -h        this message
+
+Exit: 0 = no gaps, 1 = at least one guardrail installed but not running,
+      2 = usage error / not a git repository.
+USAGE
+}
+
+QUIET=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --quiet) QUIET=1 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "scaffold-doctor: unknown argument '$1'" >&2; usage >&2; exit 2 ;;
+  esac
+  shift
+done
+
+# The shipped checks read their config by BARE RELATIVE PATH
+# (".forbidden-patterns/secrets.txt", ".scaffold.toml"), which works because git
+# invokes hooks from the top of the working tree. A doctor run from a
+# subdirectory has to reproduce that or it would report phantom gaps.
+ROOT=$(git rev-parse --show-toplevel 2>/dev/null || true)
+if [ -z "$ROOT" ]; then
+  echo "✗ not a git repository — run scaffold-doctor from inside the project" >&2
+  exit 2
+fi
+cd "$ROOT"
+
+GAPS=0
+NOTES=0
+OKS=0
+SECTION=""
+
+section() { SECTION=$1; [ "$QUIET" -eq 1 ] || printf '\n%s\n' "$1"; }
+ok()   { OKS=$((OKS + 1));   [ "$QUIET" -eq 1 ] || echo "  ✓ $1"; }
+note() { NOTES=$((NOTES + 1)); [ "$QUIET" -eq 1 ] || echo "  ! $1"; }
+# gap <what-is-inert> [how-to-fix] — the fix line is not decoration: a report
+# that tells you something is broken without telling you the command that arms
+# it gets acknowledged and not acted on.
+gap() {
+  GAPS=$((GAPS + 1))
+  if [ "$QUIET" -eq 1 ]; then echo "  ✗ [$SECTION] $1"; else echo "  ✗ $1"; fi
+  if [ $# -gt 1 ]; then echo "      fix: $2"; fi
+}
+
+[ "$QUIET" -eq 1 ] || echo "scaffold-doctor — $ROOT"
+
+# --- 1. wiring --------------------------------------------------------------
+# The single highest-value check in this file. Everything else can be perfect
+# and none of it runs if git is not pointed at .githooks. install.sh sets
+# core.hooksPath only when it is unset or already .githooks; when a project
+# already uses Husky (or anything else) install.sh writes .githooks/ anyway and
+# only WARNS, so "installed but never wired" is a state install.sh can leave
+# behind by design.
+section "wiring"
+HOOKS_PATH=$(git config --get core.hooksPath || true)
+# Compare RESOLVED directories, not strings. git accepts `.githooks`,
+# `./.githooks`, `.githooks/` and an absolute path interchangeably, and runs the
+# hook in every one of those spellings — measured. A string equality test calls
+# three working configurations broken, and a hard gap on a healthy project is
+# worse than a missed note: it teaches the reader to distrust the report.
+# `cd` failing (a hooksPath that points nowhere) leaves the value empty, which
+# correctly falls through to the gap branch.
+HOOKS_ABS=""
+GITHOOKS_ABS=$(cd .githooks 2>/dev/null && pwd -P) || true
+if [ -n "$HOOKS_PATH" ]; then
+  HOOKS_ABS=$(cd "$HOOKS_PATH" 2>/dev/null && pwd -P) || true
+fi
+if [ -n "$HOOKS_ABS" ] && [ -n "$GITHOOKS_ABS" ] && [ "$HOOKS_ABS" = "$GITHOOKS_ABS" ]; then
+  ok "core.hooksPath = $HOOKS_PATH"
+elif [ -z "$HOOKS_PATH" ]; then
+  gap "core.hooksPath is unset — git runs .git/hooks, so nothing in .githooks/ executes" \
+      "git config core.hooksPath .githooks"
+else
+  gap "core.hooksPath = '$HOOKS_PATH' — .githooks/ is on disk but git never runs it" \
+      "git config core.hooksPath .githooks   (or wire the scaffold hook into '$HOOKS_PATH')"
+fi
+
+# --- 2. hook entry point ----------------------------------------------------
+# git silently ignores a hook file without the executable bit. No error, no
+# warning, no commit blocked — the exact failure mode this script exists for.
+section "hook entry point"
+if [ ! -f .githooks/pre-commit ]; then
+  gap ".githooks/pre-commit is missing — the scaffold is not installed here" \
+      "run the scaffold's install.sh from this directory"
+elif [ ! -x .githooks/pre-commit ]; then
+  gap ".githooks/pre-commit is not executable — git skips it silently" \
+      "chmod +x .githooks/pre-commit"
+else
+  ok ".githooks/pre-commit present and executable"
+fi
+if [ -f .githooks/commit-msg ] && [ ! -x .githooks/commit-msg ]; then
+  gap ".githooks/commit-msg is not executable — git skips it silently" \
+      "chmod +x .githooks/commit-msg"
+fi
+
+# --- 3. the shipped checks --------------------------------------------------
+# The orchestrator calls these five unguarded, so a missing or non-executable
+# one makes the hook error out and BLOCK the commit — noisy, not silent, but
+# still broken, and worth naming precisely rather than leaving to a stack trace.
+section "shipped checks"
+for chk in check-size check-patterns check-filenames check-secrets check-hygiene; do
+  if [ ! -f ".githooks/lib/$chk" ]; then
+    gap "lib/$chk is missing — the hook calls it unguarded and every commit will error" \
+        "re-run install.sh to restore it"
+  elif [ ! -x ".githooks/lib/$chk" ]; then
+    gap "lib/$chk is not executable — every commit will error on it" "chmod +x .githooks/lib/$chk"
+  else
+    ok "lib/$chk armed"
+  fi
+done
+
+# --- 4. pattern data --------------------------------------------------------
+# check-patterns auto-discovers .forbidden-patterns/*.txt. If the directory is
+# gone the glob matches nothing, the loop body never runs, and the scanner exits
+# 0 — a full pattern scanner reporting success while scanning nothing.
+section "pattern data"
+if [ ! -d .forbidden-patterns ]; then
+  gap ".forbidden-patterns/ is missing — check-patterns scans nothing and still exits 0" \
+      "re-run install.sh to restore the pattern files"
+else
+  # secrets.txt is the non-disableable boundary. check-secrets exits 0 SILENTLY
+  # when it is absent locally (leniency for pre-install checkouts), so absence
+  # here is a live hole rather than a loud failure.
+  if [ ! -f .forbidden-patterns/secrets.txt ]; then
+    gap "secrets.txt is missing — check-secrets exits 0 silently on every local commit" \
+        "re-run install.sh to restore .forbidden-patterns/secrets.txt"
+  else
+    # Count only ACTIVE patterns: blank lines and comments carry no rule. The
+    # `(?-i)` case-sensitivity marker (issue #67) sits inside a pattern line, so
+    # it does not need stripping to be counted.
+    active=$(grep -cvE '^[[:space:]]*(#|$)' .forbidden-patterns/secrets.txt || true)
+    if [ "${active:-0}" -eq 0 ]; then
+      gap "secrets.txt has no active patterns — the secret scanner is disabled" \
+          "restore its patterns, or re-run install.sh"
+    else
+      ok "secrets.txt armed ($active active patterns)"
+    fi
+  fi
+  # Every other pattern file needs an extension mapping or check-patterns prints
+  # a warning to stderr and skips it — and hook stderr scrolls past unread.
+  for cfg in .forbidden-patterns/*.txt; do
+    [ -e "$cfg" ] || continue
+    base=$(basename "$cfg")
+    case "$base" in secrets.txt) continue ;; esac
+    hdr=$(grep -m1 -E '^#[[:space:]]*scaffold-extensions:' "$cfg" 2>/dev/null || true)
+    case "$base" in
+      backend.txt|frontend.txt|shell.txt) hdr=${hdr:-builtin} ;;
+    esac
+    if [ -z "$hdr" ]; then
+      gap "$base has no '# scaffold-extensions:' header and no built-in mapping — check-patterns skips it" \
+          "add '# scaffold-extensions: <ext> ...' as a comment line in $cfg"
+    else
+      pat=$(grep -cvE '^[[:space:]]*(#|$)' "$cfg" || true)
+      if [ "${pat:-0}" -eq 0 ]; then
+        note "$base has no active patterns — it scans its file types and matches nothing"
+      else
+        ok "$base armed ($pat active patterns)"
+      fi
+    fi
+  done
+fi
+
+# --- 5. opt-in surfaces -----------------------------------------------------
+# Both fail OPEN when their external tool is absent, but they are NOT equally
+# quiet, and the severity follows that difference rather than the symmetry:
+#
+#   check-gitleaks  prints an actionable note on every single commit and names
+#                   the CI gitleaks job as the authoritative gate. The developer
+#                   is already being told, so this is a note. Making it a gap
+#                   would mean the doctor exits 1 forever on any machine without
+#                   the binary — crying wolf about a self-announcing condition.
+#   agent-precheck  exits 0 with EMPTY output when jq is missing. Nothing,
+#                   anywhere, ever says so. That is a gap — as is losing its
+#                   executable bit, since its callers exec the path directly
+#                   and read exit 126 as "not blocked" (check-gitleaks differs:
+#                   the hook's own -x guard makes that bit a real off switch).
+#
+# Measured, not assumed: run each with PATH narrowed to /usr/bin:/bin.
+section "opt-in surfaces"
+if [ -f .githooks/lib/check-gitleaks ]; then
+  if [ ! -x .githooks/lib/check-gitleaks ]; then
+    note "lib/check-gitleaks is not executable — the hook's -x guard skips it (off switch)"
+  elif command -v gitleaks >/dev/null 2>&1; then
+    ok "lib/check-gitleaks armed (gitleaks on PATH)"
+  else
+    note "lib/check-gitleaks is installed but gitleaks is not on PATH — the local scan is a no-op (it says so on every commit; CI is the authoritative gate)"
+  fi
+else
+  note "gitleaks hook not installed (opt in with install.sh --gitleaks-hook)"
+fi
+if [ -f .githooks/lib/agent-precheck ]; then
+  if [ ! -x .githooks/lib/agent-precheck ]; then
+    # Unlike check-gitleaks, nothing guards this call with -x. Both
+    # claude-settings.json and cursor-hooks.json invoke the path DIRECTLY as a
+    # command, so a missing executable bit yields exit 126 — and the agent
+    # runtimes block only on exit 2, so 126 is allowed through. Measured: the
+    # tool call proceeds and nothing is printed anywhere.
+    gap "lib/agent-precheck is not executable — the agent runtime gets exit 126, not the exit 2 that blocks, so the tool call proceeds" \
+        "chmod +x .githooks/lib/agent-precheck"
+  elif command -v jq >/dev/null 2>&1; then
+    ok "lib/agent-precheck armed (jq on PATH)"
+  else
+    gap "lib/agent-precheck is installed but jq is not on PATH — it exits 0 on every agent edit" \
+        "install jq (brew install jq)"
+  fi
+else
+  note "agent guardrails not installed (opt in with install.sh --claude or --cursor)"
+fi
+
+# --- 6. project-local checks ------------------------------------------------
+# In local.d/ the executable bit IS the on/off switch, so a non-executable entry
+# is a deliberate state, not a defect — reported, never counted as a gap.
+section "project-local checks"
+if [ ! -d .githooks/local.d ]; then
+  note "no .githooks/local.d/ — project-local checks not in use"
+else
+  found=0
+  for lc in .githooks/local.d/*; do
+    [ -f "$lc" ] || continue
+    case "$(basename "$lc")" in README.md) continue ;; esac
+    found=$((found + 1))
+    if [ -x "$lc" ]; then ok "local.d/$(basename "$lc") armed"
+    else note "local.d/$(basename "$lc") present but not executable (that bit is the off switch)"; fi
+  done
+  [ "$found" -gt 0 ] || note ".githooks/local.d/ is empty — no project-local checks"
+fi
+
+# --- 7. per-project overrides -----------------------------------------------
+# scaffold-config fails open to empty output when it is missing, and empty
+# output means "no override" — so a .scaffold.toml full of intentional
+# overrides is silently ignored, in the direction of stricter, which is the
+# hardest kind of silence to notice.
+section "per-project overrides"
+if [ ! -f .scaffold.toml ]; then
+  note "no .scaffold.toml — every rule runs at its shipped default"
+elif [ ! -x .githooks/lib/scaffold-config ]; then
+  gap ".scaffold.toml exists but lib/scaffold-config is missing or not executable — every override in it is silently ignored" \
+      "re-run install.sh to restore .githooks/lib/scaffold-config"
+else
+  ok ".scaffold.toml readable and lib/scaffold-config armed"
+  if [ -x .githooks/lib/scaffold-audit ] && [ "$QUIET" -eq 0 ]; then
+    .githooks/lib/scaffold-audit 2>/dev/null | sed 's/^/      /' || true
+  fi
+fi
+
+# --- summary ----------------------------------------------------------------
+echo ""
+if [ "$GAPS" -eq 0 ]; then
+  echo "✓ armed: $OKS check(s) running, $NOTES note(s), 0 gaps."
+  exit 0
+fi
+echo "✗ $GAPS guardrail(s) installed but NOT running ($OKS armed, $NOTES note(s))."
+exit 1

--- a/tests/cases/11-npm-bundle.sh
+++ b/tests/cases/11-npm-bundle.sh
@@ -80,6 +80,26 @@ else
     else
       echo "  ✗ npm bundle is missing $docs_missing referenced doc(s)"; FAIL=$((FAIL + 1))
     fi
+
+    # Scripts reached through bin/cli.js's subcommand dispatch rather than
+    # through install.sh's $SCAFFOLD_DIR paths. The grep above walks install.sh
+    # only, so it cannot see `doctor`'s target — and an unbundled
+    # scaffold-doctor.sh would ship a CLI subcommand that ENOENTs for every npx
+    # user. Derived from cli.js rather than hardcoded, so a SECOND subcommand
+    # added later is covered the day it lands instead of the day it breaks.
+    cli_missing=0
+    cli_scripts=$(grep -oE "'[A-Za-z0-9_-]+\.sh'" "$SCAFFOLD_DIR/bin/cli.js" | tr -d "'" | sort -u)
+    for s in $cli_scripts; do
+      grep -qxF "$s" <<<"$PACKED" || {
+        echo "  ✗ script dispatched by bin/cli.js missing from npm bundle: $s"
+        cli_missing=$((cli_missing + 1))
+      }
+    done
+    if [ "$cli_missing" -eq 0 ]; then
+      echo "  ✓ every script bin/cli.js can dispatch to is bundled ($(grep -c . <<<"$cli_scripts") checked)"; PASS=$((PASS + 1))
+    else
+      echo "  ✗ npm bundle is missing $cli_missing CLI-dispatched script(s)"; FAIL=$((FAIL + 1))
+    fi
   else
     echo "  ✗ npm pack --dry-run failed"; sed 's/^/      /' "$C11"; FAIL=$((FAIL + 1))
   fi

--- a/tests/cases/18-doctor.sh
+++ b/tests/cases/18-doctor.sh
@@ -1,0 +1,247 @@
+# shellcheck shell=bash
+# cases/18-doctor.sh — scaffold-doctor must report guardrails that are INSTALLED
+# but NOT RUNNING. Sourced into the driver's shell, so the globals
+# (PASS/FAIL/HOOK_OUT/SCAFFOLD_DIR) are already in scope.
+#
+# Every assertion here is mutation-shaped: build a healthy install, break
+# exactly ONE arming mechanism, and require the doctor to both name it and exit
+# non-zero. A doctor that cannot go red is precisely the failure it exists to
+# catch, so "it printed something" is never the assertion.
+
+echo "cases/18 — scaffold-doctor (armed vs merely installed)"
+
+# A fresh installed project. --shell deliberately: a package.json fixture makes
+# the hook chase a JS toolchain and go red on one runner only, and that failure
+# then gets misread as a verdict on whatever was actually under test.
+doc_project() {
+  local t
+  t=$(mktemp -d)
+  ( cd "$t" && git init --quiet \
+    && echo '#!/usr/bin/env bash' >run.sh \
+    && "$SCAFFOLD_DIR/install.sh" --shell --no-verify ) >/dev/null 2>&1
+  printf '%s' "$t"
+}
+
+# Mutations that need a variable expanded at run time are shell FUNCTIONS, not
+# `bash -c '...'`: the subshell doc_case spawns inherits them, and a single-quoted
+# bash -c carrying a "$VAR" trips SC2016 under CI's `shellcheck -S info`.
+doc_hookspath_absolute()  { git config core.hooksPath "$PWD/.githooks"; }
+doc_commit_msg_nonexec()  {
+  cp "$SCAFFOLD_DIR/githooks/commit-msg.template" .githooks/commit-msg \
+    && chmod -x .githooks/commit-msg
+}
+
+# doc_case <name> <want-exit> <expect-substring> <mutation cmd...>
+# The mutation runs inside the project; `true` means "leave it healthy".
+doc_case() {
+  local name=$1 want=$2 expect=$3
+  shift 3
+  local t rc=0
+  t=$(doc_project)
+  ( cd "$t" && "$@" ) >/dev/null 2>&1 || true
+  ( cd "$t" && "$SCAFFOLD_DIR/scaffold-doctor.sh" ) >"$HOOK_OUT" 2>&1 || rc=$?
+  if [ "$rc" -eq "$want" ] && grep -qF "$expect" "$HOOK_OUT"; then
+    echo "  ✓ $name"
+    PASS=$((PASS + 1))
+  else
+    echo "  ✗ $name (exit $rc, wanted $want, or missing: $expect)"
+    sed 's/^/      /' "$HOOK_OUT"
+    FAIL=$((FAIL + 1))
+  fi
+  rm -rf "$t"
+}
+
+# (A) The healthy baseline. Without this the red cases below prove nothing —
+# a doctor that always exits 1 would pass every mutation assertion.
+doc_case "a clean install reports 0 gaps and exits 0" 0 "0 gaps" true
+
+# (B) Wiring. The highest-value check: everything else can be perfect and none
+# of it runs. install.sh LEAVES a foreign hooksPath alone by design (it only
+# warns), so "installed but never wired" is a state install.sh itself produces.
+doc_case "a foreign core.hooksPath is reported as not wired" 1 \
+  "core.hooksPath = '.husky'" git config core.hooksPath .husky
+doc_case "an unset core.hooksPath is reported as not wired" 1 \
+  "core.hooksPath is unset" git config --unset core.hooksPath
+
+# ...but git accepts several spellings of the SAME directory and honours every
+# one of them (measured: a planted AKIA key is blocked under each). Comparing
+# raw strings instead of resolved paths reported all three as gaps — a hard red
+# on a project whose guardrails demonstrably work, which is worse than a missed
+# note because it teaches the reader to stop trusting the report.
+doc_case "an absolute core.hooksPath pointing at .githooks is armed, not a gap" 0 \
+  "0 gaps" doc_hookspath_absolute
+doc_case "a ./-prefixed core.hooksPath is armed, not a gap" 0 \
+  "0 gaps" git config core.hooksPath ./.githooks
+doc_case "a trailing-slash core.hooksPath is armed, not a gap" 0 \
+  "0 gaps" git config core.hooksPath .githooks/
+
+# (C) git ignores a hook file without the executable bit — no error, no warning,
+# no commit blocked.
+doc_case "a non-executable pre-commit is reported" 1 \
+  ".githooks/pre-commit is not executable" chmod -x .githooks/pre-commit
+doc_case "a non-executable commit-msg hook is reported" 1 \
+  ".githooks/commit-msg is not executable" \
+  doc_commit_msg_nonexec
+
+# (D) Pattern data. check-secrets exits 0 SILENTLY when secrets.txt is absent
+# (leniency for pre-install checkouts), so absence is a live hole, not a loud
+# failure — measured: with secrets.txt gone, a real AKIA key commits clean.
+doc_case "a missing secrets.txt is reported" 1 \
+  "secrets.txt is missing" rm -f .forbidden-patterns/secrets.txt
+doc_case "a secrets.txt gutted to comments is reported" 1 \
+  "no active patterns" bash -c 'printf "# emptied\n" >.forbidden-patterns/secrets.txt'
+
+# check-patterns auto-discovers .forbidden-patterns/*.txt; with the directory
+# gone the glob matches nothing, the loop body never runs, and the scanner
+# exits 0 — a pattern scanner reporting success while scanning nothing.
+doc_case "a missing .forbidden-patterns/ directory is reported" 1 \
+  ".forbidden-patterns/ is missing" rm -rf .forbidden-patterns
+
+# A pattern file with no extension mapping is skipped with a warning on hook
+# stderr, which scrolls past unread.
+doc_case "a pattern file with no scaffold-extensions header is reported" 1 \
+  "no '# scaffold-extensions:' header" \
+  bash -c 'printf "forbidden\tno header here\n" >.forbidden-patterns/custom.txt'
+
+# (E) Overrides. scaffold-config fails open to EMPTY output when missing, and
+# empty output means "no override" — so a .scaffold.toml full of intentional
+# overrides is silently ignored.
+doc_case "a .scaffold.toml with no scaffold-config helper is reported" 1 \
+  "silently ignored" rm -f .githooks/lib/scaffold-config
+
+# (F) In local.d/ the executable bit IS the on/off switch, so a non-executable
+# entry is a deliberate state. It must be REPORTED but must NOT count as a gap —
+# a doctor that cries wolf about intentional configuration stops being read.
+doc_case "a non-executable local.d check is a note, not a gap" 0 \
+  "off switch" \
+  bash -c 'printf "#!/bin/sh\nexit 0\n" >.githooks/local.d/mine.sh && chmod -x .githooks/local.d/mine.sh'
+doc_case "an executable local.d check is reported armed" 0 \
+  "local.d/mine.sh armed" \
+  bash -c 'printf "#!/bin/sh\nexit 0\n" >.githooks/local.d/mine.sh && chmod +x .githooks/local.d/mine.sh'
+
+# (G) The shipped checks are called unguarded by the orchestrator, so a missing
+# one breaks every commit. Loud, not silent — but still worth naming precisely.
+doc_case "a missing shipped check is reported" 1 \
+  "lib/check-hygiene is missing" rm -f .githooks/lib/check-hygiene
+
+# (H) The two opt-in surfaces both fail OPEN when their tool is missing, and the
+# doctor's severities deliberately DIVERGE because their loudness does:
+# check-gitleaks announces itself on every commit (note), agent-precheck exits 0
+# with empty output (gap). Verified by measurement, not by symmetry.
+#
+# doc_minbin builds a PATH containing only the binaries the doctor itself needs,
+# so the result cannot depend on whether a given runner happens to ship jq or
+# gitleaks. Symlinks are resolved from the real PATH rather than hardcoded,
+# because jq lives in /usr/bin on some machines and /opt/homebrew/bin on others.
+doc_minbin() {
+  local d tool src
+  d=$(mktemp -d)
+  for tool in bash git grep sed awk basename; do
+    src=$(command -v "$tool" 2>/dev/null) || continue
+    ln -s "$src" "$d/$tool"
+  done
+  printf '%s' "$d"
+}
+
+DOCT=$(doc_project)
+DOCBIN=$(doc_minbin)
+cp "$SCAFFOLD_DIR/githooks/lib/check-gitleaks.template" "$DOCT/.githooks/lib/check-gitleaks"
+chmod +x "$DOCT/.githooks/lib/check-gitleaks"
+doc_rc=0
+( cd "$DOCT" && PATH="$DOCBIN" "$SCAFFOLD_DIR/scaffold-doctor.sh" ) >"$HOOK_OUT" 2>&1 || doc_rc=$?
+if [ "$doc_rc" -eq 0 ] && grep -qF "the local scan is a no-op" "$HOOK_OUT"; then
+  echo "  ✓ a gitleaks hook with no binary is a note (it warns on every commit itself)"
+  PASS=$((PASS + 1))
+else
+  echo "  ✗ gitleaks-without-binary misclassified (exit $doc_rc, wanted 0 + a note)"
+  sed 's/^/      /' "$HOOK_OUT"
+  FAIL=$((FAIL + 1))
+fi
+rm -rf "$DOCT"
+
+# agent-precheck with no jq says NOTHING, anywhere, ever — so it is a gap.
+DOCT=$(doc_project)
+cp "$SCAFFOLD_DIR/githooks/lib/agent-precheck.template" "$DOCT/.githooks/lib/agent-precheck"
+chmod +x "$DOCT/.githooks/lib/agent-precheck"
+doc_rc=0
+( cd "$DOCT" && PATH="$DOCBIN" "$SCAFFOLD_DIR/scaffold-doctor.sh" ) >"$HOOK_OUT" 2>&1 || doc_rc=$?
+if [ "$doc_rc" -eq 1 ] && grep -qF "jq is not on PATH" "$HOOK_OUT"; then
+  echo "  ✓ an agent-precheck with no jq is a gap (it fails open in total silence)"
+  PASS=$((PASS + 1))
+else
+  echo "  ✗ agent-precheck-without-jq misclassified (exit $doc_rc, wanted 1)"
+  sed 's/^/      /' "$HOOK_OUT"
+  FAIL=$((FAIL + 1))
+fi
+rm -rf "$DOCT" "$DOCBIN"
+
+# agent-precheck's executable bit is load-bearing in a way check-gitleaks' is
+# not: claude-settings.json and cursor-hooks.json invoke the PATH DIRECTLY as a
+# command, with no -x guard anywhere, so a cleared bit yields exit 126 — and the
+# agent runtimes block only on exit 2. Measured: the tool call proceeds, and
+# nothing is printed anywhere. The doctor reported "armed" for this until it
+# was caught in review.
+DOCT=$(doc_project)
+cp "$SCAFFOLD_DIR/githooks/lib/agent-precheck.template" "$DOCT/.githooks/lib/agent-precheck"
+chmod -x "$DOCT/.githooks/lib/agent-precheck"
+doc_rc=0
+( cd "$DOCT" && "$SCAFFOLD_DIR/scaffold-doctor.sh" ) >"$HOOK_OUT" 2>&1 || doc_rc=$?
+if [ "$doc_rc" -eq 1 ] && grep -qF "exit 126" "$HOOK_OUT"; then
+  echo "  ✓ a non-executable agent-precheck is a gap (126 is not the 2 that blocks)"
+  PASS=$((PASS + 1))
+else
+  echo "  ✗ a non-executable agent-precheck was reported armed (exit $doc_rc)"
+  sed 's/^/      /' "$HOOK_OUT"
+  FAIL=$((FAIL + 1))
+fi
+rm -rf "$DOCT"
+
+# (I) The shipped checks read their config by bare relative path, which works
+# only because git runs hooks from the top of the tree. A doctor run from a
+# subdirectory must reproduce that or it reports phantom gaps.
+DOCT=$(doc_project)
+mkdir -p "$DOCT/src/deep"
+doc_rc=0
+( cd "$DOCT/src/deep" && "$SCAFFOLD_DIR/scaffold-doctor.sh" ) >"$HOOK_OUT" 2>&1 || doc_rc=$?
+if [ "$doc_rc" -eq 0 ] && grep -qF "0 gaps" "$HOOK_OUT"; then
+  echo "  ✓ runs from a subdirectory without reporting phantom gaps"
+  PASS=$((PASS + 1))
+else
+  echo "  ✗ reported gaps when run from a subdirectory (exit $doc_rc)"
+  sed 's/^/      /' "$HOOK_OUT"
+  FAIL=$((FAIL + 1))
+fi
+rm -rf "$DOCT"
+
+# (J) Outside a git working tree there is no hooksPath to inspect and no project
+# to judge. Exit 2 (usage) keeps that distinguishable from "found gaps".
+DOCT=$(mktemp -d)
+doc_rc=0
+( cd "$DOCT" && "$SCAFFOLD_DIR/scaffold-doctor.sh" ) >"$HOOK_OUT" 2>&1 || doc_rc=$?
+if [ "$doc_rc" -eq 2 ] && grep -qF "not a git repository" "$HOOK_OUT"; then
+  echo "  ✓ outside a git repo it exits 2, distinct from a gap exit"
+  PASS=$((PASS + 1))
+else
+  echo "  ✗ wrong behavior outside a git repo (exit $doc_rc, wanted 2)"
+  sed 's/^/      /' "$HOOK_OUT"
+  FAIL=$((FAIL + 1))
+fi
+rm -rf "$DOCT"
+
+# (K) --quiet is what a CI step or a pre-flight script would call: gaps and the
+# summary only, with the section named inline since the headers are suppressed.
+doc_rc=0
+DOCT=$(doc_project)
+chmod -x "$DOCT/.githooks/pre-commit"
+( cd "$DOCT" && "$SCAFFOLD_DIR/scaffold-doctor.sh" --quiet ) >"$HOOK_OUT" 2>&1 || doc_rc=$?
+if [ "$doc_rc" -eq 1 ] && grep -qF "[hook entry point]" "$HOOK_OUT" && ! grep -qF "✓" "$HOOK_OUT"; then
+  echo "  ✓ --quiet prints gaps with their section and suppresses the armed lines"
+  PASS=$((PASS + 1))
+else
+  echo "  ✗ --quiet output wrong (exit $doc_rc)"
+  sed 's/^/      /' "$HOOK_OUT"
+  FAIL=$((FAIL + 1))
+fi
+rm -rf "$DOCT"
+
+reset_repo

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -52,7 +52,8 @@ for case_file in \
   "$HERE/cases/14-shell-install-mode.sh" \
   "$HERE/cases/15-local-checks.sh" \
   "$HERE/cases/16-coverage-gate.sh" \
-  "$HERE/cases/17-whole-tree-configs.sh"; do
+  "$HERE/cases/17-whole-tree-configs.sh" \
+  "$HERE/cases/18-doctor.sh"; do
   # shellcheck source=/dev/null
   . "$case_file"
 done


### PR DESCRIPTION
## Why

`install.sh` reports what it **wrote**. Whether the guardrails actually **run**
is a different question, and the gap between the two is where this repo's worst
bugs have lived — #76 was a `grep -r` that silently scanned one file instead of
a tree, #72 was a call site reset on upgrade while the check script stayed on
disk as decoration. Both were present, neither was running, and nothing said so.

The motivating measurement, on a real fixture:

```
# .forbidden-patterns/secrets.txt removed in an earlier commit
$ printf 'x = "AKIAIOSFODNN7EXAMPLE"\n' > probe.sh && git add probe.sh
$ ./.githooks/pre-commit ; echo "exit=$?"
exit=0        # no output whatsoever — a real AWS access key ID commits clean
```

## What

`scaffold-doctor.sh` never reports "file exists". For each guardrail it reports
whether the mechanism that makes it **execute** is in place:

| Section | Catches |
|---|---|
| wiring | `core.hooksPath` unset or pointing elsewhere — `install.sh` leaves a foreign hooksPath alone **by design** and only warns, so "installed but never wired" is a state it can leave behind |
| hook entry point | `pre-commit` / `commit-msg` missing the executable bit (git skips them wordlessly) |
| shipped checks | any of the five `lib/check-*` missing or non-executable |
| pattern data | absent `.forbidden-patterns/`, absent or gutted `secrets.txt`, a pattern file with no `# scaffold-extensions:` header |
| opt-in surfaces | `check-gitleaks` with no binary, `agent-precheck` with no `jq` or no executable bit |
| local.d | armed vs. deliberately disabled entries |
| overrides | a `.scaffold.toml` whose `lib/scaffold-config` is gone, so every override is silently ignored |

**Severity follows measured loudness, not symmetry.** `check-gitleaks` without
its binary prints an actionable note on *every commit* and names CI as the
authoritative gate → **note**. `agent-precheck` without `jq` exits 0 with
completely empty output → **gap**. Notes never affect exit status, because a
doctor that cries wolf about a self-announcing condition stops being read.

Exit: `0` no gaps, `1` at least one gap, `2` usage / not a git repo.

## Packaging

Ships as its own file rather than an `install.sh --doctor` flag — `install.sh`
is at its 500-line module cap (#84). `bin/cli.js` gains a `doctor` subcommand
(`npx ai-coding-rules-scaffold doctor`); everything else still passes through
untouched. `cases/11` now **derives** the CLI-dispatched script set from
`cli.js` rather than hardcoding it, so a second subcommand added later fails
closed the day it lands if it is left out of `package.json` `files`.

## Two bugs caught in adversarial review, fixed before merge

Both were reproduced against real fixtures, fixed, and are now regression-tested
(each mutation-proven to fail if the fix is reverted):

1. **False green** — a non-executable `agent-precheck` was reported *armed*.
   Both `claude-settings.json` and `cursor-hooks.json` exec the path **directly**
   with no `-x` guard, so a cleared bit yields exit **126**, and the agent
   runtimes block only on exit **2** — the tool call proceeds and nothing is
   printed anywhere. This is exactly the severity class the tool exists to catch.
2. **False red** — `core.hooksPath` was compared as a raw string against
   `".githooks"`. Measured: an absolute path, `./.githooks`, and `.githooks/`
   all run the hook and all block a planted `AKIA…` key, yet all three were
   reported as gaps. Now compared as resolved directories.

## Verification

- `./tests/run.sh` → **283 passed, 0 failed** (260 baseline + 22 new in
  `cases/18` + 1 new in `cases/11`); two consecutive clean runs.
- Every `cases/18` assertion is mutation-shaped, and the suite was re-run with
  four separate deliberate regressions introduced to confirm each fails the
  intended assertion and only that one.
- Scaffold self-lint run over the **staged index blobs** → clean.
- `shellcheck -S info` clean locally on both new files; CI's shellcheck is the
  authority.
- Dogfooded: running the doctor on this repo reports 18 armed, 0 gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)