### PR TITLE
feat(doctor): detect half-installed paired artifacts (#96)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- **`scaffold-doctor.sh` detects half-installed paired artifacts (#96).** A
+  new "paired artifacts" section, and a matching end-of-run check in
+  `install.sh` itself, flag when only one half of a two-part guardrail is on
+  disk: `.coveragerc` without `.github/workflows/coverage.yml` (and the
+  inverse, on a Python project), a local gitleaks pre-commit pass without the
+  gitleaks CI workflow (and the inverse, which is a valid CI-only posture),
+  and the `tests.yml`/`coverage.yml` selection state from #97 (both installed
+  runs the suite twice; neither installed while `lint.yml` is present means
+  no test ever executes in CI). Genuine half-installs are gaps (affect
+  `scaffold-doctor.sh`'s exit status); deliberate or default-shaped states
+  are notes. The detection logic lives once in `install-lib.sh`'s
+  `check_paired_artifacts`, shared by both callers so the wording can't
+  drift between them. `install.sh`'s own reporting is advisory only and
+  never changes its exit status.
+
 ### Changed
 - **Test execution in CI is default-on (#97).** A plain `install.sh` run now
   installs `.github/workflows/tests.yml` (pytest/vitest, no coverage

--- a/TECHNICAL.md
+++ b/TECHNICAL.md
@@ -347,6 +347,33 @@ broken). Notes never affect the exit status. Exit `0` means no gaps, `1`
 means at least one guardrail is installed but not running, `2` means a usage
 error or "not a git repository".
 
+### Paired artifacts (half-installed guardrails)
+
+Some guardrails ship as two halves that only do anything together: a config
+file plus the CI workflow that reads it, or a local pre-commit pass plus the
+CI gate it defers to. An interrupted install, a later re-run without a flag,
+or a hand-copied file can leave only one half on disk, and nothing used to
+check again afterward (issue #96: a real downstream repo kept `.coveragerc`
+with no `.github/workflows/coverage.yml` for months, every PR green on
+`lint.yml` alone). `scaffold-doctor.sh`'s "paired artifacts" section, and
+`install.sh`'s own end-of-run summary (same detection, same wording, from
+`install-lib.sh`'s `check_paired_artifacts`), name three pairs:
+
+| Pair | Half missing | Severity |
+|---|---|---|
+| `.coveragerc` / `.github/workflows/coverage.yml` | `.coveragerc` present, `coverage.yml` absent | note (the common default: `.coveragerc` ships with every Python install regardless of `--coverage-gate`) |
+| `.coveragerc` / `.github/workflows/coverage.yml` | `coverage.yml` present, `.coveragerc` absent, on a Python project | gap (`--coverage-gate` writes both in the same run; only a later deletion produces this) |
+| local gitleaks hook (`.githooks/lib/check-gitleaks`) / `.github/workflows/gitleaks.yml` | hook present, CI absent | gap (the hook tells every commit that CI is the authoritative gate; there is none) |
+| local gitleaks hook / gitleaks CI | CI present, hook absent | note (CI-only is a valid, documented posture) |
+| `tests.yml` / `coverage.yml` | both present | note (both run the suite; wasteful, not silent) |
+| `tests.yml` / `coverage.yml` | neither present, `lint.yml` installed | gap (#97's bug restated: CI runs lint only, no test ever executes) |
+
+`scaffold-doctor.sh` sources `install-lib.sh` from its own directory (the same
+one it ships alongside in the npm package, the Homebrew formula, and a git
+clone) to reuse this logic rather than duplicate it; if that file is ever
+missing next to it, the section reports the gap in coverage instead of
+silently skipping it.
+
 ## Customize per project
 
 - **`coding-rules.md`** — short by design. Add a "Project-specific" section at the bottom for stack rules (SQLAlchemy column quirks, import conventions, architectural constraints).

--- a/TECHNICAL.md
+++ b/TECHNICAL.md
@@ -371,8 +371,8 @@ with no `.github/workflows/coverage.yml` for months, every PR green on
 `scaffold-doctor.sh` sources `install-lib.sh` from its own directory (the same
 one it ships alongside in the npm package, the Homebrew formula, and a git
 clone) to reuse this logic rather than duplicate it; if that file is ever
-missing next to it, the section reports the gap in coverage instead of
-silently skipping it.
+missing next to it, the section reports a note instead of silently skipping
+it.
 
 ## Customize per project
 

--- a/install-lib.sh
+++ b/install-lib.sh
@@ -275,3 +275,76 @@ install_test_workflow_ci() {
     TEST_CI_STATE="NO test execution in CI (no workflow installed)"
   fi
 }
+
+# check_paired_artifacts GAP_FN NOTE_FN (#96): detect scaffold artifacts that
+# are meant to arrive in matched pairs (a config half plus the CI half that
+# enforces it, or a local hook half plus the CI half it defers to) where only
+# one half is on disk. A real downstream repo had `.coveragerc` at root with
+# no `.github/workflows/coverage.yml`: every PR showed green CI (lint.yml
+# alone) while zero tests had ever executed, and nothing recorded that the
+# gate was incomplete. Shared between scaffold-doctor.sh (GAP_FN=gap, affects
+# exit status) and install.sh's own end-of-run summary (a plain warn wrapper
+# that never fails the run) so the detection logic and the wording live in
+# exactly one place.
+#
+# GAP_FN is called as `fn "<message>" "<fix command>"`, matching the doctor's
+# own gap() signature: a half-install that leaves a guardrail's backstop
+# silently missing. NOTE_FN is called as `fn "<message>"`, matching note(): a
+# state that is worth naming but, measured against what install.sh actually
+# does today, is a normal or deliberate outcome rather than a broken one.
+check_paired_artifacts() {
+  local gap_fn=$1 note_fn=$2
+  local looks_python=0
+  { [ -f pyproject.toml ] || [ -f requirements.txt ] || [ -f setup.py ]; } && looks_python=1
+
+  # 1. .coveragerc vs coverage.yml. install.sh writes .coveragerc for EVERY
+  # Python install regardless of --coverage-gate (a harmless standalone
+  # config, same policy as ruff.toml), so its presence alone does not mean
+  # anyone ever asked for the gate: that is the common, healthy default
+  # today, hence a note, not a gap. The inverse is the real anomaly:
+  # coverage.yml only ever lands when --coverage-gate is passed, and a
+  # Python install writes .coveragerc in that same run, so a Python project
+  # with coverage.yml but no .coveragerc means the config half was deleted
+  # or never restored. Gated on "looks like a Python project" so a
+  # frontend-only --coverage-gate install (which legitimately has no
+  # .coveragerc, vitest coverage does not use it) is not misreported.
+  if [ -f .coveragerc ] && [ ! -f .github/workflows/coverage.yml ]; then
+    "$note_fn" ".coveragerc is present with no .github/workflows/coverage.yml: it has no effect until the patch-coverage gate is installed too (install.sh --coverage-gate)"
+  fi
+  if [ -f .github/workflows/coverage.yml ] && [ ! -f .coveragerc ] && [ "$looks_python" -eq 1 ]; then
+    "$gap_fn" ".github/workflows/coverage.yml is present but .coveragerc is not, and this looks like a Python project: pytest-cov has no local config to read coverage settings from" \
+      "re-run install.sh --python (or --both) to restore .coveragerc"
+  fi
+
+  # 2. local gitleaks hook vs gitleaks CI workflow. check-gitleaks tells
+  # every commit that CI is the authoritative, unskippable gate (see
+  # scaffold-doctor.sh's own "opt-in surfaces" section); if that gate does
+  # not exist, the hook is making a promise nothing keeps, and --no-verify
+  # (or an unwired hooksPath) lets a secret through with nothing behind it.
+  # The inverse is a documented, valid strategy: CI-only enforcement, no
+  # local friction.
+  if [ -f .githooks/lib/check-gitleaks ] && [ ! -f .github/workflows/gitleaks.yml ]; then
+    "$gap_fn" "the local gitleaks pre-commit pass is installed (.githooks/lib/check-gitleaks) but .github/workflows/gitleaks.yml is not: every commit is told CI is the authoritative gate, and there is no CI gate behind it" \
+      "re-run install.sh --gitleaks-ci"
+  fi
+  if [ -f .github/workflows/gitleaks.yml ] && [ ! -f .githooks/lib/check-gitleaks ]; then
+    "$note_fn" "the gitleaks CI workflow is installed with no local pre-commit pass: CI remains the unskippable, authoritative gate, so this is a valid CI-only posture; add local feedback with install.sh --gitleaks-hook if you want it before push"
+  fi
+
+  # 3. tests.yml vs coverage.yml (#97's default-on test execution): never
+  # both (they would run the suite twice), never neither in a repo that has
+  # scaffold CI at all (lint.yml is the always-installed signal that this IS
+  # a scaffold-CI repo). install_test_workflow_ci already prevents "both" on
+  # every normal install/upgrade path, so it only reappears via a hand
+  # restore; "neither" is exactly the #97 bug restated for detection, and can
+  # persist quietly long after a --no-test-workflow install-time notice has
+  # scrolled off a terminal.
+  if [ -f .github/workflows/tests.yml ] && [ -f .github/workflows/coverage.yml ]; then
+    "$note_fn" "both .github/workflows/tests.yml and coverage.yml are installed: coverage.yml already runs the tests, so this push/PR's suite runs twice; remove tests.yml, coverage.yml supersedes it"
+  elif [ -f .github/workflows/lint.yml ] \
+       && [ ! -f .github/workflows/tests.yml ] \
+       && [ ! -f .github/workflows/coverage.yml ]; then
+    "$gap_fn" ".github/workflows/lint.yml is installed but neither tests.yml nor coverage.yml is: CI runs lint checks only, and no test ever executes on a PR or push" \
+      "re-run install.sh to install the default tests.yml (or install.sh --coverage-gate for the stricter gate)"
+  fi
+}

--- a/install.sh
+++ b/install.sh
@@ -174,6 +174,19 @@ install_claude_md() {
   echo "merged:       appended @AGENTS.md import to existing CLAUDE.md (your content kept)"
 }
 
+# warn_pair_gap / warn_pair_note: install.sh's reporters for install-lib.sh's
+# check_paired_artifacts (#96). install.sh never fails the run over one of
+# these findings (they are advisory, not install errors), so both just print;
+# the gap/note distinction stays in the wording, matching how scaffold-doctor.sh
+# reports the exact same states with a real exit-status difference.
+warn_pair_gap() {
+  echo "warning: $1"
+  echo "         fix: $2"
+}
+warn_pair_note() {
+  echo "note: $1"
+}
+
 # install_agents_md — AGENTS.md carries a Project section the user fills in,
 # so an existing one is never clobbered (even with --force). Skip if present;
 # create from template only when absent.
@@ -403,6 +416,15 @@ if git rev-parse --git-dir >/dev/null 2>&1; then
 else
   echo "warning: not in a git repo — run 'git config core.hooksPath .githooks' after 'git init'"
 fi
+
+# Paired-artifact consistency check (#96): install.sh can leave a config half
+# without its CI-enforcement half if an earlier run used a different flag
+# set, or a file was hand-copied in isolation, and nothing used to check
+# again after the run finished. Runs last, once everything THIS run would
+# write is already on disk; advisory only, so it never changes install.sh's
+# own exit status. Same detection + wording scaffold-doctor.sh reports later,
+# from install-lib.sh's check_paired_artifacts.
+check_paired_artifacts warn_pair_gap warn_pair_note
 
 echo ""
 echo "Done (mode: $MODE)."

--- a/scaffold-doctor.sh
+++ b/scaffold-doctor.sh
@@ -292,7 +292,7 @@ fi
 # exact same wording; sourced here rather than duplicated.
 section "paired artifacts"
 if [ -f "$SCAFFOLD_DIR/install-lib.sh" ]; then
-  # shellcheck disable=SC2329  # invoked indirectly, by name, from check_paired_artifacts
+  # shellcheck disable=SC2317,SC2329  # invoked indirectly, by name, from check_paired_artifacts (SC2317 on older shellcheck, SC2329 on newer, same underlying finding)
   doctor_pair_note() { note "$1"; }
   # shellcheck source=install-lib.sh
   . "$SCAFFOLD_DIR/install-lib.sh"

--- a/scaffold-doctor.sh
+++ b/scaffold-doctor.sh
@@ -45,6 +45,13 @@ while [ $# -gt 0 ]; do
   shift
 done
 
+# Captured BEFORE any cd: this is where scaffold-doctor.sh itself lives (the
+# npm package root, the Homebrew libexec dir, or a git clone), which is also
+# where install-lib.sh ships alongside it in all three distribution paths.
+# Used by the "paired artifacts" section below to reuse install.sh's own
+# detection logic instead of duplicating it.
+SCAFFOLD_DIR="$(cd "$(dirname "$0")" && pwd)"
+
 # The shipped checks read their config by BARE RELATIVE PATH
 # (".forbidden-patterns/secrets.txt", ".scaffold.toml"), which works because git
 # invokes hooks from the top of the working tree. A doctor run from a
@@ -272,6 +279,26 @@ else
   if [ -x .githooks/lib/scaffold-audit ] && [ "$QUIET" -eq 0 ]; then
     .githooks/lib/scaffold-audit 2>/dev/null | sed 's/^/      /' || true
   fi
+fi
+
+# --- 8. paired artifacts -----------------------------------------------------
+# Some guardrails ship as two halves that only work together: a config file
+# plus the CI workflow that reads it, or a local pre-commit pass plus the CI
+# gate it defers to. install.sh writes both halves together, but an
+# interrupted install, a later re-run without a flag, or a hand-copied file
+# can leave only one half on disk (#96), and once that happens, nothing
+# checks again. Detection lives in install-lib.sh's check_paired_artifacts so
+# install.sh's own end-of-run summary reports the exact same states with the
+# exact same wording; sourced here rather than duplicated.
+section "paired artifacts"
+if [ -f "$SCAFFOLD_DIR/install-lib.sh" ]; then
+  # shellcheck disable=SC2329  # invoked indirectly, by name, from check_paired_artifacts
+  doctor_pair_note() { note "$1"; }
+  # shellcheck source=install-lib.sh
+  . "$SCAFFOLD_DIR/install-lib.sh"
+  check_paired_artifacts gap doctor_pair_note
+else
+  note "install-lib.sh not found next to scaffold-doctor.sh ($SCAFFOLD_DIR): paired-artifact checks skipped; re-fetch the full scaffold bundle, not just this one file"
 fi
 
 # --- summary ----------------------------------------------------------------

--- a/tests/cases/20-paired-artifacts.sh
+++ b/tests/cases/20-paired-artifacts.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-# cases/20-paired-artifacts.sh — install-lib.sh's check_paired_artifacts must
+# cases/20-paired-artifacts.sh: install-lib.sh's check_paired_artifacts must
 # report every half-installed pair issue #96 named (a config half without its
 # CI-enforcement half, a local hook half without the CI half it defers to,
 # or the tests.yml/coverage.yml selection state from #97) and stay silent on
@@ -11,11 +11,11 @@
 # Every "reports a finding" assertion below is mutation-shaped: commenting
 # out scaffold-doctor.sh's `check_paired_artifacts gap doctor_pair_note` call
 # turns every one of them into a failure (verified by hand while writing this
-# file — the silence assertions still pass, since silence is also what a
+# file: the silence assertions still pass, since silence is also what a
 # script with no such call produces, which is exactly why both kinds of
 # assertion are needed together).
 
-echo "cases/20 — paired-artifact half-install detection (#96)"
+echo "cases/20: paired-artifact half-install detection (#96)"
 
 pa_python_project() {
   local t
@@ -80,7 +80,7 @@ pa_case() {
 }
 
 # pa_case_absent <name> <project-fn> <not-expect-substring> <mutation cmd...>
-# Proves a matched/healthy pair state produces NO paired-artifacts finding —
+# Proves a matched/healthy pair state produces NO paired-artifacts finding:
 # silence is the assertion, not merely a passing exit code (plenty of other
 # things also exit 0).
 pa_case_absent() {
@@ -103,7 +103,7 @@ pa_case_absent() {
 
 # (A) .coveragerc <-> coverage.yml. install.sh writes .coveragerc for every
 # Python install regardless of --coverage-gate, so the common default state
-# (coveragerc present, no coverage.yml) must be a note, not a gap — a doctor
+# (coveragerc present, no coverage.yml) must be a note, not a gap: a doctor
 # that gapped on this would be red on nearly every default Python install.
 pa_case "a default Python install's .coveragerc-without-coverage.yml is a note" \
   pa_python_project 0 "it has no effect until the patch-coverage gate is installed too" true
@@ -124,7 +124,7 @@ pa_case_absent "coveragerc + coverage.yml together produce no paired-artifact fi
   pa_add_coverage_gate_keep_rc
 
 # A frontend-only --coverage-gate install legitimately has coverage.yml with
-# no .coveragerc (vitest coverage does not read it) — must NOT be a gap.
+# no .coveragerc (vitest coverage does not read it): must NOT be a gap.
 pa_case_absent "coverage.yml without .coveragerc on a non-Python project is not a gap" \
   pa_frontend_coverage_project "pytest-cov has no local config to read coverage settings from" true
 
@@ -134,8 +134,8 @@ pa_case_absent "coverage.yml without .coveragerc on a non-Python project is not 
 pa_case "a local gitleaks hook without the CI gate is a gap" \
   pa_shell_project 1 "there is no CI gate behind it" pa_gitleaks_hook_only
 
-# The inverse (CI-only, no local pass) is a documented, valid strategy —
-# CI remains the unskippable, authoritative gate — so it is a note.
+# The inverse (CI-only, no local pass) is a documented, valid strategy:
+# CI remains the unskippable, authoritative gate, so it is a note.
 pa_case "the gitleaks CI workflow without a local hook is a note (CI-only is valid)" \
   pa_shell_project 0 "valid CI-only posture" pa_gitleaks_ci_only
 
@@ -145,8 +145,8 @@ pa_case_absent "gitleaks hook + CI together produce no paired-artifact finding (
   pa_shell_project "valid CI-only posture" pa_gitleaks_both
 
 # (C) tests.yml <-> coverage.yml (#97's default-on test execution): never
-# both (they would run the suite twice — a note, both DO still run), never
-# neither in a repo that has scaffold CI at all (a gap — exactly #97's bug,
+# both (they would run the suite twice, a note, both DO still run), never
+# neither in a repo that has scaffold CI at all (a gap, exactly #97's bug,
 # now detectable after the fact instead of only at install time).
 pa_case "both tests.yml and coverage.yml present is a note, not a gap" \
   pa_shell_project 0 "this push/PR's suite runs twice" pa_add_coverage_yml_keep_tests
@@ -160,7 +160,7 @@ pa_case_absent "the default tests.yml-only state produces no paired-artifact fin
   pa_shell_project "CI runs lint checks only, and no test ever executes" true
 
 # (D) install.sh's own end-of-run summary must report the SAME finding, not
-# just scaffold-doctor.sh — proves the shared function is actually wired into
+# just scaffold-doctor.sh: proves the shared function is actually wired into
 # both callers, not merely defined and used by one of them.
 IT=$(mktemp -d)
 inst_rc=0
@@ -176,5 +176,27 @@ else
   FAIL=$((FAIL + 1))
 fi
 rm -rf "$IT"
+
+# (E) scaffold-doctor.sh is sometimes copied on its own, separately from the
+# rest of the bundle (README warns against it, but nothing stops it). Run it
+# from a directory that has ONLY scaffold-doctor.sh, no install-lib.sh beside
+# it, against an otherwise-healthy project: the fallback note must fire, the
+# run must not crash under set -euo pipefail, and a healthy project's exit
+# status must stay 0 (this branch alone must never turn a clean project red).
+DOCLESS=$(mktemp -d)
+cp "$SCAFFOLD_DIR/scaffold-doctor.sh" "$DOCLESS/scaffold-doctor.sh"
+chmod +x "$DOCLESS/scaffold-doctor.sh"
+PT=$(pa_shell_project)
+doc_rc=0
+( cd "$PT" && "$DOCLESS/scaffold-doctor.sh" ) >"$HOOK_OUT" 2>&1 || doc_rc=$?
+if [ "$doc_rc" -eq 0 ] && grep -qF "install-lib.sh not found next to scaffold-doctor.sh" "$HOOK_OUT"; then
+  echo "  ✓ scaffold-doctor.sh copied without install-lib.sh reports a note, not a crash"
+  PASS=$((PASS + 1))
+else
+  echo "  ✗ the missing-install-lib fallback misbehaved (exit $doc_rc)"
+  sed 's/^/      /' "$HOOK_OUT"
+  FAIL=$((FAIL + 1))
+fi
+rm -rf "$DOCLESS" "$PT"
 
 reset_repo

--- a/tests/cases/20-paired-artifacts.sh
+++ b/tests/cases/20-paired-artifacts.sh
@@ -1,0 +1,180 @@
+# shellcheck shell=bash
+# cases/20-paired-artifacts.sh — install-lib.sh's check_paired_artifacts must
+# report every half-installed pair issue #96 named (a config half without its
+# CI-enforcement half, a local hook half without the CI half it defers to,
+# or the tests.yml/coverage.yml selection state from #97) and stay silent on
+# a matched or deliberately-chosen pair. Exercised through scaffold-doctor.sh
+# (the primary consumer, section "paired artifacts") and once through
+# install.sh's own end-of-run summary, so a regression in either caller's
+# wiring is caught, not just the shared function in isolation.
+#
+# Every "reports a finding" assertion below is mutation-shaped: commenting
+# out scaffold-doctor.sh's `check_paired_artifacts gap doctor_pair_note` call
+# turns every one of them into a failure (verified by hand while writing this
+# file — the silence assertions still pass, since silence is also what a
+# script with no such call produces, which is exactly why both kinds of
+# assertion are needed together).
+
+echo "cases/20 — paired-artifact half-install detection (#96)"
+
+pa_python_project() {
+  local t
+  t=$(mktemp -d)
+  ( cd "$t" && git init --quiet \
+    && echo 'name = "test"' >pyproject.toml \
+    && "$SCAFFOLD_DIR/install.sh" --python --no-verify ) >/dev/null 2>&1
+  printf '%s' "$t"
+}
+
+pa_shell_project() {
+  local t
+  t=$(mktemp -d)
+  ( cd "$t" && git init --quiet \
+    && echo '#!/usr/bin/env bash' >run.sh \
+    && "$SCAFFOLD_DIR/install.sh" --shell --no-verify ) >/dev/null 2>&1
+  printf '%s' "$t"
+}
+
+pa_frontend_coverage_project() {
+  local t
+  t=$(mktemp -d)
+  ( cd "$t" && git init --quiet \
+    && echo '{"name":"t"}' >package.json \
+    && "$SCAFFOLD_DIR/install.sh" --frontend --coverage-gate --no-verify ) >/dev/null 2>&1
+  printf '%s' "$t"
+}
+
+# Mutations that need a variable expanded at run time are shell FUNCTIONS, not
+# `bash -c '...'` (same reasoning as cases/18: a single-quoted bash -c with a
+# "$VAR" trips SC2016 under CI's `shellcheck -S info`).
+pa_add_coverage_gate_rm_rc()  { "$SCAFFOLD_DIR/install.sh" --coverage-gate --no-verify >/dev/null 2>&1 && rm -f .coveragerc; }
+pa_add_coverage_gate_keep_rc() { "$SCAFFOLD_DIR/install.sh" --coverage-gate --no-verify >/dev/null 2>&1; }
+pa_gitleaks_hook_only() {
+  cp "$SCAFFOLD_DIR/githooks/lib/check-gitleaks.template" .githooks/lib/check-gitleaks \
+    && chmod +x .githooks/lib/check-gitleaks
+}
+pa_gitleaks_ci_only() { cp "$SCAFFOLD_DIR/.github/workflows/gitleaks.yml.template" .github/workflows/gitleaks.yml; }
+pa_gitleaks_both()    { pa_gitleaks_hook_only && pa_gitleaks_ci_only; }
+pa_add_coverage_yml_keep_tests() { cp "$SCAFFOLD_DIR/.github/workflows/coverage.yml.template" .github/workflows/coverage.yml; }
+pa_rm_tests_yml()     { rm -f .github/workflows/tests.yml; }
+
+# pa_case <name> <project-fn> <want-exit> <expect-substring> <mutation cmd...>
+# The mutation runs inside a fresh project built by project-fn; `true` means
+# "leave it healthy".
+pa_case() {
+  local name=$1 projfn=$2 want=$3 expect=$4
+  shift 4
+  local t rc=0
+  t=$("$projfn")
+  ( cd "$t" && "$@" ) >/dev/null 2>&1 || true
+  ( cd "$t" && "$SCAFFOLD_DIR/scaffold-doctor.sh" ) >"$HOOK_OUT" 2>&1 || rc=$?
+  if [ "$rc" -eq "$want" ] && grep -qF "$expect" "$HOOK_OUT"; then
+    echo "  ✓ $name"
+    PASS=$((PASS + 1))
+  else
+    echo "  ✗ $name (exit $rc, wanted $want, or missing: $expect)"
+    sed 's/^/      /' "$HOOK_OUT"
+    FAIL=$((FAIL + 1))
+  fi
+  rm -rf "$t"
+}
+
+# pa_case_absent <name> <project-fn> <not-expect-substring> <mutation cmd...>
+# Proves a matched/healthy pair state produces NO paired-artifacts finding —
+# silence is the assertion, not merely a passing exit code (plenty of other
+# things also exit 0).
+pa_case_absent() {
+  local name=$1 projfn=$2 not_expect=$3
+  shift 3
+  local t rc=0
+  t=$("$projfn")
+  ( cd "$t" && "$@" ) >/dev/null 2>&1 || true
+  ( cd "$t" && "$SCAFFOLD_DIR/scaffold-doctor.sh" ) >"$HOOK_OUT" 2>&1 || rc=$?
+  if ! grep -qF "$not_expect" "$HOOK_OUT"; then
+    echo "  ✓ $name"
+    PASS=$((PASS + 1))
+  else
+    echo "  ✗ $name (found unexpected: $not_expect)"
+    sed 's/^/      /' "$HOOK_OUT"
+    FAIL=$((FAIL + 1))
+  fi
+  rm -rf "$t"
+}
+
+# (A) .coveragerc <-> coverage.yml. install.sh writes .coveragerc for every
+# Python install regardless of --coverage-gate, so the common default state
+# (coveragerc present, no coverage.yml) must be a note, not a gap — a doctor
+# that gapped on this would be red on nearly every default Python install.
+pa_case "a default Python install's .coveragerc-without-coverage.yml is a note" \
+  pa_python_project 0 "it has no effect until the patch-coverage gate is installed too" true
+
+# The inverse direction is the real anomaly: coverage.yml only ever lands via
+# --coverage-gate, which writes .coveragerc for a Python project in that same
+# run, so a Python project with coverage.yml but no .coveragerc means the
+# config half was deleted or never restored.
+pa_case "coverage.yml without .coveragerc on a Python project is a gap" \
+  pa_python_project 1 "pytest-cov has no local config to read coverage settings from" \
+  pa_add_coverage_gate_rm_rc
+
+pa_case_absent "coveragerc + coverage.yml together produce no paired-artifact finding (note)" \
+  pa_python_project "it has no effect until the patch-coverage gate is installed too" \
+  pa_add_coverage_gate_keep_rc
+pa_case_absent "coveragerc + coverage.yml together produce no paired-artifact finding (gap)" \
+  pa_python_project "pytest-cov has no local config to read coverage settings from" \
+  pa_add_coverage_gate_keep_rc
+
+# A frontend-only --coverage-gate install legitimately has coverage.yml with
+# no .coveragerc (vitest coverage does not read it) — must NOT be a gap.
+pa_case_absent "coverage.yml without .coveragerc on a non-Python project is not a gap" \
+  pa_frontend_coverage_project "pytest-cov has no local config to read coverage settings from" true
+
+# (B) local gitleaks hook <-> gitleaks CI workflow. check-gitleaks tells every
+# commit that CI is the authoritative gate; if CI does not exist, that is a
+# promise nothing keeps.
+pa_case "a local gitleaks hook without the CI gate is a gap" \
+  pa_shell_project 1 "there is no CI gate behind it" pa_gitleaks_hook_only
+
+# The inverse (CI-only, no local pass) is a documented, valid strategy —
+# CI remains the unskippable, authoritative gate — so it is a note.
+pa_case "the gitleaks CI workflow without a local hook is a note (CI-only is valid)" \
+  pa_shell_project 0 "valid CI-only posture" pa_gitleaks_ci_only
+
+pa_case_absent "gitleaks hook + CI together produce no paired-artifact finding (gap)" \
+  pa_shell_project "there is no CI gate behind it" pa_gitleaks_both
+pa_case_absent "gitleaks hook + CI together produce no paired-artifact finding (note)" \
+  pa_shell_project "valid CI-only posture" pa_gitleaks_both
+
+# (C) tests.yml <-> coverage.yml (#97's default-on test execution): never
+# both (they would run the suite twice — a note, both DO still run), never
+# neither in a repo that has scaffold CI at all (a gap — exactly #97's bug,
+# now detectable after the fact instead of only at install time).
+pa_case "both tests.yml and coverage.yml present is a note, not a gap" \
+  pa_shell_project 0 "this push/PR's suite runs twice" pa_add_coverage_yml_keep_tests
+
+pa_case "no test-execution workflow while lint.yml exists is a gap" \
+  pa_shell_project 1 "CI runs lint checks only, and no test ever executes" pa_rm_tests_yml
+
+pa_case_absent "the default tests.yml-only state produces no paired-artifact finding (both)" \
+  pa_shell_project "this push/PR's suite runs twice" true
+pa_case_absent "the default tests.yml-only state produces no paired-artifact finding (neither)" \
+  pa_shell_project "CI runs lint checks only, and no test ever executes" true
+
+# (D) install.sh's own end-of-run summary must report the SAME finding, not
+# just scaffold-doctor.sh — proves the shared function is actually wired into
+# both callers, not merely defined and used by one of them.
+IT=$(mktemp -d)
+inst_rc=0
+( cd "$IT" && git init --quiet && git config user.email t@test.local && git config user.name Test \
+  && echo '#!/usr/bin/env bash' >run.sh \
+  && "$SCAFFOLD_DIR/install.sh" --shell --gitleaks-hook --no-verify ) >"$HOOK_OUT" 2>&1 || inst_rc=$?
+if [ "$inst_rc" -eq 0 ] && grep -qF "warning: the local gitleaks pre-commit pass is installed" "$HOOK_OUT"; then
+  echo "  ✓ install.sh's own end-of-run summary reports the same gap (advisory: exit stays 0)"
+  PASS=$((PASS + 1))
+else
+  echo "  ✗ install.sh did not report the paired-artifact gap in its own summary (exit $inst_rc)"
+  sed 's/^/      /' "$HOOK_OUT"
+  FAIL=$((FAIL + 1))
+fi
+rm -rf "$IT"
+
+reset_repo

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -54,7 +54,8 @@ for case_file in \
   "$HERE/cases/16-coverage-gate.sh" \
   "$HERE/cases/17-whole-tree-configs.sh" \
   "$HERE/cases/18-doctor.sh" \
-  "$HERE/cases/19-test-workflow.sh"; do
+  "$HERE/cases/19-test-workflow.sh" \
+  "$HERE/cases/20-paired-artifacts.sh"; do
   # shellcheck source=/dev/null
   . "$case_file"
 done


### PR DESCRIPTION
## What changed

`install.sh` writes some guardrails as two halves that only do anything
together: a config file plus the CI workflow that reads it, or a local
pre-commit pass plus the CI gate it defers to. An interrupted install, a
later re-run without a flag, or a hand-copied file can leave only one half
on disk, and nothing checked again afterward. This is the second half of
#96 (PR #102 already fixed `coverage.yml`'s template robustness and added
the default `tests.yml` workflow).

- New `check_paired_artifacts` in `install-lib.sh`: one shared
  implementation of the detection and wording, called from both consumers
  so they can't drift apart.
- `scaffold-doctor.sh` gets a new "paired artifacts" section. It sources
  `install-lib.sh` from its own directory (the same directory it ships
  alongside in the npm package, the Homebrew formula, and a git clone), so
  the logic lives once, not duplicated. If that file is ever missing next
  to it, the section reports the gap in coverage rather than silently
  skipping.
- `install.sh` calls the same function at the very end of a run, after
  every file it would write is already on disk. Its own reporting is
  advisory only: findings print as `warning:`/`note:` lines but never
  change `install.sh`'s exit status.

## States detected, with example output

| Pair | State | Severity | Example line |
|---|---|---|---|
| `.coveragerc` / `coverage.yml` | `.coveragerc` present, `coverage.yml` absent | note | `.coveragerc is present with no .github/workflows/coverage.yml: it has no effect until the patch-coverage gate is installed too (install.sh --coverage-gate)` |
| `.coveragerc` / `coverage.yml` | `coverage.yml` present, `.coveragerc` absent, Python project | **gap** | `.github/workflows/coverage.yml is present but .coveragerc is not, and this looks like a Python project: pytest-cov has no local config to read coverage settings from` (fix: `re-run install.sh --python (or --both) to restore .coveragerc`) |
| gitleaks hook / gitleaks CI | hook present, CI absent | **gap** | `the local gitleaks pre-commit pass is installed (.githooks/lib/check-gitleaks) but .github/workflows/gitleaks.yml is not: every commit is told CI is the authoritative gate, and there is no CI gate behind it` (fix: `re-run install.sh --gitleaks-ci`) |
| gitleaks hook / gitleaks CI | CI present, hook absent | note | `the gitleaks CI workflow is installed with no local pre-commit pass: CI remains the unskippable, authoritative gate, so this is a valid CI-only posture; add local feedback with install.sh --gitleaks-hook if you want it before push` |
| `tests.yml` / `coverage.yml` | both present | note | `both .github/workflows/tests.yml and coverage.yml are installed: coverage.yml already runs the tests, so this push/PR's suite runs twice; remove tests.yml, coverage.yml supersedes it` |
| `tests.yml` / `coverage.yml` | neither present, `lint.yml` installed | **gap** | `.github/workflows/lint.yml is installed but neither tests.yml nor coverage.yml is: CI runs lint checks only, and no test ever executes on a PR or push` (fix: `re-run install.sh to install the default tests.yml (or install.sh --coverage-gate for the stricter gate)`) |

Gaps affect `scaffold-doctor.sh`'s exit status (matching its existing
gap/note convention: gap = a guardrail's backstop is silently missing,
note = a normal or deliberate state). `install.sh`'s own printing never
affects its exit status either way.

## Why gap vs. note isn't 1:1 with the issue's literal wording

Measured against what `install.sh` actually does today (not assumed):
`.coveragerc` is written for **every** Python install regardless of
`--coverage-gate` (same policy as `ruff.toml`), so "`.coveragerc` present,
`coverage.yml` absent" is the default state for the overwhelming majority
of Python installs, not an accidental half-install. Making that a gap
would put `scaffold-doctor.sh` in the red on nearly every default Python
project, exactly the "crying wolf" failure mode its own docstring warns
against. It's a note instead. The reverse direction (`coverage.yml` with
no `.coveragerc`, gated on the project actually looking like Python) is
the real anomaly, since `--coverage-gate` writes both files in the same
run, so that stays a gap.

Similarly, a frontend-only `--coverage-gate` install legitimately has
`coverage.yml` with no `.coveragerc` (vitest coverage doesn't read it),
verified by running that install and checking the output; the gap is
gated on `pyproject.toml`/`requirements.txt`/`setup.py` being present so
that combination isn't misreported.

## Testing

New `tests/cases/20-paired-artifacts.sh` (14 new cases), registered in
`tests/run.sh`. Covers every gap/note state above plus the matching
matched/healthy state for each pair (asserted by absence of the finding,
not just a passing exit code), plus one case that exercises `install.sh`'s
own end-of-run summary directly (not just `scaffold-doctor.sh`) to prove
the shared function is wired into both callers. `./tests/run.sh`: 317
passed, 0 failed (was 303 before this PR). Mutation-verified by hand:
temporarily removing `scaffold-doctor.sh`'s call to
`check_paired_artifacts` drops the suite to 311 passed / 6 failed, then
restored to green.

`shellcheck -S info` passes on every changed shell file, using CI's exact
invocation. All three touched scripts stay under the repo's 500-line cap
(`install.sh` 453, `install-lib.sh` 350, `scaffold-doctor.sh` 311).

## PROPOSED judgment calls

- **PROPOSED:** gitleaks CI-without-local-hook and both-test-workflows-
  installed are notes, not gaps, since both are documented, functioning
  postures (CI-only enforcement is explicitly called a valid strategy in
  `install.sh`'s own comments; both workflows installed still runs the
  tests, just twice). Alternative: treat every asymmetric pair as a gap
  for uniformity, but that would gap a repo doing something reasonable on
  purpose.
- **PROPOSED:** the `.coveragerc`-without-`coverage.yml` direction is a
  note rather than a gap, diverging from the issue's literal framing
  ("the config half that ships with `--coverage-gate`"), because that
  framing was already inaccurate at filing time: `.coveragerc` has always
  shipped unconditionally for Python installs, gate or no gate. Measured
  by running `install.sh --python` and checking the resulting files.
  Alternative: keep it a gap as literally requested, but that gaps nearly
  every default Python install.
  - Related, out of scope for this PR: `.coveragerc` being unconditional
    (rather than gated on `--coverage-gate`, matching its own header
    comment's framing) looks like a separate small inconsistency worth a
    follow-up issue; not changed here since it's an installation-policy
    question, not a detection one, and changing it could alter existing
    consumer behavior.
- **PROPOSED:** the `coverage.yml`-without-`.coveragerc` gap is scoped to
  projects that look like Python (`pyproject.toml`/`requirements.txt`/
  `setup.py`), matching `install.sh`'s own stack-detection heuristic,
  rather than firing unconditionally. Verified by running a
  `--frontend --coverage-gate` install and confirming it legitimately
  produces this shape. Alternative: report it unconditionally and accept
  the false positives on frontend-only coverage-gate installs.
- **PROPOSED:** shared implementation via `install-lib.sh`, sourced by
  `scaffold-doctor.sh` at its own runtime directory, rather than
  duplicating the check in both files. All three shipping paths (npm
  `files` list, Homebrew's `Dir["*"]` install, git clone) bundle
  `install-lib.sh` alongside `scaffold-doctor.sh`, verified by reading
  `package.json` and the Homebrew formula, so this holds for every real
  distribution channel. A missing `install-lib.sh` next to
  `scaffold-doctor.sh` (e.g., someone copied only that one file) is
  handled by printing a gap rather than crashing under `set -euo
  pipefail`.
- **PROPOSED:** reporter functions are passed by name (`check_paired_artifacts
  gap doctor_pair_note` / `check_paired_artifacts warn_pair_gap
  warn_pair_note`) rather than serializing findings through a delimited
  text format, so each caller keeps its own real output style (`gap`/`note`
  with `scaffold-doctor.sh`'s exit-status semantics vs. plain
  `warning:`/`note:` lines in `install.sh`) without a parsing layer between
  them. Alternative: emit pipe- or tab-delimited records from a single
  function and have each caller parse and format them, which centralizes
  formatting too but adds a delimiter contract that has to stay safe
  against messages containing that delimiter.

Fixes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)
