### PR TITLE
chore(packaging): sync the canonical Homebrew formula to v0.12.0

### DIFF
--- a/packaging/homebrew/ai-coding-rules-scaffold.rb
+++ b/packaging/homebrew/ai-coding-rules-scaffold.rb
@@ -9,8 +9,8 @@
 class AiCodingRulesScaffold < Formula
   desc "Pre-commit and CI guardrails: size, pattern, secret, and hygiene checks"
   homepage "https://github.com/Sting25/ai-coding-rules-scaffold"
-  url "https://github.com/Sting25/ai-coding-rules-scaffold/archive/refs/tags/v0.11.0.tar.gz"
-  sha256 "be7d737c060ae13feec767b05cb30d4d3d83d5c9e6c9ad8bcaee7b066cbb8d2e"
+  url "https://github.com/Sting25/ai-coding-rules-scaffold/archive/refs/tags/v0.12.0.tar.gz"
+  sha256 "d3d55ddbc9ba4e04739ac86f5179fd776c6eb6a2cb9f3581465d028f3f90fd03"
   license "MIT"
 
   def install


### PR DESCRIPTION
Post-tag follow-up, as `RELEASING.md` step 3 prescribes ("update the canonical
copy in this repo in the next convenient PR so it doesn't drift from the tap").

The tap's own `bump-formula` workflow already updated
`Sting25/homebrew-tap` after the `v0.12.0` tag push. This repo holds the
**versioned source of truth** for that formula, so it follows.

| Field | New value |
|---|---|
| `url` | `.../archive/refs/tags/v0.12.0.tar.gz` |
| `sha256` | `d3d55ddbc9ba4e04739ac86f5179fd776c6eb6a2cb9f3581465d028f3f90fd03` |

## Verification

The hash was confirmed **two independent ways** before this PR:

1. Computed locally from the released tarball —
   `curl -fsSL .../v0.12.0.tar.gz | shasum -a 256`.
2. Byte-compared against what the tap's workflow wrote on its own; `diff`
   against the tap's live `Formula/ai-coding-rules-scaffold.rb` reports the file
   is **identical**, so the canonical copy and the tap now agree exactly.

Docs/packaging only — no shipped code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)