### PR TITLE
feat: wire the dependency-review gate into the installer and this repo (#113)

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,54 @@
+name: dependency-review
+
+# OPT-IN dependency supply-chain gate. Install via `install.sh
+# --dependency-review`, which copies this in as
+# `.github/workflows/dependency-review.yml`. Off by default: it adds a
+# third-party action dependency and relies on GitHub's Dependency Graph
+# (see the availability caveat below), so opt in deliberately, same posture
+# as gitleaks.yml.template (`install.sh --gitleaks-ci`), both opt-in flags.
+#
+# What it does:
+#   On a pull request, diffs the dependency manifests/lockfiles the PR changes
+#   and FAILS the check if it introduces a dependency with a known vulnerability
+#   (GitHub Advisory DB) or — increasingly the bigger risk — a malicious /
+#   yanked package (the chalk-debug, Shai-Hulud class of attack). This is the
+#   PR-time complement to dependabot.yml, which keeps already-trusted pins fresh;
+#   this one blocks a bad dep from entering in the first place.
+#
+# AVAILABILITY CAVEAT (read before relying on it):
+#   dependency-review-action needs GitHub's Dependency Graph enabled.
+#     - PUBLIC repos: on by default — works out of the box.
+#     - PRIVATE repos: requires GitHub Advanced Security (GHAS) to be enabled,
+#       otherwise the action errors. If you're a private repo without GHAS,
+#       this workflow can't run — lean on Dependabot + the lockfile review
+#       instead. (Same "needs a GitHub entitlement" caveat gitleaks carries for
+#       organizations.)
+#
+# Actions are pinned to a full commit SHA (supply-chain hardening); the trailing
+# comment records the human-readable tag. Bump via Dependabot (see
+# dependabot.yml.template).
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  # Uncomment to let the action post a summary comment on the PR (needs the
+  # extra scope + `comment-summary-in-pr: on-failure` below):
+  # pull-requests: write
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false  # don't leave GITHUB_TOKEN in .git/config
+      - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294  # v5.0.0
+        with:
+          # Fail the PR on a vulnerable dep at or above this severity. Tighten to
+          # 'low' for a stricter gate, or loosen to 'high' to cut noise.
+          fail-on-severity: moderate
+          # Malicious/yanked packages are blocked regardless of severity by the
+          # advisory feed; the threshold above only governs vulnerability noise.
+          # comment-summary-in-pr: on-failure   # needs pull-requests: write above

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -10,17 +10,17 @@ name: dependency-review
 # What it does:
 #   On a pull request, diffs the dependency manifests/lockfiles the PR changes
 #   and FAILS the check if it introduces a dependency with a known vulnerability
-#   (GitHub Advisory DB) or — increasingly the bigger risk — a malicious /
+#   (GitHub Advisory DB) or, increasingly the bigger risk, a malicious /
 #   yanked package (the chalk-debug, Shai-Hulud class of attack). This is the
 #   PR-time complement to dependabot.yml, which keeps already-trusted pins fresh;
 #   this one blocks a bad dep from entering in the first place.
 #
 # AVAILABILITY CAVEAT (read before relying on it):
 #   dependency-review-action needs GitHub's Dependency Graph enabled.
-#     - PUBLIC repos: on by default — works out of the box.
+#     - PUBLIC repos: on by default, works out of the box.
 #     - PRIVATE repos: requires GitHub Advanced Security (GHAS) to be enabled,
 #       otherwise the action errors. If you're a private repo without GHAS,
-#       this workflow can't run — lean on Dependabot + the lockfile review
+#       this workflow can't run: lean on Dependabot + the lockfile review
 #       instead. (Same "needs a GitHub entitlement" caveat gitleaks carries for
 #       organizations.)
 #

--- a/.github/workflows/dependency-review.yml.template
+++ b/.github/workflows/dependency-review.yml.template
@@ -10,17 +10,17 @@ name: dependency-review
 # What it does:
 #   On a pull request, diffs the dependency manifests/lockfiles the PR changes
 #   and FAILS the check if it introduces a dependency with a known vulnerability
-#   (GitHub Advisory DB) or — increasingly the bigger risk — a malicious /
+#   (GitHub Advisory DB) or, increasingly the bigger risk, a malicious /
 #   yanked package (the chalk-debug, Shai-Hulud class of attack). This is the
 #   PR-time complement to dependabot.yml, which keeps already-trusted pins fresh;
 #   this one blocks a bad dep from entering in the first place.
 #
 # AVAILABILITY CAVEAT (read before relying on it):
 #   dependency-review-action needs GitHub's Dependency Graph enabled.
-#     - PUBLIC repos: on by default — works out of the box.
+#     - PUBLIC repos: on by default, works out of the box.
 #     - PRIVATE repos: requires GitHub Advanced Security (GHAS) to be enabled,
 #       otherwise the action errors. If you're a private repo without GHAS,
-#       this workflow can't run — lean on Dependabot + the lockfile review
+#       this workflow can't run: lean on Dependabot + the lockfile review
 #       instead. (Same "needs a GitHub entitlement" caveat gitleaks carries for
 #       organizations.)
 #

--- a/.github/workflows/dependency-review.yml.template
+++ b/.github/workflows/dependency-review.yml.template
@@ -1,9 +1,11 @@
 name: dependency-review
 
-# OPT-IN dependency supply-chain gate. Copy to your project as
-# `.github/workflows/dependency-review.yml`. NOT installed by install.sh — it
-# adds a third-party action dependency and relies on GitHub's Dependency Graph,
-# so opt in deliberately (same posture as gitleaks.yml.template).
+# OPT-IN dependency supply-chain gate. Install via `install.sh
+# --dependency-review`, which copies this in as
+# `.github/workflows/dependency-review.yml`. Off by default: it adds a
+# third-party action dependency and relies on GitHub's Dependency Graph
+# (see the availability caveat below), so opt in deliberately, same posture
+# as gitleaks.yml.template (`install.sh --gitleaks-ci`), both opt-in flags.
 #
 # What it does:
 #   On a pull request, diffs the dependency manifests/lockfiles the PR changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,16 @@ versioning follows [SemVer](https://semver.org/).
   (version-pinned) and lints both a sample file and the config file itself,
   so a template that breaks its own rules fails CI here instead of in a
   consumer's repo.
+- **`install.sh --dependency-review` wires up the dependency-review CI gate
+  (#113).** `.github/workflows/dependency-review.yml.template` shipped and
+  was documented in TECHNICAL.md, but no installer call site referenced it,
+  so it was never installed into any consumer project. A dedicated opt-in
+  flag now installs it via `cp_scaffold_preserve` (same drift-preserving
+  policy as `--gitleaks-ci`'s `gitleaks.yml`), kept opt-in rather than
+  default-on because the action errors on a private repo without GitHub
+  Advanced Security. This repo now installs its own rendered copy at
+  `.github/workflows/dependency-review.yml`, since the repo is public and
+  GitHub's Dependency Graph is on by default here.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ Tests run in CI by default: a plain install also drops `.github/workflows/tests.
 ./install.sh --cursor       # also install opt-in Cursor agent guardrails
 ./install.sh --commit-msg   # also install the Conventional-Commits commit-msg hook
 ./install.sh --gitleaks-hook # also install opt-in local gitleaks pre-commit pass
+./install.sh --gitleaks-ci  # also install the gitleaks CI workflow (unskippable gate)
+./install.sh --dependency-review # also install the dependency-review CI gate (opt-in: needs GitHub Advanced Security on a private repo, or it errors)
 ./install.sh --all-langs    # install every language's forbidden-pattern file
 ./install.sh --coverage-gate # swap the default tests.yml for coverage.yml (tests + patch-coverage gate)
 ./install.sh --no-test-workflow # opt out of the default CI test-execution workflow (loud recorded skip)
@@ -120,7 +122,8 @@ the `commit-msg` hook, whenever it differs from the shipped version, with no
 `--force` needed, so pulling a new tag and re-running delivers security
 fixes. Your own configs (`ruff.toml`, `eslint.config.js`, `.scaffold.toml`,
 the rules docs, …) are left untouched, and `.forbidden-patterns/*.txt` files
-and the CI workflows (`lint.yml`, `tests.yml`, `coverage.yml`, `gitleaks.yml`)
+and the CI workflows (`lint.yml`, `tests.yml`, `coverage.yml`, `gitleaks.yml`,
+`dependency-review.yml`)
 that you've edited are kept with a drift notice rather than overwritten (use
 `--force` to take the shipped version, backed up to `.scaffold-bak`).
 

--- a/TECHNICAL.md
+++ b/TECHNICAL.md
@@ -283,13 +283,16 @@ minimal; turn them on per project.
   is absent — always pair it with the CI workflow above, which is the
   machine-independent boundary.
 
-- **dependency-review CI gate (`.github/workflows/dependency-review.yml.template`).**
-  Copy it in to block a PR that introduces a dependency with a known
-  vulnerability or a malicious/yanked package (the chalk-debug / Shai-Hulud
-  class) — the PR-time complement to Dependabot's freshness bumps. Not
-  auto-installed; pinned to a commit SHA. **Needs GitHub's Dependency Graph:**
-  on by default for public repos, requires GitHub Advanced Security for private
-  repos (caveat documented in the template header).
+- **dependency-review CI gate (`install.sh --dependency-review` →
+  `.github/workflows/dependency-review.yml`).** Blocks a PR that introduces a
+  dependency with a known vulnerability or a malicious/yanked package (the
+  chalk-debug / Shai-Hulud class): the PR-time complement to Dependabot's
+  freshness bumps. Opt-in, not default-on, and deliberately so: the action
+  needs GitHub's Dependency Graph, on by default for public repos but
+  requiring GitHub Advanced Security for private repos, where it errors
+  without that entitlement (caveat documented in the template header, same
+  "needs a GitHub entitlement" shape as gitleaks for organizations). Pinned to
+  a commit SHA; bump via Dependabot.
 
 - **Patch-coverage gate (`install.sh --coverage-gate` →
   `.github/workflows/coverage.yml`, installed _instead of_ the default-on

--- a/install.sh
+++ b/install.sh
@@ -14,6 +14,10 @@
 #   install.sh --commit-msg # also install the Conventional-Commits commit-msg hook
 #   install.sh --gitleaks-hook # also install opt-in local gitleaks pre-commit pass
 #   install.sh --gitleaks-ci # also install the gitleaks CI workflow (unskippable gate)
+#   install.sh --dependency-review # also install the dependency-review CI gate
+#                            # (opt-in: needs GitHub Advanced Security on a
+#                            # private repo, or it errors, so it is never
+#                            # default-on)
 #   install.sh --all-langs  # install every language's forbidden-pattern file
 #   install.sh --coverage-gate # install the patch-coverage gate INSTEAD of the
 #                            # plain tests.yml (tests still run, plus a stricter
@@ -38,7 +42,7 @@
 # is BACKED UP to .scaffold-bak first, so an edit you made to one is
 # recoverable and the "backed up:" line tells you it happened. User-owned
 # configs are left alone. A drifted .forbidden-patterns/*.txt, or a drifted
-# CI workflow (lint.yml, tests.yml, coverage.yml, gitleaks.yml), only prints
+# CI workflow (lint.yml, tests.yml, coverage.yml, gitleaks.yml, dependency-review.yml), only prints
 # a notice and keeps your file (use --force to replace it: your
 # customizations are backed up to .scaffold-bak first).
 # .githooks/local.d/ is never written to at all: it's where project-local checks
@@ -55,6 +59,7 @@ CURSOR=0
 COMMIT_MSG=0
 GITLEAKS_HOOK=0
 GITLEAKS_CI=0
+DEPENDENCY_REVIEW=0
 ALL_LANGS=0
 COVERAGE_GATE=0
 NO_TEST_WORKFLOW=0
@@ -73,11 +78,12 @@ for arg in "$@"; do
     --commit-msg) COMMIT_MSG=1 ;;
     --gitleaks-hook) GITLEAKS_HOOK=1 ;;
     --gitleaks-ci) GITLEAKS_CI=1 ;;
