### PR TITLE
chore(release): v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+## [v0.12.0] — 2026-08-21
+
+A release about the difference between a guardrail being *installed* and a
+guardrail being *armed*. `scaffold-doctor` reports, for every check the
+scaffold ships, whether the mechanism that makes it actually execute is in
+place — `core.hooksPath` wiring, executable bits, pattern data, opt-in
+surfaces and their external tools. Mutation-testing the doctor immediately
+found a real hole in the shipped secret patterns (`AWS_SECRET_ACCESS_KEY`),
+which is fixed here too. `install.sh` also gave up its post-install toolchain
+step to a sourced module, having reached the 500-line cap it enforces on
+everyone else.
+
 ### Added
 - **`scaffold-doctor.sh` — checks whether an installed scaffold is armed, not
   just present.** `install.sh` reports what it *wrote*; that's a different

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ somewhere stable:
 
 ```sh
 # Recommended: pin to a tagged release for reproducibility
-git clone --branch v0.11.0 https://github.com/Sting25/ai-coding-rules-scaffold ~/src/ai-coding-rules-scaffold
+git clone --branch v0.12.0 https://github.com/Sting25/ai-coding-rules-scaffold ~/src/ai-coding-rules-scaffold
 # Or track main if you want the latest changes
 git clone https://github.com/Sting25/ai-coding-rules-scaffold ~/src/ai-coding-rules-scaffold
 ```

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-coding-rules-scaffold",
-  "version": "0.11.0",
-  "description": "Agent-agnostic coding-rules scaffold: pre-commit + CI guardrails (file size, forbidden patterns, secret/credential scanning, hygiene) that install into your project. Run via `npx ai-coding-rules-scaffold`.",
+  "version": "0.12.0",
+  "description": "Agent-agnostic coding-rules scaffold: pre-commit + CI guardrails (file size, forbidden patterns, secret/credential scanning, hygiene) that install into your project, plus `scaffold-doctor` to check they are actually armed and not just present. Run via `npx ai-coding-rules-scaffold`.",
   "bin": {
     "ai-coding-rules-scaffold": "bin/cli.js"
   },


### PR DESCRIPTION
Release prep for **v0.12.0**. Per `RELEASING.md`, the tag is the source of truth
and these are the derived copies moved to match:

| Place | Change |
|---|---|
| `CHANGELOG.md` | `[Unreleased]` → `## [v0.12.0] — 2026-08-21`, empty `[Unreleased]` retained |
| `README.md` | `git clone --branch v0.11.0` → `v0.12.0` |
| `package.json` | `"version": "0.11.0"` → `"0.12.0"`, description extended to mention `scaffold-doctor` |

`packaging/homebrew/…rb` is intentionally **not** touched here — its `sha256`
cannot be computed until the tag exists. It follows in a post-tag PR, as the
checklist prescribes.

## Why minor

`scaffold-doctor` is a new user-facing tool plus a new
`npx ai-coding-rules-scaffold doctor` subcommand. No existing consumer behavior
changes.

## What's in it

- **`scaffold-doctor`** (#89) — reports guardrails that are installed but not
  running: `core.hooksPath` wiring, executable bits, the five shipped checks,
  pattern data, opt-in surfaces and their external tools, `local.d/` entries,
  and `.scaffold.toml` overrides a missing `scaffold-config` would silently drop.
- **AWS secret gap** (#90, closes #87) — the credential rule required its
  keyword adjacent to the separator, so a hardcoded `AWS_SECRET_ACCESS_KEY`
  committed clean. Found by mutation-testing the doctor.
- **`install-verify.sh` extraction** (#88, closes #84) — `install.sh` had hit
  497 of the 500-line cap it enforces on every project it installs into.
- **setup-node v7** (#70) — plus the template catch-up Dependabot never does.

## Verification

- `./tests/run.sh` → **285 passed, 0 failed** (was 260 at the start of this line
  of work).
- The checklist's whole-tree self-lint dry run — `check-secrets --ci`,
  `check-hygiene --ci`, `check-size --ci` over `git ls-files -z` — all rc=0, so
  the fat changelog prose does not trip the scanner.
- `./scaffold-doctor.sh` on this repo → `18 armed, 3 notes, 0 gaps`, exit 0.
- Version agreement checked: `package.json` is `0.12.0`, matching the `v0.12.0`
  tag to be pushed — `release.yml` fails closed if these diverge.

## Note

The commit is `chore(release): v0.12.0`, not `release: v0.12.0` as v0.11.0 used —
the repo's own `commit-msg` hook rejects `release` as a type. Filed separately so
`RELEASING.md` can say so rather than leaving the next person to discover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)