### PR TITLE
docs(rules): add ephemeral-environments and atomic-commit operational rules

### DIFF
--- a/operational-rules.md
+++ b/operational-rules.md
@@ -102,6 +102,22 @@ _Anchor:_ mocked tests passed for months while the production
 migration silently broke; the divergence was invisible until a
 deploy hit the real schema.
 
+### Ephemeral environments replace a standing QA server
+
+Always test against a real database, never synthetic-only fixtures for
+anything load-bearing, and always do that testing inside a throwaway
+environment (a spun-up container, VM, or short-lived cloud host) rather
+than a persistent QA server. Stand it up, run the full pre-prod check,
+tear it down. A persistent QA server drifts from production configuration
+over time and becomes a second thing to maintain; an ephemeral one is
+defined by the same provisioning script that builds production, so it
+cannot drift.
+_Anchor:_ a search-index rework needed Linux-only measurements (systemd
+unit verification, anonymous-memory RSS) that a macOS dev machine could
+never produce; the fix was a disposable host built from the same
+provisioning script as production, checked and destroyed, not a
+standing QA box.
+
 ### Tests cover every code path; back claims with measurement
 
 "We have tests" is not the same as "this is tested." Every branch,
@@ -215,6 +231,23 @@ feels small and the cumulative work feels productive.
 _Anchor:_ mixed commits become unrevertable when one fix turns out
 to be wrong; pre-commit failures force re-stage cycles when many
 unrelated changes are batched together.
+
+### Commit atomically without waiting for per-commit approval
+
+This overrides the generic "never commit unless explicitly asked"
+default some tools ship with. On a feature branch or worktree, once
+a logical unit of work passes its own gate (tests, lint, the checks
+this repo already runs), commit it immediately and move on. Do not
+pause mid-task to ask permission for each individual commit; that
+default exists to stop unwanted proactive commits, not to add a
+confirmation step to work the user already asked for. Pushing,
+merging into a protected branch, and force-pushing still need their
+own explicit approval every time; committing locally on a branch
+already in scope does not.
+_Anchor:_ mid-session, an agent kept asking before each commit on a
+branch the user had already scoped and approved the work for; the
+user had to explicitly say "always do atomic commits, do not wait
+for me" to stop the interruptions.
 
 ### Locked decisions are revisitable on new evidence
 


### PR DESCRIPTION
## Summary

Adds two new sections to `operational-rules.md`, both authored in an earlier working session and landed here from an uncommitted local edit.

**Ephemeral environments replace a standing QA server**: testing against a real database should happen inside a throwaway environment (a container, VM, or short-lived cloud host) rather than a persistent QA box. A standing QA server drifts from production configuration over time and becomes a second thing to maintain, while an ephemeral one is built from the same provisioning script as production, so it cannot drift. The anchor is a search-index rework that needed Linux-only measurements a macOS dev machine could never produce, resolved with a disposable host built and destroyed per run.

**Commit atomically without waiting for per-commit approval**: on a feature branch or worktree already in scope, once a logical unit of work passes its own gate (tests, lint, the checks the repo already runs), it should be committed immediately rather than pausing to ask permission for each individual commit. This overrides the generic "never commit unless explicitly asked" default some tools ship with, since that default exists to stop unwanted proactive commits, not to add a confirmation step to work already approved. Pushing, merging into a protected branch, and force-pushing still require explicit approval every time. The anchor is a session where an agent kept asking before each commit on a branch the user had already scoped and approved, until told explicitly to stop interrupting.

## Test plan

- [x] `git apply` of the pre-authored patch applied cleanly, inserting each section immediately after its named anchor section
- [x] Reproduced the `self-lint.yml` prettier check locally (`.prettierrc.json.template` + `prettier@3.9.6 --check`): passes with no reformatting needed
- [x] `./tests/run.sh`: 280 passed, 5 failed; the 5 failures are pre-existing on unmodified `main` (missing `@eslint/compat` in this machine's npm environment) and unrelated to this docs-only change
- [x] Only `operational-rules.md` touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)