+    --dependency-review) DEPENDENCY_REVIEW=1 ;;
     --all-langs)  ALL_LANGS=1 ;;
     --coverage-gate) COVERAGE_GATE=1 ;;
     --no-test-workflow) NO_TEST_WORKFLOW=1 ;;
     --no-install) NO_INSTALL=1 ;;
-    --help|-h)    sed -n '2,45p' "$0"; exit 0 ;;
+    --help|-h)    sed -n '2,49p' "$0"; exit 0 ;;
     *) echo "error: unknown argument: $arg" >&2; exit 1 ;;
   esac
 done
@@ -136,7 +142,8 @@ fi
 # refreshed on re-run), cp_safe (USER-OWNED, never auto-replaced), cp_pattern
 # (.forbidden-patterns/*.txt, notify-on-drift), cp_scaffold_preserve
 # (scaffold-owned CI workflows: lint.yml, tests.yml, coverage.yml,
-# gitleaks.yml, notify-on-drift like cp_pattern, since #110), and the shared
+# gitleaks.yml, dependency-review.yml, notify-on-drift like cp_pattern, since
+# #110), and the shared
 # _cp_replace / _backup mechanism (where the A7 symlink defenses live) plus
 # mkx, are defined in install-lib.sh. They're SOURCED (not exec'd) so they
 # run in this shell with its globals (FORCE) and `set -euo pipefail`.
