### PR TITLE
docs: fix stale check-script count and README pointers

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ If your project already uses Husky or lefthook, `install.sh` detects the existin
    .githooks/pre-commit
    ```
 
-Either way, the four `lib/check-*` scripts in `.githooks/lib/` are also runnable directly (`git ls-files | .githooks/lib/check-secrets`), so you can wire them into any orchestrator.
+Either way, the `lib/check-*` scripts in `.githooks/lib/` are also runnable directly (`git ls-files | .githooks/lib/check-secrets`), so you can wire them into any orchestrator.
 
 ## AI agent integration
 
@@ -206,6 +206,8 @@ git add some_module.py
 git commit -m "should be rejected"
 # → hook prints: ✗ some_module.py: Use structlog (or the project's logger), not print()
 ```
+
+Want to confirm the guardrails are actually wired up, not just present? Run `./scaffold-doctor.sh`; see [Check whether it's armed](./TECHNICAL.md#check-whether-its-armed) in TECHNICAL.md for what it checks.
 
 ## Platform notes
 

--- a/tests/cases/01-size-patterns.sh
+++ b/tests/cases/01-size-patterns.sh
@@ -154,8 +154,9 @@ printf 'h = %s\n' 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b
 git add sha.txt
 assert_passes "SHA-256 hash is not a false positive"
 
-# 10g. NEGATIVE: an UNQUOTED assignment stays uncaught by design — quoted-only;
-#      unquoted/env-var forms are the gitleaks layer's job (see README).
+# 10g. NEGATIVE: an UNQUOTED assignment stays uncaught by design, quoted-only;
+#      unquoted/env-var forms are the gitleaks layer's job (see TECHNICAL.md,
+#      Opt-in layers).
 printf 'api_key = %s\n' 'my_config_variable_name_here' >unq.txt
 git add unq.txt
 assert_passes "unquoted credential assignment is not flagged (quoted-only by design)"

--- a/tests/cases/11-npm-bundle.sh
+++ b/tests/cases/11-npm-bundle.sh
@@ -28,7 +28,8 @@ else
     #
     # The workflow glob is load-bearing: gitleaks.yml.template and
     # dependency-review.yml.template are "copy it in" templates the user applies
-    # by hand (README §gitleaks/§dependency-review; install.sh only names them),
+    # by hand (TECHNICAL.md's Opt-in layers section covers gitleaks and
+    # dependency-review; install.sh only names them),
     # so install.sh never READS them via $SCAFFOLD_DIR and the grep above can't
     # see them. Without this glob an npm/npx user silently lacks two security-CI
     # gates git-clone/Homebrew users get (audit B3). Globbing every


### PR DESCRIPTION
## Summary
- README's Husky/lefthook note said "the four `lib/check-*` scripts"; reworded to drop the hardcoded count so it can't go stale again.
- Retargeted two test-file comments (`tests/cases/01-size-patterns.sh`, `tests/cases/11-npm-bundle.sh`) that still said "see README" for content that now lives in TECHNICAL.md.
- Added a one-line scaffold-doctor teaser to README's "Verify it works" section, pointing at TECHNICAL.md's "Check whether it's armed" for detail.

Fixes #101

## Test plan
- [x] `./tests/run.sh` — 281 passed, 5 failed (the 5 failures are the pre-existing `@eslint/compat` environment gaps in `tests/cases/17-whole-tree-configs.sh`, unrelated to this change and being fixed separately; no new failures from these comment/doc-only edits)
- [x] `bash -n` on both edited test files confirms no syntax errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)