### PR TITLE
feat(install): run tests in CI by default; keep the patch-coverage gate opt-in (#97)

### DIFF
--- a/.github/workflows/coverage.yml.template
+++ b/.github/workflows/coverage.yml.template
@@ -1,7 +1,10 @@
 name: coverage
 
-# OPT-IN patch-coverage gate. Copy to your project as
-# `.github/workflows/coverage.yml` (or `install.sh --coverage-gate`).
+# OPT-IN patch-coverage gate: the strictness layer on top of the default-on
+# `tests.yml` (#97). Copy to your project as `.github/workflows/coverage.yml`
+# (or `install.sh --coverage-gate`, which installs this INSTEAD OF tests.yml:
+# this workflow already runs the tests, so installing both would run them
+# twice for the same push/PR).
 #
 # WHAT THIS DOES — and what it cannot do.
 # It fails the PR when lines you ADDED OR CHANGED in this PR are not executed by
@@ -45,7 +48,13 @@ jobs:
           if [ -f pyproject.toml ] || [ -f pytest.ini ] || [ -f setup.py ]; then
             echo "python=true" >> "$GITHUB_OUTPUT"
           fi
-          if [ -f package.json ]; then
+          # Gate on vitest actually being DECLARED, not merely on package.json
+          # existing (#96). A repo can ship package.json for lint tooling only
+          # (eslint/prettier/tsc, no test runner) and this step used to run
+          # `vitest` there anyway, hard-failing a stack that opted into lint
+          # but never into testing.
+          if [ -f package.json ] && { grep -q '"vitest"' package.json \
+               || grep -qE '"test"[[:space:]]*:[[:space:]]*"[^"]*vitest' package.json; }; then
             echo "frontend=true" >> "$GITHUB_OUTPUT"
           fi
 
@@ -73,6 +82,26 @@ jobs:
         # undo the tolerance this block exists to provide. A command on the left
         # of `||` is a tested command and exempt from -e.
         run: |
+          # Install the project itself before running its tests (#96). A pytest
+          # job that installs only pytest dies at import for any project whose
+          # tests import the package under test. Detect a `dev` extra with a
+          # grep (same style install.sh uses for its pytest-config detection)
+          # rather than a full TOML parse, no extra dependency, and the two
+          # states that matter (extra present / absent) are simple string shapes.
+          if [ -f pyproject.toml ]; then
+            if grep -q '^\[project.optional-dependencies\]' pyproject.toml && grep -qE '^dev[[:space:]]*=' pyproject.toml; then
+              pip install -e ".[dev]"
+            else
+              pip install -e .
+            fi
+          elif [ -f setup.py ]; then
+            pip install -e .
+          fi
+          # Some projects pin test deps in a requirements file instead of (or
+          # in addition to) a pyproject extra: install any that exist.
+          for req in requirements.txt requirements-dev.txt requirements/dev.txt; do
+            [ -f "$req" ] && pip install -r "$req"
+          done
           # Pinned: an unpinned `pip install` executes whatever version is newest
           # at run time, minutes after publish — contradicting the cooldown posture
           # the scaffold's dependabot.yml.template documents. Dependabot bumps these.

--- a/.github/workflows/coverage.yml.template
+++ b/.github/workflows/coverage.yml.template
@@ -88,7 +88,14 @@ jobs:
           # grep (same style install.sh uses for its pytest-config detection)
           # rather than a full TOML parse, no extra dependency, and the two
           # states that matter (extra present / absent) are simple string shapes.
-          if [ -f pyproject.toml ]; then
+          #
+          # Only attempt the editable install when the project is actually
+          # installable: a `[project]` table (PEP 621) or a `setup.py`. A
+          # pyproject.toml that only holds tool config (`[tool.ruff]`,
+          # `[tool.pytest.ini_options]`, a poetry package-mode-false project)
+          # has no build backend for `pip install -e .` to target, and would
+          # hard-fail this step for a project that never claimed to be a package.
+          if [ -f pyproject.toml ] && grep -q '^\[project\]' pyproject.toml; then
             if grep -q '^\[project.optional-dependencies\]' pyproject.toml && grep -qE '^dev[[:space:]]*=' pyproject.toml; then
               pip install -e ".[dev]"
             else
@@ -98,9 +105,14 @@ jobs:
             pip install -e .
           fi
           # Some projects pin test deps in a requirements file instead of (or
-          # in addition to) a pyproject extra: install any that exist.
+          # in addition to) a pyproject extra: install any that exist. `if`/`fi`,
+          # not `[ -f "$req" ] && pip install -r "$req"` as the loop body (see
+          # tests.yml.template for why that form can exit the STEP non-zero
+          # under bash -e when the file is absent, even though nothing failed).
           for req in requirements.txt requirements-dev.txt requirements/dev.txt; do
-            [ -f "$req" ] && pip install -r "$req"
+            if [ -f "$req" ]; then
+              pip install -r "$req"
+            fi
           done
           # Pinned: an unpinned `pip install` executes whatever version is newest
           # at run time, minutes after publish — contradicting the cooldown posture

--- a/.github/workflows/tests.yml.template
+++ b/.github/workflows/tests.yml.template
@@ -52,10 +52,17 @@ jobs:
       # (same style as install.sh's pytest-config detection below) rather than
       # a full TOML parse, no extra dependency, and the two states that
       # matter (extra present / absent) are simple string shapes.
+      #
+      # Only attempt the editable install when the project is actually
+      # installable: a `[project]` table (PEP 621) or a `setup.py`. A
+      # pyproject.toml that only holds tool config (`[tool.ruff]`,
+      # `[tool.pytest.ini_options]`, a poetry package-mode-false project) has
+      # no build backend for `pip install -e .` to target, and would hard-fail
+      # this step for a project that never claimed to be a package.
       - name: Install project (so tests importing the package can collect)
         if: steps.detect.outputs.present == 'true'
         run: |
-          if [ -f pyproject.toml ]; then
+          if [ -f pyproject.toml ] && grep -q '^\[project\]' pyproject.toml; then
             if grep -q '^\[project.optional-dependencies\]' pyproject.toml && grep -qE '^dev[[:space:]]*=' pyproject.toml; then
               pip install -e ".[dev]"
             else
@@ -66,8 +73,20 @@ jobs:
           fi
           # Some projects pin test deps in a requirements file instead of (or
           # in addition to) a pyproject extra: install any that exist.
+          #
+          # `if`/`fi`, not `[ -f "$req" ] && pip install -r "$req"` as the loop
+          # body. Under `bash -e` (the default shell for a `run:` step), a
+          # standalone `&&` list that ends this loop and this step is not an
+          # exempt context, so on whichever iteration the file is absent, the
+          # list's own exit status (1, from the failed `[ -f ]` test) becomes
+          # the exit status of the step itself, failing the job even though
+          # nothing actually went wrong. Confirmed by running the extracted
+          # body under `bash -e` with none of the three files present (the
+          # common case): the old form exited 1, this form exits 0.
           for req in requirements.txt requirements-dev.txt requirements/dev.txt; do
-            [ -f "$req" ] && pip install -r "$req"
+            if [ -f "$req" ]; then
+              pip install -r "$req"
+            fi
           done
       - name: Run pytest
         if: steps.detect.outputs.present == 'true'

--- a/.github/workflows/tests.yml.template
+++ b/.github/workflows/tests.yml.template
@@ -1,0 +1,129 @@
+name: tests
+
+# DEFAULT-ON test execution. Copy to your project as
+# `.github/workflows/tests.yml` (install.sh installs it automatically; opt out
+# with `--no-test-workflow`, or install `--coverage-gate` instead (see below).
+#
+# WHY THIS EXISTS (#97). A default install used to produce lint-only CI: green
+# checks with zero tests ever executing. "CI is green" then means "nothing is
+# malformed", never "nothing is broken", and nothing records that the real gate
+# was a local pytest run on one machine. This workflow just RUNS the test
+# suite (pytest / vitest) on every PR/push, no coverage threshold. Pair it with
+# `install.sh --coverage-gate` for the stricter patch-coverage layer on top:
+# that installs `coverage.yml` INSTEAD of this file (it already runs the tests
+# plus a diff-cover gate), so tests never run twice in the same CI run.
+#
+# Skips gracefully, loudly, when a stack isn't present: each job always starts
+# (a job-level `if: hashFiles(...)` would make GitHub reject the WHOLE workflow
+# as invalid, see lint.yml's header) and its steps no-op with a logged reason.
+#
+# Actions are pinned to a commit SHA (trailing comment = version); the SHAs
+# match lint.yml / coverage.yml so Dependabot bumps them together.
+
+on:
+  pull_request:
+  push:
+    branches: [main, master]
+
+permissions:
+  contents: read
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false  # don't leave GITHUB_TOKEN in .git/config
+      - id: detect
+        run: |
+          if [ -f pyproject.toml ] || [ -f pytest.ini ] || [ -f setup.py ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "no Python project detected (no pyproject.toml / pytest.ini / setup.py), skipping pytest job"
+          fi
+      - if: steps.detect.outputs.present == 'true'
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        with:
+          python-version: "3.12"
+      # Install the project itself before running its tests (#96). A pytest
+      # job that installs only pytest dies at import for any project whose
+      # tests import the package under test. Detect a `dev` extra with a grep
+      # (same style as install.sh's pytest-config detection below) rather than
+      # a full TOML parse, no extra dependency, and the two states that
+      # matter (extra present / absent) are simple string shapes.
+      - name: Install project (so tests importing the package can collect)
+        if: steps.detect.outputs.present == 'true'
+        run: |
+          if [ -f pyproject.toml ]; then
+            if grep -q '^\[project.optional-dependencies\]' pyproject.toml && grep -qE '^dev[[:space:]]*=' pyproject.toml; then
+              pip install -e ".[dev]"
+            else
+              pip install -e .
+            fi
+          elif [ -f setup.py ]; then
+            pip install -e .
+          fi
+          # Some projects pin test deps in a requirements file instead of (or
+          # in addition to) a pyproject extra: install any that exist.
+          for req in requirements.txt requirements-dev.txt requirements/dev.txt; do
+            [ -f "$req" ] && pip install -r "$req"
+          done
+      - name: Run pytest
+        if: steps.detect.outputs.present == 'true'
+        # Same tolerance as coverage.yml: only pytest's exit 5 (no tests
+        # collected) is swallowed, so an empty suite doesn't fail a fresh
+        # install, but a real failure (1), interruption (2), internal error
+        # (3), or usage error (4) fails the job. `|| rc=$?`, not `; rc=$?`:
+        # the default shell for a `run:` step is `bash -e`, under which
+        # `pytest …; rc=$?` never reaches the assignment (see coverage.yml).
+        run: |
+          pip install pytest==9.1.1
+          rc=0
+          pytest || rc=$?
+          if [ "$rc" -ne 0 ] && [ "$rc" -ne 5 ]; then
+            echo "pytest exited $rc, failing the job (only 5 = no tests collected is tolerated)."
+            exit "$rc"
+          fi
+
+  vitest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false  # don't leave GITHUB_TOKEN in .git/config
+      # Gate on vitest actually being DECLARED, not merely on package.json
+      # existing (#96). A repo can have package.json for lint tooling only
+      # (eslint/prettier/tsc, no test runner), and running `vitest` there hard
+      # fails the job for a stack that was never opted into testing.
+      - id: detect
+        run: |
+          if [ ! -f package.json ]; then
+            echo "no package.json, skipping vitest job"
+          elif grep -q '"vitest"' package.json \
+               || grep -qE '"test"[[:space:]]*:[[:space:]]*"[^"]*vitest' package.json; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "package.json present but vitest is not declared (devDependencies/dependencies/scripts.test), skipping vitest job"
+          fi
+      - if: steps.detect.outputs.present == 'true'
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
+        with:
+          node-version: "20"
+      - name: Install dependencies
+        if: steps.detect.outputs.present == 'true'
+        # Frozen-lockfile install when a lockfile exists, same as lint.yml.
+        # --ignore-scripts: vitest is pure JS and never needs a dependency's
+        # install hooks, and this runner holds GITHUB_TOKEN.
+        run: |
+          if [ -f package-lock.json ] || [ -f npm-shrinkwrap.json ]; then
+            npm ci --ignore-scripts
+          else
+            npm install --ignore-scripts
+          fi
+      - name: Run vitest
+        if: steps.detect.outputs.present == 'true'
+        # No `|| true` (see coverage.yml #71): a failing suite must fail the
+        # job. --passWithNoTests exits 0 for a genuinely empty suite instead of
+        # swallowing a real failure the way `|| true` did.
+        run: npx --no-install vitest run --passWithNoTests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- **Test execution in CI is default-on (#97).** A plain `install.sh` run now
+  installs `.github/workflows/tests.yml` (pytest/vitest, no coverage
+  threshold) instead of leaving CI lint-only with zero tests ever executing.
+  `--coverage-gate` swaps `tests.yml` for `coverage.yml` (same tests, plus the
+  patch-coverage gate) rather than installing both, so tests never run twice
+  in the same CI run. New `--no-test-workflow` opts out entirely for a repo
+  that genuinely cannot run tests in CI, with a loud recorded skip in the
+  install summary. The installer's end-of-run summary now states plainly
+  which of the three states a repo ended in.
+- **`coverage.yml` installs the project before running pytest, and gates the
+  vitest job on vitest actually being declared (#96).** The pytest job
+  previously installed only `pytest` itself, so any project whose tests
+  import the package under test failed at collection; it now runs
+  `pip install -e ".[dev]"` (falling back to `pip install -e .`, plus any
+  `requirements*.txt`) first. The frontend job previously ran on any
+  `package.json`; it now only runs when `vitest` is actually declared in
+  `dependencies`/`devDependencies`/`scripts.test`, so a repo that ships
+  `package.json` for lint tooling only no longer hard-fails the job. Both
+  fixes are also applied to the new `tests.yml`.
+
 ## [v0.12.0] — 2026-08-21
 
 A release about the difference between a guardrail being *installed* and a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,12 +20,25 @@ versioning follows [SemVer](https://semver.org/).
   vitest job on vitest actually being declared (#96).** The pytest job
   previously installed only `pytest` itself, so any project whose tests
   import the package under test failed at collection; it now runs
-  `pip install -e ".[dev]"` (falling back to `pip install -e .`, plus any
-  `requirements*.txt`) first. The frontend job previously ran on any
+  `pip install -e ".[dev]"` (falling back to `pip install -e .`, plus any of
+  `requirements.txt`, `requirements-dev.txt`, or `requirements/dev.txt` that
+  exist) first, and only when the project actually has a `[project]` table
+  or a `setup.py` (a pyproject.toml holding only tool config is skipped
+  rather than hard-failed). The frontend job previously ran on any
   `package.json`; it now only runs when `vitest` is actually declared in
   `dependencies`/`devDependencies`/`scripts.test`, so a repo that ships
   `package.json` for lint tooling only no longer hard-fails the job. Both
   fixes are also applied to the new `tests.yml`.
+- **Fixed a real CI-breaking bug in the shipped `tests.yml.template` before
+  it ever ran in the wild:** the requirements-file install loop's last
+  statement was `[ -f "$req" ] && pip install -r "$req"`, and under the
+  `bash -e` a `run:` step uses, that construct's own exit status (1, from the
+  failed file test) became the whole step's exit status whenever the last
+  candidate file was absent, which is nearly always. The default pytest job
+  would have failed for virtually every Python consumer. Fixed to
+  `if [ -f "$req" ]; then pip install -r "$req"; fi`, verified by running the
+  extracted step body under `bash -e` with pyproject-only, requirements.txt-
+  only, and no fixtures at all: all three now exit 0.
 
 ## [v0.12.0] — 2026-08-21
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ From your project root:
 
 The script auto-detects Python (`pyproject.toml` / `requirements.txt` / `setup.py`) or frontend (`package.json`) and installs the matching pieces. If neither is present, it falls back to **shell mode** when the repo contains any `*.sh`/`*.bash` file (tracked or not yet committed); with no manifest and no shell scripts it exits and asks for the stack explicitly. A manifest always wins over the shell fallback, so a `package.json` project that also ships build scripts is still a frontend install.
 
+Tests run in CI by default: a plain install also drops `.github/workflows/tests.yml`, so pytest/vitest execute on every PR/push with no coverage threshold. `--coverage-gate` swaps that for the stricter patch-coverage gate; `--no-test-workflow` opts out entirely (loudly, with a recorded skip in the install summary) for a repo that genuinely cannot run tests in CI.
+
 ```sh
 ./install.sh --python       # Python only
 ./install.sh --frontend     # TS/JS only
@@ -106,14 +108,15 @@ The script auto-detects Python (`pyproject.toml` / `requirements.txt` / `setup.p
 ./install.sh --commit-msg   # also install the Conventional-Commits commit-msg hook
 ./install.sh --gitleaks-hook # also install opt-in local gitleaks pre-commit pass
 ./install.sh --all-langs    # install every language's forbidden-pattern file
-./install.sh --coverage-gate # also install the opt-in CI patch-coverage gate
+./install.sh --coverage-gate # swap the default tests.yml for coverage.yml (tests + patch-coverage gate)
+./install.sh --no-test-workflow # opt out of the default CI test-execution workflow (loud recorded skip)
 ./install.sh --no-install   # detect missing tools but never auto-run a package manager
 ./install.sh --help         # show usage
 ```
 
 **Re-running is the upgrade path.** Running `install.sh` again refreshes
 scaffold-owned code — the pre-commit hook, the `.githooks/lib/*` scanners, the
-`commit-msg` hook, and the `lint.yml` / coverage workflows — whenever it differs
+`commit-msg` hook, and the `lint.yml` / `tests.yml` / coverage workflows, whenever it differs
 from the shipped version, with no `--force` needed, so pulling a new tag and
 re-running delivers security fixes. Your own configs (`ruff.toml`,
 `eslint.config.js`, `.scaffold.toml`, the rules docs, …) are left untouched, and

--- a/TECHNICAL.md
+++ b/TECHNICAL.md
@@ -203,10 +203,19 @@ vitest job where `package.json` never declares `vitest`, no-ops with a logged
 reason instead of failing). No coverage threshold: the point is only that
 tests actually **run** on every PR/push, closing the gap where a default
 install produced lint-only CI and a green check meant "nothing is malformed",
-never "nothing is broken." The pytest job installs the project itself first
-(`pip install -e ".[dev]"` when a `dev` extra is declared, else
-`pip install -e .`, plus any `requirements*.txt`) so tests that import the
-package under test can actually collect.
+never "nothing is broken." The pytest job installs the project itself first,
+but only when it looks actually installable (a `[project]` table or a
+`setup.py`, not a pyproject.toml that only holds tool config): `pip install
+-e ".[dev]"` when a `dev` extra is declared, else `pip install -e .`, plus
+any of `requirements.txt`, `requirements-dev.txt`, or `requirements/dev.txt`
+that exist, so tests that import the package under test can actually
+collect.
+
+`.github/workflows/tests.yml` is a scaffold-claimed filename: `install.sh`
+treats it as scaffold-owned code (like `lint.yml`) and refreshes it on every
+re-run, so a project that already has its own hand-written `tests.yml` will
+have it replaced (backed up to `.scaffold-bak` first, with a warning printed
+at install time).
 
 Two ways to change this:
 

--- a/TECHNICAL.md
+++ b/TECHNICAL.md
@@ -26,7 +26,7 @@ Two always-on enforcement layers (pre-commit hook + CI mirror) plus optional age
   - **React** — `dangerouslySetInnerHTML` (XSS); opt-in `react-hooks` + `jsx-a11y` blocks.
   - **Vue** — `.vue` scanned; `v-html` (XSS).
   - **Svelte** — `.svelte` scanned; `{@html}` (XSS).
-- **Testing** — a runner config ships per stack (`vitest.config.ts` for TS/JS unless the project already uses Jest; `pytest.ini` + `.coveragerc` for Python). A runner alone forces nothing; the **opt-in patch-coverage gate** (`--coverage-gate`) fails a PR when *changed* lines ship untested. It gates execution of changed lines, not assertion quality — see [`RECOMMENDATIONS.md`](./RECOMMENDATIONS.md) on why you can't fully machine-force meaningful tests.
+- **Testing** — a runner config ships per stack (`vitest.config.ts` for TS/JS unless the project already uses Jest; `pytest.ini` + `.coveragerc` for Python), and `install.sh` installs `.github/workflows/tests.yml` by **default** so pytest/vitest actually run on every PR/push, no coverage threshold. On top of that, the **opt-in patch-coverage gate** (`--coverage-gate`) swaps `tests.yml` for `coverage.yml`, which runs the same tests and additionally fails a PR when *changed* lines ship untested. It gates execution of changed lines, not assertion quality: see [`RECOMMENDATIONS.md`](./RECOMMENDATIONS.md) on why you can't fully machine-force meaningful tests. `--no-test-workflow` opts out of installing either (a loud, recorded skip) for a repo that genuinely cannot run tests in CI.
 - **PHP** — `php -l` syntax + `phpcs` (when configured) **+** `php.txt`: `var_dump`/`print_r`, `->dd()`/`dump()`, `die`/`exit` (opt-in).
 - **Go** — `go.txt`: `fmt.Println`/`Printf` debug, `panic`/`print` (opt-in); ready-to-uncomment golangci-lint CI job.
 - **Rust** — `rust.txt`: `dbg!`, `println!`, `.unwrap()`/`.expect()` (opt-in); clippy CI job stub.
@@ -60,6 +60,7 @@ Language pattern files auto-install when their manifest is detected (`go.mod`, `
 | `githooks/local.d/README.md.template` | `.githooks/local.d/README.md` | Documents the project-local check contract. The **directory** is yours: drop executables in and hook + CI both run them, and `install.sh` never writes into it |
 | `.scaffold.toml.template` | `.scaffold.toml` | Per-project rule overrides — ships empty (commented), enforces nothing until edited |
 | `.github/workflows/lint.yml.template` | `.github/workflows/lint.yml` | CI mirror — invokes the same `lib/check-*` scripts as the hook, scoped to the PR/push diff (`lib/ci-changed-files`) for quality gates, whole-tree for the secret/credential scans |
+| `.github/workflows/tests.yml.template` | `.github/workflows/tests.yml` | Default-on test execution: runs pytest/vitest on every PR/push, no coverage threshold. Skipped by `--no-test-workflow`; replaced by `coverage.yml` under `--coverage-gate` |
 | `githooks/lib/ci-changed-files.template` | `.githooks/lib/ci-changed-files` | Resolves the PR/push diff so CI quality gates scan only changed files; fails open to the whole tree when there's no diff base |
 | `.github/dependabot.yml.template` | `.github/dependabot.yml` | Weekly grouped version bumps for the SHA-pinned GitHub Actions |
 | `forbidden-patterns/backend.txt.template` | `.forbidden-patterns/backend.txt` | Python patterns consumed by hook + CI |
@@ -115,7 +116,7 @@ Build-breaking (`ruff` / `eslint`, on every lint + commit + in CI):
 | Re-throwing in `catch` while discarding the original error cause/stack | `eslint preserve-caught-error` (needs ESLint ≥ 9.35) |
 | TypeScript type errors | `tsc --noEmit` (hook + CI, when `tsconfig.json` present) |
 | Unformatted TS/JS | `prettier --check` (hook + CI, when a prettier config is present; `prettier --write` fixes) |
-| Changed lines shipped without a test (opt-in) | `diff-cover` patch-coverage gate (`--coverage-gate`, CI) |
+| Changed lines shipped without a test (opt-in strictness layer on default-on test execution) | `diff-cover` patch-coverage gate (`--coverage-gate`, CI) |
 
 Commit + CI-breaking (pre-commit hook + `lint.yml`):
 
@@ -193,10 +194,39 @@ severity = "warn"
   guardrails job prints it into the build log. Treat changes to `.scaffold.toml`
   as security-relevant in review, the same as edits to `.githooks/**`.
 
+## Default-on test execution
+
+`install.sh` installs `.github/workflows/tests.yml` by default (#97): a pytest
+job and a vitest job, each gated on the matching stack actually being present
+(a pytest job on a repo with no `pyproject.toml`/`pytest.ini`/`setup.py`, or a
+vitest job where `package.json` never declares `vitest`, no-ops with a logged
+reason instead of failing). No coverage threshold: the point is only that
+tests actually **run** on every PR/push, closing the gap where a default
+install produced lint-only CI and a green check meant "nothing is malformed",
+never "nothing is broken." The pytest job installs the project itself first
+(`pip install -e ".[dev]"` when a `dev` extra is declared, else
+`pip install -e .`, plus any `requirements*.txt`) so tests that import the
+package under test can actually collect.
+
+Two ways to change this:
+
+- **`install.sh --coverage-gate`** swaps `tests.yml` for `coverage.yml`:
+  same tests, plus a patch-coverage gate on top (see below). Installing both
+  would run the suite twice for the same push/PR, so it's always one or the
+  other, never both; an upgrade that adds `--coverage-gate` on top of a prior
+  default install retires the now-redundant `tests.yml` if it's still
+  untouched since install.
+- **`install.sh --no-test-workflow`** installs neither. For a repo that
+  genuinely cannot run tests in CI. The installer prints a loud recorded skip
+  when this flag is used, and its end-of-run summary always states plainly
+  which of the three states (`tests.yml`, `coverage.yml`, or no test
+  execution at all) the repo ended up in.
+
 ## Opt-in layers
 
-Beyond the always-on hook + CI mirror, three extras are available. They're off
-by default so the scaffold stays minimal; turn them on per project.
+Beyond the always-on hook + CI mirror and the default-on test workflow above,
+further extras are available. They're off by default so the scaffold stays
+minimal; turn them on per project.
 
 - **Agent-runtime guardrails (`install.sh --claude`).** The opt-in third layer —
   catching bad input *before* the agent writes it, not at commit time.
@@ -251,7 +281,8 @@ by default so the scaffold stays minimal; turn them on per project.
   repos (caveat documented in the template header).
 
 - **Patch-coverage gate (`install.sh --coverage-gate` →
-  `.github/workflows/coverage.yml`).** The one mechanism here that *forces tests
+  `.github/workflows/coverage.yml`, installed *instead of* the default-on
+  `tests.yml` above).** The one mechanism here that *forces tests
   to be written*: it fails a PR when lines you **added or changed** aren't
   executed by any test (`diff-cover`, default 100% of changed lines; lower the
   `DIFF_COVER_FAIL_UNDER` env to ease adoption, then ratchet up). It deliberately
@@ -260,7 +291,8 @@ by default so the scaffold stays minimal; turn them on per project.
   never **verified** by one — an assertion-free test still counts as covered.
   Pair it with required human review; for real test-*quality* signal, layer on
   mutation testing (see [`RECOMMENDATIONS.md`](./RECOMMENDATIONS.md), "Forcing
-  tests"). Opt-in because forcing tests on new code is a policy a team must
+  tests"). The gate itself stays opt-in because forcing a strict bar on new code
+  is a policy choice a team must
   choose deliberately.
 
   The job also **fails on failing tests**, not only on uncovered lines. That is

--- a/install-lib.sh
+++ b/install-lib.sh
@@ -181,3 +181,97 @@ cp_pattern() {
 # via a chmod that follows a broken link and fails under set -e — nor should we
 # flip the mode of a skipped, user-owned file.
 mkx() { if [ -f "$1" ]; then chmod +x "$1"; fi; }
+
+# install_test_workflow_ci, the test-execution CI workflow (#97): DEFAULT-ON,
+# exactly one of two shapes, plus a recorded opt-out. Extracted here (like
+# install-verify.sh's run_toolchain_verify) once install.sh neared its own
+# 500-line cap; reads the caller's globals (NO_TEST_WORKFLOW, COVERAGE_GATE,
+# SCAFFOLD_DIR) and sets TEST_CI_STATE for the caller's end-of-run summary.
+#
+# A default install used to produce lint-only CI (green checks with zero
+# tests ever executing), which is the bug this closes. Three end states,
+# decided in this order:
+#
+#   1. --no-test-workflow -> install NEITHER workflow. The one way a repo ends
+#      up with no test execution in CI, and it must say so loudly, per
+#      operational-rules.md's "record every skip" (unless a workflow from a
+#      prior run is already on disk, CI keeps running it either way).
+#   2. --coverage-gate (or coverage.yml already on disk from a prior run) ->
+#      install coverage.yml, which already runs the tests AND gates patch
+#      coverage. It gates EXECUTION of changed lines, not assertion quality;
+#      see RECOMMENDATIONS.md.
+#   3. default -> install tests.yml: pytest/vitest run on every PR/push, no
+#      coverage threshold.
+#
+# Never both: coverage.yml already runs the tests, so installing tests.yml
+# alongside it would run the suite twice for the same push/PR. If an upgrade
+# adds --coverage-gate on top of a prior default install, the now-redundant
+# tests.yml (if untouched since install) is retired rather than left to
+# double-run.
+install_test_workflow_ci() {
+  if [ "$NO_TEST_WORKFLOW" -eq 1 ]; then
+    if [ "$COVERAGE_GATE" -eq 1 ]; then
+      echo "warning: --no-test-workflow overrides --coverage-gate: neither tests.yml nor coverage.yml will be installed."
+    fi
+    if [ -f ".github/workflows/tests.yml" ] || [ -f ".github/workflows/coverage.yml" ]; then
+      echo "note: an existing tests.yml/coverage.yml was left in place. --no-test-workflow only skips a NEW install, it does not remove one."
+      echo "note: this repo's CI still runs tests via that existing workflow; --no-test-workflow only affects what THIS run installs."
+    else
+      echo "SKIPPED: test-execution CI workflow (--no-test-workflow). This repo's CI will NOT run tests."
+      echo "         Recorded skip (operational-rules.md, 'no silent failures'): add tests.yml or coverage.yml"
+      echo "         by hand, or re-run without --no-test-workflow, before trusting this repo's CI as a real gate."
+    fi
+  elif [ "$COVERAGE_GATE" -eq 1 ] || { [ -f ".github/workflows/coverage.yml" ] && [ ! -f ".github/workflows/tests.yml" ]; }; then
+    cp_scaffold "$SCAFFOLD_DIR/.github/workflows/coverage.yml.template" ".github/workflows/coverage.yml"
+    echo "note: coverage.yml gates patch coverage (default 100% of changed lines)."
+    echo "      It forces changed lines to be RUN by a test, not verified — pair with review."
+    if [ -f ".github/workflows/tests.yml" ]; then
+      if cmp -s "$SCAFFOLD_DIR/.github/workflows/tests.yml.template" ".github/workflows/tests.yml"; then
+        # Only remove the stale file once it's actually backed up (mirrors
+        # cp_scaffold's own `_backup "$dst" || return 0` policy): never delete
+        # without a recoverable copy, even if that means leaving both
+        # workflows in place (with the warning above) on the rare
+        # backup-cap exhaustion.
+        if _backup ".github/workflows/tests.yml"; then
+          rm -f ".github/workflows/tests.yml"
+          echo "removed:      .github/workflows/tests.yml (superseded by coverage.yml: running both would run tests twice)"
+        fi
+      else
+        echo "warning: .github/workflows/tests.yml also exists and looks customized, left in place."
+        echo "         Remove it by hand so tests don't run twice; coverage.yml already runs them."
+      fi
+    fi
+  else
+    # `tests.yml` is a common consumer-authored filename, and this path is
+    # cp_scaffold (scaffold-owned: refreshed/overwritten on every run). On a
+    # FIRST install that collision is invisible unless we say so: a project
+    # that already had its own hand-written tests.yml would otherwise see it
+    # silently replaced (backed up, per cp_scaffold's policy, but with no
+    # explanation of why a file it didn't ask the scaffold to manage changed).
+    if [ -f ".github/workflows/tests.yml" ] && ! cmp -s "$SCAFFOLD_DIR/.github/workflows/tests.yml.template" ".github/workflows/tests.yml"; then
+      echo "warning: .github/workflows/tests.yml already exists and is not the scaffold's version."
+      echo "         tests.yml is a scaffold-claimed filename (install.sh treats it as scaffold-owned"
+      echo "         and refreshes it on every re-run); your version is backed up to .scaffold-bak."
+    fi
+    cp_scaffold "$SCAFFOLD_DIR/.github/workflows/tests.yml.template" ".github/workflows/tests.yml"
+    echo "note: tests.yml runs pytest/vitest on every PR/push with no coverage threshold."
+    echo "      Add --coverage-gate for the patch-coverage strictness layer on top."
+  fi
+
+  # Final state for the caller's summary line: read back from disk rather
+  # than the flags alone, so an upgrade that already had one file installed
+  # (independent of THIS run's flags) is reported accurately. TEST_CI_STATE is
+  # a deliberate global: install.sh (which sources this file) reads it after
+  # calling this function, but shellcheck lints install-lib.sh on its own and
+  # can't see that cross-file use.
+  # shellcheck disable=SC2034
+  if [ -f ".github/workflows/coverage.yml" ]; then
+    TEST_CI_STATE="tests + patch-coverage gate via coverage.yml"
+  elif [ -f ".github/workflows/tests.yml" ]; then
+    TEST_CI_STATE="tests run in CI via tests.yml"
+  elif [ "$NO_TEST_WORKFLOW" -eq 1 ]; then
+    TEST_CI_STATE="NO test execution in CI (--no-test-workflow given)"
+  else
+    TEST_CI_STATE="NO test execution in CI (no workflow installed)"
+  fi
+}

--- a/install.sh
+++ b/install.sh
@@ -15,9 +15,22 @@
 #   install.sh --gitleaks-hook # also install opt-in local gitleaks pre-commit pass
 #   install.sh --gitleaks-ci # also install the gitleaks CI workflow (unskippable gate)
 #   install.sh --all-langs  # install every language's forbidden-pattern file
-#   install.sh --coverage-gate # also install the opt-in CI patch-coverage gate
+#   install.sh --coverage-gate # install the patch-coverage gate INSTEAD of the
+#                            # plain tests.yml (tests still run, plus a stricter
+#                            # check on top, see below)
+#   install.sh --no-test-workflow # opt out of installing a test-execution CI
+#                            # workflow at all (records a loud skip; for repos
+#                            # that genuinely cannot run tests in CI)
 #   install.sh --no-install # detect missing tools but never auto-run a package manager
 #   install.sh --help       # show this help
+#
+# Test execution in CI is DEFAULT-ON (#97): a plain install writes
+# `.github/workflows/tests.yml` so pytest/vitest run on every PR/push, no
+# coverage threshold. `--coverage-gate` swaps that for `.github/workflows/coverage.yml`
+# (same tests, plus a diff-cover patch-coverage gate) rather than installing both,
+# never both, so a repo's tests never run twice in the same CI run. Only
+# `--no-test-workflow` leaves a repo with no test execution in CI, and it says so
+# loudly in the summary below, per the "record every skip" rule.
 #
 # On re-run (upgrade): scaffold-owned code (the hook, .githooks/lib/*, CI
 # workflows) is REFRESHED when it differs from the shipped version, so security
@@ -42,6 +55,7 @@ GITLEAKS_HOOK=0
 GITLEAKS_CI=0
 ALL_LANGS=0
 COVERAGE_GATE=0
+NO_TEST_WORKFLOW=0
 NO_INSTALL=0
 
 for arg in "$@"; do
@@ -59,8 +73,9 @@ for arg in "$@"; do
     --gitleaks-ci) GITLEAKS_CI=1 ;;
     --all-langs)  ALL_LANGS=1 ;;
     --coverage-gate) COVERAGE_GATE=1 ;;
+    --no-test-workflow) NO_TEST_WORKFLOW=1 ;;
     --no-install) NO_INSTALL=1 ;;
-    --help|-h)    sed -n '2,26p' "$0"; exit 0 ;;
+    --help|-h)    sed -n '2,43p' "$0"; exit 0 ;;
     *) echo "error: unknown argument: $arg" >&2; exit 1 ;;
   esac
 done
@@ -367,14 +382,66 @@ if [ "$GITLEAKS_CI" -eq 1 ]; then
   echo "note: gitleaks.yml is the unskippable CI secret scan (runs even without --no-verify locally)."
 fi
 
-# Opt-in CI patch-coverage gate (--coverage-gate). Fails a PR when CHANGED lines
-# ship untested (diff-cover). Kept opt-in: it forces tests on new code, which is
-# a policy choice a team must make deliberately. It gates EXECUTION of changed
-# lines, not assertion quality — see RECOMMENDATIONS.md.
-if [ "$COVERAGE_GATE" -eq 1 ]; then
+# Test-execution CI workflow (#97): DEFAULT-ON, exactly one of two shapes, plus
+# a recorded opt-out. A default install used to produce lint-only CI (green
+# checks with zero tests ever executing), which is the bug this closes. Three
+# end states, decided in this order:
+#
+#   1. --no-test-workflow -> install NEITHER workflow. The one way a repo ends
+#      up with no test execution in CI, and it must say so loudly (below), per
+#      operational-rules.md's "record every skip".
+#   2. --coverage-gate (or coverage.yml already on disk from a prior run) ->
+#      install coverage.yml, which already runs the tests AND gates patch
+#      coverage. It gates EXECUTION of changed lines, not assertion quality;
+#      see RECOMMENDATIONS.md.
+#   3. default -> install tests.yml: pytest/vitest run on every PR/push, no
+#      coverage threshold.
+#
+# Never both: coverage.yml already runs the tests, so installing tests.yml
+# alongside it would run the suite twice for the same push/PR. If an upgrade
+# adds --coverage-gate on top of a prior default install, the now-redundant
+# tests.yml (if untouched since install) is retired rather than left to double-run.
+if [ "$NO_TEST_WORKFLOW" -eq 1 ]; then
+  if [ "$COVERAGE_GATE" -eq 1 ]; then
+    echo "warning: --no-test-workflow overrides --coverage-gate: neither tests.yml nor coverage.yml will be installed."
+  fi
+  if [ -f ".github/workflows/tests.yml" ] || [ -f ".github/workflows/coverage.yml" ]; then
+    echo "note: an existing tests.yml/coverage.yml was left in place. --no-test-workflow only skips a NEW install, it does not remove one."
+  fi
+  echo "SKIPPED: test-execution CI workflow (--no-test-workflow). This repo's CI will NOT run tests."
+  echo "         Recorded skip (operational-rules.md, 'no silent failures'): add tests.yml or coverage.yml"
+  echo "         by hand, or re-run without --no-test-workflow, before trusting this repo's CI as a real gate."
+elif [ "$COVERAGE_GATE" -eq 1 ] || { [ -f ".github/workflows/coverage.yml" ] && [ ! -f ".github/workflows/tests.yml" ]; }; then
   cp_scaffold "$SCAFFOLD_DIR/.github/workflows/coverage.yml.template" ".github/workflows/coverage.yml"
   echo "note: coverage.yml gates patch coverage (default 100% of changed lines)."
   echo "      It forces changed lines to be RUN by a test, not verified — pair with review."
+  if [ -f ".github/workflows/tests.yml" ]; then
+    if cmp -s "$SCAFFOLD_DIR/.github/workflows/tests.yml.template" ".github/workflows/tests.yml"; then
+      _backup ".github/workflows/tests.yml" || true
+      rm -f ".github/workflows/tests.yml"
+      echo "removed:      .github/workflows/tests.yml (superseded by coverage.yml: running both would run tests twice)"
+    else
+      echo "warning: .github/workflows/tests.yml also exists and looks customized, left in place."
+      echo "         Remove it by hand so tests don't run twice; coverage.yml already runs them."
+    fi
+  fi
+else
+  cp_scaffold "$SCAFFOLD_DIR/.github/workflows/tests.yml.template" ".github/workflows/tests.yml"
+  echo "note: tests.yml runs pytest/vitest on every PR/push with no coverage threshold."
+  echo "      Add --coverage-gate for the patch-coverage strictness layer on top."
+fi
+
+# Final state for the summary line below: read back from disk rather than the
+# flags alone, so an upgrade that already had one file installed (independent
+# of THIS run's flags) is reported accurately.
+if [ -f ".github/workflows/coverage.yml" ]; then
+  TEST_CI_STATE="tests + patch-coverage gate via coverage.yml"
+elif [ -f ".github/workflows/tests.yml" ]; then
+  TEST_CI_STATE="tests run in CI via tests.yml"
+elif [ "$NO_TEST_WORKFLOW" -eq 1 ]; then
+  TEST_CI_STATE="NO test execution in CI (--no-test-workflow given)"
+else
+  TEST_CI_STATE="NO test execution in CI (no workflow installed)"
 fi
 
 # Wire the hook — preserve existing core.hooksPath if already set (e.g. Husky).
@@ -395,6 +462,7 @@ fi
 
 echo ""
 echo "Done (mode: $MODE)."
+echo "CI test state: $TEST_CI_STATE"
 
 # Post-install toolchain check — the scaffold ships CONFIGS and ENFORCEMENT, but
 # the actual tools (ruff/eslint/tsc/prettier/test runner) are project deps. That

--- a/install.sh
+++ b/install.sh
@@ -382,67 +382,11 @@ if [ "$GITLEAKS_CI" -eq 1 ]; then
   echo "note: gitleaks.yml is the unskippable CI secret scan (runs even without --no-verify locally)."
 fi
 
-# Test-execution CI workflow (#97): DEFAULT-ON, exactly one of two shapes, plus
-# a recorded opt-out. A default install used to produce lint-only CI (green
-# checks with zero tests ever executing), which is the bug this closes. Three
-# end states, decided in this order:
-#
-#   1. --no-test-workflow -> install NEITHER workflow. The one way a repo ends
-#      up with no test execution in CI, and it must say so loudly (below), per
-#      operational-rules.md's "record every skip".
-#   2. --coverage-gate (or coverage.yml already on disk from a prior run) ->
-#      install coverage.yml, which already runs the tests AND gates patch
-#      coverage. It gates EXECUTION of changed lines, not assertion quality;
-#      see RECOMMENDATIONS.md.
-#   3. default -> install tests.yml: pytest/vitest run on every PR/push, no
-#      coverage threshold.
-#
-# Never both: coverage.yml already runs the tests, so installing tests.yml
-# alongside it would run the suite twice for the same push/PR. If an upgrade
-# adds --coverage-gate on top of a prior default install, the now-redundant
-# tests.yml (if untouched since install) is retired rather than left to double-run.
-if [ "$NO_TEST_WORKFLOW" -eq 1 ]; then
-  if [ "$COVERAGE_GATE" -eq 1 ]; then
-    echo "warning: --no-test-workflow overrides --coverage-gate: neither tests.yml nor coverage.yml will be installed."
-  fi
-  if [ -f ".github/workflows/tests.yml" ] || [ -f ".github/workflows/coverage.yml" ]; then
-    echo "note: an existing tests.yml/coverage.yml was left in place. --no-test-workflow only skips a NEW install, it does not remove one."
-  fi
-  echo "SKIPPED: test-execution CI workflow (--no-test-workflow). This repo's CI will NOT run tests."
-  echo "         Recorded skip (operational-rules.md, 'no silent failures'): add tests.yml or coverage.yml"
-  echo "         by hand, or re-run without --no-test-workflow, before trusting this repo's CI as a real gate."
-elif [ "$COVERAGE_GATE" -eq 1 ] || { [ -f ".github/workflows/coverage.yml" ] && [ ! -f ".github/workflows/tests.yml" ]; }; then
-  cp_scaffold "$SCAFFOLD_DIR/.github/workflows/coverage.yml.template" ".github/workflows/coverage.yml"
-  echo "note: coverage.yml gates patch coverage (default 100% of changed lines)."
-  echo "      It forces changed lines to be RUN by a test, not verified — pair with review."
-  if [ -f ".github/workflows/tests.yml" ]; then
-    if cmp -s "$SCAFFOLD_DIR/.github/workflows/tests.yml.template" ".github/workflows/tests.yml"; then
-      _backup ".github/workflows/tests.yml" || true
-      rm -f ".github/workflows/tests.yml"
-      echo "removed:      .github/workflows/tests.yml (superseded by coverage.yml: running both would run tests twice)"
-    else
-      echo "warning: .github/workflows/tests.yml also exists and looks customized, left in place."
-      echo "         Remove it by hand so tests don't run twice; coverage.yml already runs them."
-    fi
-  fi
-else
-  cp_scaffold "$SCAFFOLD_DIR/.github/workflows/tests.yml.template" ".github/workflows/tests.yml"
-  echo "note: tests.yml runs pytest/vitest on every PR/push with no coverage threshold."
-  echo "      Add --coverage-gate for the patch-coverage strictness layer on top."
-fi
-
-# Final state for the summary line below: read back from disk rather than the
-# flags alone, so an upgrade that already had one file installed (independent
-# of THIS run's flags) is reported accurately.
-if [ -f ".github/workflows/coverage.yml" ]; then
-  TEST_CI_STATE="tests + patch-coverage gate via coverage.yml"
-elif [ -f ".github/workflows/tests.yml" ]; then
-  TEST_CI_STATE="tests run in CI via tests.yml"
-elif [ "$NO_TEST_WORKFLOW" -eq 1 ]; then
-  TEST_CI_STATE="NO test execution in CI (--no-test-workflow given)"
-else
-  TEST_CI_STATE="NO test execution in CI (no workflow installed)"
-fi
+# Test-execution CI workflow (#97): DEFAULT-ON, exactly one of two shapes,
+# plus a recorded opt-out (--no-test-workflow). See install-lib.sh's
+# install_test_workflow_ci for the full decision order and rationale; it sets
+# TEST_CI_STATE for the summary near the end of this script.
+install_test_workflow_ci
 
 # Wire the hook — preserve existing core.hooksPath if already set (e.g. Husky).
 # Use `git rev-parse --git-dir` so this works in worktrees (where .git is a

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     ".scaffold.toml.template",
     ".github/dependabot.yml.template",
     ".github/workflows/lint.yml.template",
+    ".github/workflows/tests.yml.template",
     ".github/workflows/coverage.yml.template",
     ".github/workflows/gitleaks.yml.template",
     ".github/workflows/dependency-review.yml.template"

--- a/tests/cases/16-coverage-gate.sh
+++ b/tests/cases/16-coverage-gate.sh
@@ -57,7 +57,13 @@ _run_step_with_fake() {
   fi
   printf '%s\n' "$body" >"$d/step.sh"
   local rc=0
-  ( PATH="$d:$PATH" bash -e "$d/step.sh" ) >/dev/null 2>&1 || rc=$?
+  # cd into the SAME empty dir the fake binaries live in, not $WORK, which the
+  # driver's bootstrap seeds with a throwaway pyproject.toml (#96/#97). Running
+  # from an empty dir makes the body's `[ -f pyproject.toml ]` project-install
+  # guard evaluate false on its own, so the real `pip install -e .` it gates
+  # never fires here; no per-line filtering of those calls is needed on top of
+  # the unconditional `pip install pytest…` line _run_block already drops.
+  ( cd "$d" && PATH="$d:$PATH" bash -e "$d/step.sh" ) >/dev/null 2>&1 || rc=$?
   rm -rf "$d"
   printf '%s' "$rc"
 }

--- a/tests/cases/19-test-workflow.sh
+++ b/tests/cases/19-test-workflow.sh
@@ -201,7 +201,123 @@ _check_vitest_gating() {
 _check_vitest_gating tests "$TESTS_TPL" 2 present
 _check_vitest_gating coverage "$COV_TPL" 1 frontend
 
-# --- (G) tests.yml.template is a valid GitHub Actions workflow -------------
+# --- (G) "Install project" step: the requirements-loop exit-code bug and the
+#     installable-pyproject guard. Lifts the REAL step body (same technique as
+#     (F) above and cases/16) and runs it under `bash -e` with a fake `pip`
+#     that logs its own argv instead of touching the network, so both the
+#     step's EXIT CODE and WHICH pip commands it ran are observable.
+#
+# The bug this regresses: the requirements loop's body used to be
+# `[ -f "$req" ] && pip install -r "$req"`, whose own exit status (1, from the
+# failed `[ -f ]` test) becomes the exit status of the whole step under
+# `bash -e` whenever the LAST candidate file is absent, which is nearly
+# always, so the default pytest job would fail for virtually every Python
+# consumer even though nothing went wrong. Scenario (c) below is that exact case.
+_install_project_body() {
+  awk -v step="      - name: Install project (so tests importing the package can collect)" '
+    $0 == step { found = 1 }
+    found && /run: \|/ { inrun = 1; next }
+    inrun {
+      if ($0 ~ /^[[:space:]]*$/) next
+      if ($0 !~ /^          /) exit
+      sub(/^          /, "")
+      print
+    }
+  ' "$TESTS_TPL"
+}
+
+# _run_with_fake_pip BODY [FIXTURE_FILE=CONTENT ...]: writes each fixture
+# file, then runs BODY under `bash -e` from that same directory with a fake
+# `pip` on PATH that appends its argv to pip.log and exits 0. Sets
+# INSTALL_RC (the step's exit code) and INSTALL_LOG (every pip invocation,
+# empty if pip was never called) as globals, since a shell function can only
+# return a single exit-code integer.
+_run_with_fake_pip() {
+  local body=$1; shift
+  local d fixture path content
+  d=$(mktemp -d)
+  mkdir -p "$d/bin"
+  {
+    printf '#!/bin/sh\n'
+    printf 'echo "pip $*" >>"%s/pip.log"\n' "$d"
+    printf 'exit 0\n'
+  } >"$d/bin/pip"
+  chmod +x "$d/bin/pip"
+  for fixture in "$@"; do
+    path=${fixture%%=*}
+    content=${fixture#*=}
+    printf '%s\n' "$content" >"$d/$path"
+  done
+  printf '%s\n' "$body" >"$d/step.sh"
+  ( cd "$d" && PATH="$d/bin:$PATH" bash -e "$d/step.sh" ) >/dev/null 2>&1
+  INSTALL_RC=$?
+  INSTALL_LOG=$(cat "$d/pip.log" 2>/dev/null || true)
+  rm -rf "$d"
+}
+
+IBODY=$(_install_project_body)
+if [ -z "$IBODY" ]; then
+  echo "  ✗ could not lift the 'Install project' step out of tests.yml.template (step renamed?)"
+  FAIL=$((FAIL + 1))
+else
+  # (a) An installable pyproject.toml alone: exits 0, and DOES run the
+  #     editable install (no dev extra declared, so plain `pip install -e .`).
+  _run_with_fake_pip "$IBODY" 'pyproject.toml=[project]
+name = "x"
+version = "0.1"
+'
+  if [ "$INSTALL_RC" -eq 0 ] && printf '%s' "$INSTALL_LOG" | grep -qF "pip install -e ."; then
+    echo "  ✓ (a) installable pyproject.toml alone: exits 0 and runs the editable install"
+    PASS=$((PASS + 1))
+  else
+    echo "  ✗ (a) installable pyproject.toml: rc=$INSTALL_RC log=[$INSTALL_LOG]"
+    FAIL=$((FAIL + 1))
+  fi
+
+  # (b) requirements.txt alone, no pyproject.toml/setup.py at all: exits 0,
+  #     skips the editable install, and DOES install the requirements file.
+  _run_with_fake_pip "$IBODY" 'requirements.txt=pytest==9.1.1
+'
+  if [ "$INSTALL_RC" -eq 0 ] \
+     && printf '%s' "$INSTALL_LOG" | grep -qF "pip install -r requirements.txt" \
+     && ! printf '%s' "$INSTALL_LOG" | grep -qF "install -e"; then
+    echo "  ✓ (b) requirements.txt alone: exits 0 and installs it, no editable install attempted"
+    PASS=$((PASS + 1))
+  else
+    echo "  ✗ (b) requirements.txt alone: rc=$INSTALL_RC log=[$INSTALL_LOG]"
+    FAIL=$((FAIL + 1))
+  fi
+
+  # (c) THE REGRESSION CASE: nothing at all (no pyproject.toml, no setup.py,
+  #     no requirements file). Every candidate in the loop is absent, so under
+  #     the old `[ -f "$req" ] && pip install -r "$req"` body this exited 1
+  #     even though the step correctly did nothing. Must exit 0 with no pip
+  #     invocation at all.
+  _run_with_fake_pip "$IBODY"
+  if [ "$INSTALL_RC" -eq 0 ] && [ -z "$INSTALL_LOG" ]; then
+    echo "  ✓ (c) nothing present: exits 0 with no pip invocation (regression fixed)"
+    PASS=$((PASS + 1))
+  else
+    echo "  ✗ (c) nothing present: rc=$INSTALL_RC (want 0) log=[$INSTALL_LOG] (want empty)"
+    FAIL=$((FAIL + 1))
+  fi
+
+  # (d) A pyproject.toml that holds only tool config (no [project] table) and
+  #     no setup.py: exits 0, and must NOT attempt an editable install; there
+  #     is no build backend for `pip install -e .` to target.
+  _run_with_fake_pip "$IBODY" 'pyproject.toml=[tool.pytest.ini_options]
+testpaths = ["tests"]
+'
+  if [ "$INSTALL_RC" -eq 0 ] && ! printf '%s' "$INSTALL_LOG" | grep -qF "install -e"; then
+    echo "  ✓ (d) tool-config-only pyproject.toml: exits 0, editable install correctly skipped"
+    PASS=$((PASS + 1))
+  else
+    echo "  ✗ (d) tool-config-only pyproject.toml: rc=$INSTALL_RC log=[$INSTALL_LOG]"
+    FAIL=$((FAIL + 1))
+  fi
+fi
+
+# --- (H) tests.yml.template is a valid GitHub Actions workflow -------------
 if command -v actionlint >/dev/null 2>&1; then
   G=$(mktemp -d); mkdir -p "$G/.github/workflows"
   cp "$TESTS_TPL" "$G/.github/workflows/tests.yml"

--- a/tests/cases/19-test-workflow.sh
+++ b/tests/cases/19-test-workflow.sh
@@ -1,0 +1,221 @@
+# shellcheck shell=bash
+# cases/19-test-workflow.sh: default-on test-execution CI workflow (#97) and
+# the two robustness fixes it shares with coverage.yml (#96: project install
+# before pytest, vitest gated on being declared rather than package.json
+# merely existing). Sourced into the driver's shell, so the globals
+# (PASS/FAIL/HOOK_OUT/SCAFFOLD_DIR/WORK) and helpers are already in scope. Its
+# own file rather than appended to cases/09 or cases/16, both near the
+# 500-line cap.
+#
+# Every assertion here is mutation-shaped: a plain install must WRITE
+# tests.yml (removing the install.sh call site would fail it), --coverage-gate
+# must yield coverage.yml WITHOUT the plain tests.yml (reverting the
+# priority-order fix would fail it), and --no-test-workflow must both skip the
+# workflow AND print the recorded-skip line the "record every skip" rule
+# demands (removing either half fails it).
+
+echo "cases/19: default-on test workflow (#97) + robustness fixes (#96)"
+
+TESTS_TPL="$SCAFFOLD_DIR/.github/workflows/tests.yml.template"
+COV_TPL="$SCAFFOLD_DIR/.github/workflows/coverage.yml.template"
+
+# --- (A) default install writes tests.yml, not coverage.yml ----------------
+A=$(mktemp -d)
+( cd "$A" && git init --quiet && echo 'name = "x"' >pyproject.toml \
+  && "$SCAFFOLD_DIR/install.sh" --python --no-verify ) >"$HOOK_OUT" 2>&1
+if [ -f "$A/.github/workflows/tests.yml" ] \
+   && cmp -s "$TESTS_TPL" "$A/.github/workflows/tests.yml" \
+   && [ ! -f "$A/.github/workflows/coverage.yml" ] \
+   && grep -qF "CI test state: tests run in CI via tests.yml" "$HOOK_OUT"; then
+  echo "  ✓ a plain install writes tests.yml and reports the state (#97)"
+  PASS=$((PASS + 1))
+else
+  echo "  ✗ a plain install did not write tests.yml as expected"
+  sed 's/^/      /' "$HOOK_OUT"
+  FAIL=$((FAIL + 1))
+fi
+rm -rf "$A"
+
+# --- (B) --no-test-workflow installs neither AND records a loud skip -------
+B=$(mktemp -d)
+( cd "$B" && git init --quiet && echo 'name = "x"' >pyproject.toml \
+  && "$SCAFFOLD_DIR/install.sh" --python --no-verify --no-test-workflow ) >"$HOOK_OUT" 2>&1
+if [ ! -f "$B/.github/workflows/tests.yml" ] && [ ! -f "$B/.github/workflows/coverage.yml" ] \
+   && grep -qF "SKIPPED: test-execution CI workflow" "$HOOK_OUT" \
+   && grep -qF "CI test state: NO test execution in CI (--no-test-workflow given)" "$HOOK_OUT"; then
+  echo "  ✓ --no-test-workflow installs neither workflow and records a loud skip"
+  PASS=$((PASS + 1))
+else
+  echo "  ✗ --no-test-workflow did not skip + record as expected"
+  sed 's/^/      /' "$HOOK_OUT"
+  FAIL=$((FAIL + 1))
+fi
+rm -rf "$B"
+
+# --- (C) --coverage-gate yields coverage.yml WITHOUT the plain tests.yml ---
+C=$(mktemp -d)
+( cd "$C" && git init --quiet && echo 'name = "x"' >pyproject.toml \
+  && "$SCAFFOLD_DIR/install.sh" --python --no-verify --coverage-gate ) >"$HOOK_OUT" 2>&1
+if [ -f "$C/.github/workflows/coverage.yml" ] && [ ! -f "$C/.github/workflows/tests.yml" ] \
+   && grep -qF "CI test state: tests + patch-coverage gate via coverage.yml" "$HOOK_OUT"; then
+  echo "  ✓ --coverage-gate installs coverage.yml, never alongside tests.yml"
+  PASS=$((PASS + 1))
+else
+  echo "  ✗ --coverage-gate did not produce coverage.yml-without-tests.yml"
+  sed 's/^/      /' "$HOOK_OUT"
+  FAIL=$((FAIL + 1))
+fi
+rm -rf "$C"
+
+# --- (D) upgrading a default install to --coverage-gate retires the now- ---
+#         redundant tests.yml (backed up, not silently deleted) instead of
+#         leaving both in place to double-run the suite.
+D=$(mktemp -d)
+( cd "$D" && git init --quiet && echo 'name = "x"' >pyproject.toml \
+  && "$SCAFFOLD_DIR/install.sh" --python --no-verify \
+  && "$SCAFFOLD_DIR/install.sh" --python --no-verify --coverage-gate ) >"$HOOK_OUT" 2>&1
+if [ -f "$D/.github/workflows/coverage.yml" ] && [ ! -f "$D/.github/workflows/tests.yml" ] \
+   && [ -f "$D/.github/workflows/tests.yml.scaffold-bak" ] \
+   && grep -qF "removed:      .github/workflows/tests.yml" "$HOOK_OUT"; then
+  echo "  ✓ adding --coverage-gate on a later run retires a prior tests.yml (backed up)"
+  PASS=$((PASS + 1))
+else
+  echo "  ✗ upgrade to --coverage-gate did not retire the stale tests.yml as expected"
+  sed 's/^/      /' "$HOOK_OUT"
+  FAIL=$((FAIL + 1))
+fi
+rm -rf "$D"
+
+# --- (E) --no-test-workflow overriding an explicit --coverage-gate is noted,
+#         not silently one-or-the-other.
+E=$(mktemp -d)
+( cd "$E" && git init --quiet && echo 'name = "x"' >pyproject.toml \
+  && "$SCAFFOLD_DIR/install.sh" --python --no-verify --coverage-gate --no-test-workflow ) >"$HOOK_OUT" 2>&1
+if [ ! -f "$E/.github/workflows/coverage.yml" ] && [ ! -f "$E/.github/workflows/tests.yml" ] \
+   && grep -qF "warning: --no-test-workflow overrides --coverage-gate" "$HOOK_OUT"; then
+  echo "  ✓ --no-test-workflow overrides --coverage-gate, visibly"
+  PASS=$((PASS + 1))
+else
+  echo "  ✗ combining both flags did not behave / warn as expected"
+  sed 's/^/      /' "$HOOK_OUT"
+  FAIL=$((FAIL + 1))
+fi
+rm -rf "$E"
+
+# --- (F) vitest job gating: lift the detect step's REAL shell body out of the
+#     shipped YAML (same technique as cases/16) and run it against fixture
+#     package.json files. Asserting on file TEXT ("grep for present=true")
+#     would pass against a rewrite that reintroduced the hole (gating on
+#     package.json existing) by another route; running the body cannot.
+# $1 = template file, $2 = which `- id: detect` step to lift (1-indexed; both
+# templates have exactly one vitest-relevant detect step: in
+# tests.yml.template it's the 2nd (the vitest job's, after the pytest job's);
+# in coverage.yml.template it's the only one and covers both stacks at once).
+_vitest_detect_body() {
+  local tpl=$1 target=$2
+  awk -v target="$target" '
+    /- id: detect/ { seen++ }
+    seen == target && /run: \|/ { inrun = 1; next }
+    inrun {
+      if ($0 ~ /^[[:space:]]*$/) next
+      if ($0 !~ /^          /) exit
+      sub(/^          /, "")
+      print
+    }
+  ' "$tpl"
+}
+
+_run_detect_with_pkg() {
+  # $1 = step body, $2 = package.json content ("" = no package.json at all).
+  local body=$1 pkg=$2
+  local d out result
+  d=$(mktemp -d)
+  if [ -n "$pkg" ]; then
+    printf '%s\n' "$pkg" >"$d/package.json"
+  fi
+  out=$(mktemp)
+  printf '%s\n' "$body" >"$d/step.sh"
+  ( cd "$d" && GITHUB_OUTPUT="$out" bash -e "$d/step.sh" ) >/dev/null 2>&1 || true
+  result=$(cat "$out")
+  rm -rf "$d" "$out"
+  printf '%s' "$result"
+}
+
+PKG_NO_VITEST='{"name":"x","devDependencies":{"eslint":"9.0.0"}}'
+PKG_WITH_VITEST_DEP='{"name":"x","devDependencies":{"vitest":"^2.0.0"}}'
+PKG_WITH_VITEST_SCRIPT='{"name":"x","scripts":{"test":"vitest run"}}'
+
+# _check_vitest_gating LABEL TEMPLATE STEP-INDEX OUTPUT-KEY: a function
+# rather than a `for` loop over packed strings, so it never touches this
+# shell's positional parameters (this file is SOURCED into the shared driver
+# shell, not run as its own process). tests.yml's vitest job writes
+# `present=true`; coverage.yml's single combined detect step writes
+# `frontend=true` for the same condition.
+_check_vitest_gating() {
+  local label=$1 tpl=$2 target=$3 key=$4
+  local BODY R
+  BODY=$(_vitest_detect_body "$tpl" "$target")
+  if [ -z "$BODY" ]; then
+    echo "  ✗ could not lift the vitest detect step out of $label (step renamed?)"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
+  R=$(_run_detect_with_pkg "$BODY" "")
+  if ! printf '%s' "$R" | grep -qF "${key}=true"; then
+    echo "  ✓ [$label] no package.json at all: vitest job stays gated off"
+    PASS=$((PASS + 1))
+  else
+    echo "  ✗ [$label] no package.json still produced: $R"
+    FAIL=$((FAIL + 1))
+  fi
+
+  R=$(_run_detect_with_pkg "$BODY" "$PKG_NO_VITEST")
+  if ! printf '%s' "$R" | grep -qF "${key}=true"; then
+    echo "  ✓ [$label] package.json WITHOUT vitest declared stays gated off (#96)"
+    PASS=$((PASS + 1))
+  else
+    echo "  ✗ [$label] package.json without vitest still set: $R"
+    FAIL=$((FAIL + 1))
+  fi
+
+  R=$(_run_detect_with_pkg "$BODY" "$PKG_WITH_VITEST_DEP")
+  if printf '%s' "$R" | grep -qF "${key}=true"; then
+    echo "  ✓ [$label] vitest in devDependencies is detected"
+    PASS=$((PASS + 1))
+  else
+    echo "  ✗ [$label] vitest in devDependencies was NOT detected"
+    FAIL=$((FAIL + 1))
+  fi
+
+  R=$(_run_detect_with_pkg "$BODY" "$PKG_WITH_VITEST_SCRIPT")
+  if printf '%s' "$R" | grep -qF "${key}=true"; then
+    echo "  ✓ [$label] a scripts.test invoking vitest is detected"
+    PASS=$((PASS + 1))
+  else
+    echo "  ✗ [$label] scripts.test invoking vitest was NOT detected"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+_check_vitest_gating tests "$TESTS_TPL" 2 present
+_check_vitest_gating coverage "$COV_TPL" 1 frontend
+
+# --- (G) tests.yml.template is a valid GitHub Actions workflow -------------
+if command -v actionlint >/dev/null 2>&1; then
+  G=$(mktemp -d); mkdir -p "$G/.github/workflows"
+  cp "$TESTS_TPL" "$G/.github/workflows/tests.yml"
+  if ( cd "$G" && actionlint -shellcheck= -pyflakes= .github/workflows/tests.yml ) >"$HOOK_OUT" 2>&1; then
+    echo "  ✓ tests.yml.template is a valid GitHub Actions workflow"
+    PASS=$((PASS + 1))
+  else
+    echo "  ✗ tests.yml.template failed actionlint"
+    sed 's/^/      /' "$HOOK_OUT"
+    FAIL=$((FAIL + 1))
+  fi
+  rm -rf "$G"
+else
+  echo "  - skipped tests.yml validation (actionlint not installed)"
+fi
+
+reset_repo

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -53,7 +53,8 @@ for case_file in \
   "$HERE/cases/15-local-checks.sh" \
   "$HERE/cases/16-coverage-gate.sh" \
   "$HERE/cases/17-whole-tree-configs.sh" \
-  "$HERE/cases/18-doctor.sh"; do
+  "$HERE/cases/18-doctor.sh" \
+  "$HERE/cases/19-test-workflow.sh"; do
   # shellcheck source=/dev/null
   . "$case_file"
 done

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -137,6 +137,9 @@ done
 # shipped (empty) template; a team that has recorded overrides keeps it.
 remove_if_unmodified ".scaffold.toml"                "$SCAFFOLD_DIR/.scaffold.toml.template"
 remove_if_unmodified ".github/workflows/lint.yml"    "$SCAFFOLD_DIR/.github/workflows/lint.yml.template"
+# Default-on test-execution workflow (only present unless installed with
+# --no-test-workflow, or superseded by --coverage-gate's coverage.yml below).
+remove_if_unmodified ".github/workflows/tests.yml"   "$SCAFFOLD_DIR/.github/workflows/tests.yml.template"
 # The local.d README only — never the directory. Anything else in there is a
 # project's own check scripts, which the scaffold neither wrote nor owns; the
 # rmdir sweep below clears the directory iff it is empty. Not touched by --all
@@ -154,7 +157,8 @@ remove_if_unmodified ".cursor/hooks.json"            "$SCAFFOLD_DIR/cursor-hooks
 remove_if_unmodified ".githooks/commit-msg"          "$SCAFFOLD_DIR/githooks/commit-msg.template"
 # Opt-in local gitleaks pass (only present if installed with --gitleaks-hook).
 remove_if_unmodified ".githooks/lib/check-gitleaks"  "$SCAFFOLD_DIR/githooks/lib/check-gitleaks.template"
-# Opt-in CI patch-coverage gate (only present if installed with --coverage-gate).
+# Opt-in CI patch-coverage gate (only present if installed with --coverage-gate;
+# installed INSTEAD OF tests.yml above, so at most one of the two exists).
 remove_if_unmodified ".github/workflows/coverage.yml" "$SCAFFOLD_DIR/.github/workflows/coverage.yml.template"
 # Opt-in gitleaks CI workflow (only present if installed with --gitleaks-ci).
 remove_if_unmodified ".github/workflows/gitleaks.yml" "$SCAFFOLD_DIR/.github/workflows/gitleaks.yml.template"


### PR DESCRIPTION
## What changed

- New `.github/workflows/tests.yml.template`: a plain pytest + vitest workflow that runs on every PR/push with no coverage threshold, each job gated on its stack actually being present.
- `install.sh` installs `tests.yml` by **default**. `--coverage-gate` swaps that for `coverage.yml` instead of installing both (never both, so tests never run twice in the same CI run); an upgrade that adds `--coverage-gate` on top of a prior default install retires the now-redundant `tests.yml` (backed up first, not silently deleted).
- New `--no-test-workflow` opt-out flag for a repo that genuinely cannot run tests in CI. It prints a loud recorded skip, per the "record every skip" rule.
- The installer's end-of-run summary now states plainly which of the three states the repo ended up in (`CI test state: ...`).
- `coverage.yml.template` gets the same two robustness fixes as the new template: the pytest job installs the project itself (`pip install -e ".[dev]"`, falling back to `pip install -e .`, plus `requirements*.txt`) before running tests, and the frontend job is gated on `vitest` actually being declared in `package.json` rather than merely on `package.json` existing.
- `package.json` "files" and `uninstall.sh` are updated to register/remove `tests.yml.template` alongside the existing workflow templates.
- `TECHNICAL.md` gets a new "Default-on test execution" section and a reworked Patch-coverage gate bullet; `README.md`'s flag list and Install section note the new default and `--no-test-workflow`; `CHANGELOG.md` records both changes under Unreleased.
- New `tests/cases/19-test-workflow.sh` mutation-proves all three install states plus the vitest/pytest gating fixes by lifting each template's detect-step shell body and running it against fixture `package.json` files (same technique as `cases/16`). Along the way it caught and fixed a latent isolation bug in `cases/16`: its step-body harness ran from the driver's shared `$WORK` dir (which the bootstrap seeds with a throwaway `pyproject.toml`), so the new coverage.yml project-install step attempted a real network `pip install` during that test; it now runs from the same empty temp dir as the fake tool binaries.

## Why

Quoting the issue's core argument: a default install produced lint-only CI, so "CI is green" meant only "nothing is malformed," never "nothing is broken," and test execution was the single most load-bearing check in the set while being the only one shipped default-off.

## End-state matrix

| Install command | Workflow installed | Tests run in CI? | Patch-coverage gate? |
|---|---|---|---|
| `install.sh` (default) | `tests.yml` | Yes | No |
| `install.sh --coverage-gate` | `coverage.yml` (instead of `tests.yml`) | Yes | Yes |
| `install.sh --no-test-workflow` | neither | No (loud recorded skip in the summary) | No |

## PROPOSED judgment calls

- **PROPOSED:** When `--coverage-gate` is added on a later run and a prior default-installed `tests.yml` is still byte-identical to the shipped template, retire it automatically (backed up via the existing `_backup` mechanism) rather than leaving both files in place. Alternative: only warn and require the user to delete it by hand, which is more conservative but reintroduces the "double-run tests" state issue #97 exists to close if the user misses the warning.
- **PROPOSED:** `--no-test-workflow` overrides `--coverage-gate` when both are passed together (with a visible warning), rather than treating it as a usage error. Alternative: `install.sh` could hard-error on the conflicting combination instead of picking a precedence order.
- **PROPOSED:** Detecting a project's `dev` extra for the pytest project-install step uses a `grep`-based heuristic (`[project.optional-dependencies]` header + a `dev =` key) rather than a real TOML parser, matching this repo's existing convention of grep-based config detection (see `install.sh`'s own pytest-config lookup). Alternative: shell out to `python -c "import tomllib"` for a real parse, which is more correct for edge cases (e.g. an inline table) but adds a Python-version dependency to a step that currently only needs `pip`.
- **PROPOSED:** vitest presence detection greps `package.json` for a literal `"vitest"` key or a `scripts.test` value containing `vitest`, rather than using `jq`. Alternative: use `jq` for a structurally correct check, but the rest of this repo's CI templates deliberately avoid a `jq` dependency in workflow bodies (only `install.sh`'s optional agent-precheck path uses it), so grep keeps the templates dependency-free.
- **PROPOSED:** New `tests/cases/19-test-workflow.sh` rather than extending `cases/09` or `cases/16`, per the file's own 500-line-cap culture (`09` is already at 436 lines). Alternative: split further into two files (one for install.sh state machine, one for vitest gating), which is more granular but adds another file to an already-long sourced list in `tests/run.sh`.
- **PROPOSED:** Fixed `cases/16`'s isolation bug (running step bodies from `$WORK` instead of an empty temp dir) as part of this PR rather than filing it separately, since my own change (the coverage.yml project-install step) is what exposed it and the fix is a two-line, narrowly-scoped change to that test file. Alternative: leave `cases/16` alone and instead filter out the new `pip install -e ...` lines in the step-body extraction, but that would have required matching arbitrary indentation levels and left the harness silently dependent on `$WORK` never gaining a real installable Python project in the future.

Fixes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)