@@ -405,6 +412,20 @@ fi
 if [ "$GITLEAKS_CI" -eq 1 ]; then
   cp_scaffold_preserve "$SCAFFOLD_DIR/.github/workflows/gitleaks.yml.template" ".github/workflows/gitleaks.yml"
   echo "note: gitleaks.yml is the unskippable CI secret scan (runs even without --no-verify locally)."
+fi
+
+# Opt-in dependency-review CI gate (--dependency-review, #113). Same shape as
+# --gitleaks-ci above: a dedicated flag actually INSTALLS the workflow via
+# cp_scaffold_preserve, so a re-run keeps a hand-edited or pre-existing
+# dependency-review.yml and prints a drift note instead of silently
+# overwriting it; --force replaces it, backed up first. Kept opt-in rather
+# than default-on because dependency-review-action needs GitHub's Dependency
+# Graph: on by default for public repos, but it ERRORS on a private repo
+# without GitHub Advanced Security, so a default-on install would break CI
+# for private-repo consumers without GHAS.
+if [ "$DEPENDENCY_REVIEW" -eq 1 ]; then
+  cp_scaffold_preserve "$SCAFFOLD_DIR/.github/workflows/dependency-review.yml.template" ".github/workflows/dependency-review.yml"
+  echo "note: dependency-review.yml needs GitHub's Dependency Graph (on by default for public repos; needs GitHub Advanced Security for private repos, or it errors)."
 fi
 
 # Test-execution CI workflow (#97): DEFAULT-ON, exactly one of two shapes,

--- a/tests/cases/09-toolchain-clobber.sh
+++ b/tests/cases/09-toolchain-clobber.sh
@@ -315,6 +315,26 @@ else
 fi
 rm -rf "$UGC"
 
+# (T) --dependency-review installs the CI gate (same shape as --gitleaks-ci
+#     above, #113), so npx users, who have no on-disk copy of
+#     dependency-review.yml.template, can wire it too; uninstall then removes
+#     it (no half-uninstall).
+UDR=$(mktemp -d)
+( cd "$UDR" && git init --quiet && echo '{"name":"x"}' >package.json \
+  && "$SCAFFOLD_DIR/install.sh" --frontend --dependency-review --no-verify >/dev/null 2>&1 )
+if [ -f "$UDR/.github/workflows/dependency-review.yml" ] \
+   && cmp -s "$SCAFFOLD_DIR/.github/workflows/dependency-review.yml.template" "$UDR/.github/workflows/dependency-review.yml"; then
+  ( cd "$UDR" && "$SCAFFOLD_DIR/uninstall.sh" >/dev/null 2>&1 )
+  if [ ! -e "$UDR/.github/workflows/dependency-review.yml" ]; then
+    echo "  ✓ --dependency-review installs dependency-review.yml and uninstall removes it"; PASS=$((PASS + 1))
+  else
+    echo "  ✗ uninstall left dependency-review.yml behind (half-uninstall)"; FAIL=$((FAIL + 1))
+  fi
+else
+  echo "  ✗ --dependency-review did not install .github/workflows/dependency-review.yml"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$UDR"
+
 # (T) uninstall removes ci-changed-files too (install adds 8 libs; the uninstall
 #     loop dropped this one, leaving the scaffold half-uninstalled).
 UCI=$(mktemp -d)
@@ -365,11 +385,11 @@ rm -rf "$URS"
 #     upgrade). It moved to cp_scaffold_preserve, so it now behaves like a
 #     drifted .forbidden-patterns file: kept, with a drift note. #110 moved
 #     tests.yml, coverage.yml and gitleaks.yml to the same policy for the same
-#     reason. Full drift / --force / pristine coverage for cp_scaffold_preserve,
-#     across all four workflows, lives in cases/21-ci-workflow-drift.sh; this
-#     one assertion keeps this section's own "re-runs refresh scaffold-owned
-#     code" framing honest, since it used to claim the opposite for lint.yml
-#     specifically.
+#     reason; #113 added dependency-review.yml as a fifth. Full drift /
+#     --force / pristine coverage for cp_scaffold_preserve, across all five
+#     workflows, lives in cases/21-ci-workflow-drift.sh; this one assertion
+#     keeps this section's own "re-runs refresh scaffold-owned code" framing
+#     honest, since it used to claim the opposite for lint.yml specifically.
 URW=$(mktemp -d)
 ( cd "$URW" && git init --quiet && echo '{"name":"x"}' >package.json \
   && "$SCAFFOLD_DIR/install.sh" --frontend --no-verify >/dev/null 2>&1 )

--- a/tests/cases/11-npm-bundle.sh
+++ b/tests/cases/11-npm-bundle.sh
@@ -26,15 +26,16 @@ else
     # workflow template) expanded to their real members, plus the installer
     # scripts and the npm wrapper.
     #
-    # The workflow glob is load-bearing: gitleaks.yml.template and
-    # dependency-review.yml.template are "copy it in" templates the user applies
-    # by hand (TECHNICAL.md's Opt-in layers section covers gitleaks and
-    # dependency-review; install.sh only names them),
-    # so install.sh never READS them via $SCAFFOLD_DIR and the grep above can't
-    # see them. Without this glob an npm/npx user silently lacks two security-CI
-    # gates git-clone/Homebrew users get (audit B3). Globbing every
-    # .github/workflows/*.yml.template makes the guard fail closed on any
-    # documented-but-unbundled workflow — present or added later.
+    # The workflow glob is load-bearing. gitleaks.yml.template and
+    # dependency-review.yml.template are both read via a literal $SCAFFOLD_DIR
+    # path today (install.sh's --gitleaks-ci and --dependency-review blocks,
+    # #110 and #113), so the primary grep above already catches them, but a
+    # documented workflow template does not have to be read that way to need
+    # bundling: an npm/npx user needs every shipped .github/workflows/*.yml.template
+    # regardless of whether install.sh currently wires a flag to it (audit B3).
+    # Globbing every .github/workflows/*.yml.template makes the guard fail
+    # closed on any documented, unbundled workflow, present or added later,
+    # instead of relying on the literal-path grep staying in sync by luck.
     REQUIRED=$(
       {
         # SC2016 off on purpose: we match the LITERAL text "$SCAFFOLD_DIR" / "${"

--- a/tests/cases/21-ci-workflow-drift.sh
+++ b/tests/cases/21-ci-workflow-drift.sh
@@ -25,8 +25,16 @@
 # three checks per file: the mechanism is identical, only the destination
 # path, shipped template, and the install flag needed to bring the file into
 # existence differ.
+#
+# What #113 is: dependency-review.yml.template shipped and documented but no
+# install.sh call site ever wrote it, so it was dead weight (issue #113).
+# Wired up the same way as gitleaks.yml (#110): a dedicated opt-in flag,
+# --dependency-review, installs it via cp_scaffold_preserve, so it gets the
+# same fifth _wd_case slot. It stays opt-in (never default-on) because the
+# action errors on a private repo without GitHub Advanced Security; the extra
+# case below proves a plain, no-flag install never creates it.
 
-echo "cases/21: CI workflow drift-preserving install policy (lint.yml #105, tests/coverage/gitleaks.yml #110)"
+echo "cases/21: CI workflow drift-preserving install policy (lint.yml #105, tests/coverage/gitleaks.yml #110, dependency-review.yml #113)"
 
 # _wd_fixture EXTRA_FLAG: a throwaway frontend-mode repo with the scaffold
 # installed. EXTRA_FLAG is the flag (if any) needed for this run to touch the
@@ -121,5 +129,19 @@ _wd_case "lint.yml"     ".github/workflows/lint.yml"     "$SCAFFOLD_DIR/.github/
 _wd_case "tests.yml"    ".github/workflows/tests.yml"    "$SCAFFOLD_DIR/.github/workflows/tests.yml.template"    ""
 _wd_case "coverage.yml" ".github/workflows/coverage.yml" "$SCAFFOLD_DIR/.github/workflows/coverage.yml.template" "--coverage-gate"
 _wd_case "gitleaks.yml" ".github/workflows/gitleaks.yml" "$SCAFFOLD_DIR/.github/workflows/gitleaks.yml.template" "--gitleaks-ci"
+_wd_case "dependency-review.yml" ".github/workflows/dependency-review.yml" "$SCAFFOLD_DIR/.github/workflows/dependency-review.yml.template" "--dependency-review"
+
+# (T) a DEFAULT install (no flag at all) never creates dependency-review.yml:
+# the action errors on a private repo without GitHub Advanced Security, so
+# default-on would break consumer CI (#113). Same shape as the opt-in check
+# _wd_case already proves per-workflow above, but this asserts ABSENCE on the
+# plain, no-flag install path rather than presence behind its own flag.
+T4=$(_wd_fixture "")
+if [ ! -e "$T4/.github/workflows/dependency-review.yml" ]; then
+  echo "  ✓ [dependency-review.yml] a default install does not create it"; PASS=$((PASS + 1))
+else
+  echo "  ✗ [dependency-review.yml] a default install should not create dependency-review.yml"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$T4"
 
 reset_repo

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -162,6 +162,9 @@ remove_if_unmodified ".githooks/lib/check-gitleaks"  "$SCAFFOLD_DIR/githooks/lib
 remove_if_unmodified ".github/workflows/coverage.yml" "$SCAFFOLD_DIR/.github/workflows/coverage.yml.template"
 # Opt-in gitleaks CI workflow (only present if installed with --gitleaks-ci).
 remove_if_unmodified ".github/workflows/gitleaks.yml" "$SCAFFOLD_DIR/.github/workflows/gitleaks.yml.template"
+# Opt-in dependency-review CI gate (only present if installed with
+# --dependency-review).
+remove_if_unmodified ".github/workflows/dependency-review.yml" "$SCAFFOLD_DIR/.github/workflows/dependency-review.yml.template"
 
 # Likely-customized files — only with --all
 if [ "$REMOVE_ALL" -eq 1 ]; then


### PR DESCRIPTION
Resolves the #113 orphan: the dependency-review gate is now reachable through the installer and running on this repo.

## What changed

- **`--dependency-review` opt-in installer flag:** installs `.github/workflows/dependency-review.yml` through the drift-preserving path, mirroring `--gitleaks-ci` everywhere it appears (help, summary, uninstall, drift tests, round-trip tests). Kept opt-in deliberately: the action errors on private repos without GitHub Advanced Security, so default-on would break consumer CI.
- **Dogfood:** the rendered workflow is installed in this repo itself (public, Dependency Graph on by default), so the shipped template is finally exercised by real CI. This PR runs it live.
- **Truthfulness fixes:** the template's stale "same posture as gitleaks.yml.template" claim is accurate again; `uninstall.sh` gained the missing mirror entry (a half-uninstall bug the flag would have introduced otherwise); two small pre-existing doc gaps found en route (README missing the `--gitleaks-ci` line, a stale comment in `tests/cases/11`) were fixed and are called out here for review.

## Measurements

- Suite: 335 passed, 5 failed vs main's 330/5 (the 5 are the documented machine-local npx-cache failures); +5 new assertions, zero new failures.
- E2E: default install creates no dependency-review.yml; with the flag it is byte-identical to the template; drift kept with note and no backup; `--force` replaces with backup.
- actionlint exit 0; zizmor 1.25.2 and 1.26.1 exit 0 on all changed workflows; action-SHA cross-file drift check clean.
- CHANGELOG, README, TECHNICAL prettier-clean; zero em/en dashes in added lines; all commit subjects pass the shipped commit-msg hook.

Closes #113.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
