### PR TITLE
feat: finish the deferred audit follow-ups (#116, #117, #118)

### DIFF
--- a/.npmrc.template
+++ b/.npmrc.template
@@ -1,0 +1,26 @@
+# Copy to your project as `.npmrc` (install.sh --npm-cooldown, issue #117).
+#
+# min-release-age delays how soon a freshly published package version becomes
+# installable, counted in DAYS from its publish time: npm resolves to an
+# older version instead until that many days have passed. Requires npm
+# >= 11.10.0 (shipped 2026-02-11, npm/cli PR #8965). On an older npm this key
+# is simply an unrecognized config: npm prints a WARN and ignores it, the
+# install still proceeds, the same fail-open shape as install.sh
+# --gitleaks-hook when the gitleaks binary is missing. It only hard-errors on
+# an unrecognized key if the project has also set strict-npmrc=true, which
+# this template does not.
+#
+# 7 days matches this scaffold's own .github/dependabot.yml cooldown
+# (default-days: 7) so the two layers agree on one number instead of two to
+# reconcile. Dependabot's cooldown only holds back ITS OWN update PRs; it does
+# nothing for an `npm install <pkg>` a developer or an agent runs by hand,
+# which is exactly the window recent npm supply-chain incidents (a maintainer
+# account compromised, a malicious version published, pulled hours later)
+# exploited. This setting closes that install-time gap.
+#
+# `before` is a related but separate config: an exact calendar date instead of
+# a rolling day count. If a project sets `before` in this same file, `before`
+# wins over min-release-age (per the npm docs, the two may coexist but an
+# explicit absolute date overrides a relative window within one source). This
+# template does not set `before`.
+min-release-age=7

--- a/AGENTS.md.template
+++ b/AGENTS.md.template
@@ -39,9 +39,8 @@ run with a hand-picked path is a gate that no longer gates.
 **If you turn a check down, say so out loud.** Adding a `scaffold-allow` marker,
 disabling or downgrading a check in `.scaffold.toml`, widening an ignore list, or
 skipping a test makes a red run green without fixing anything. Per
-`operational-rules.md` that is a last resort; when you do it, name the check, the
-file, and the reason in your summary to the user, in plain language. Never leave
-it to be noticed in the diff.
+`operational-rules.md` that is a last resort; when you do it, it goes in the
+plain-language change summary below, by name.
 
 In a monorepo, run `pytest` from the directory holding the pytest config, not
 from the repo root. pytest reads exactly one ini-file and the rootdir one wins,
@@ -50,6 +49,19 @@ so invoking from the root can silently use the wrong config.
 ## Session start
 
 Before your first commit each session, check whether this project's guardrails are actually armed, not just present, and surface any gap or note line to the user in plain language rather than silently proceeding. Run `npx ai-coding-rules-scaffold doctor` (works no matter how this project's scaffold was installed); if you know the scaffold's git-clone or Homebrew path on this machine, `<that path>/scaffold-doctor.sh` works too. This is the detection net for an unarmed hook after a fresh clone (`core.hooksPath` is per-clone local config, so a clone of an already-scaffolded repo starts unwired) and for a partial install.
+
+## Plain-language change summary
+
+At the end of a working session, and before you hand back a commit or open a PR, summarize the work in plain language. For a user who does not read code this is the only artifact they can actually judge; the diff, the check output, and the CI log all assume a reader who does. It is their decision surface, not a stand-in for review: you report, they decide, and nothing you write here makes your own output trustworthy.
+
+Four things, in words a non-programmer can act on:
+
+- **What changed and why**, described by behavior and consequence, not by filename, function, or command.
+- **Anything destructive or hard to reverse** you did or are proposing: deleted rows, a dropped table, rewritten history, a force-push, an overwritten file, a migration against live data. Say whether it can be undone, and from what.
+- **Every guardrail you turned down, by name.** This is where "If you turn a check down, say so out loud" above lands: name the check, the file, and the reason, one line each. Never leave it to be noticed in the diff.
+- **What the user should check or decide before calling it done**: what you could not verify, the judgment call you made on their behalf, the provider dashboard or setting no diff can show. Per `operational-rules.md` you report the measurements; the verdict is theirs.
+
+Give it unprompted, and give it even when the answer is "nothing destructive, nothing turned down". A summary the user has to ask for is one they will not know to ask for.
 
 ## Operational rules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,15 @@ versioning follows [SemVer](https://semver.org/).
   agent or developer runs; this closes that gap with the same number.
   `.npmrc` is user-owned (`cp_safe`), so a re-run never overwrites a
   project's own copy without `--force`.
+- **Optional Claude Code Skill packaging (`install.sh --claude-skill`,
+  #118 part 2).** Installs `.claude/skills/coding-rules/SKILL.md`, a Skill
+  that tells Claude Code to read the project's installed `coding-rules.md`
+  and `operational-rules.md` in full on demand (before writing/editing
+  code, before a commit, or when asked about this project's conventions).
+  A third, distinct loading path alongside the always-installed AGENTS.md
+  summary (imported into every turn, but only links to the full files by
+  name) and `--claude`'s runtime hooks (block a bad tool call as it
+  happens); combine freely with either. User-owned (`cp_safe`).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,15 @@ versioning follows [SemVer](https://semver.org/).
   before it reaches a manifest. README's "Already have commit history?"
   section recommends a one-time full-history secret scan (`gitleaks git
 .`) for a repo that predates the scaffold install.
+- **Opt-in npm install-layer cooldown (`install.sh --npm-cooldown`,
+  #117).** A new `.npmrc.template` sets `min-release-age=7`, delaying how
+  soon a freshly published npm package version becomes installable, needs
+  npm `>= 11.10.0` (older npm just warns and ignores the unrecognized key,
+  fail-open). Matches `.github/dependabot.yml`'s existing 7-day cooldown,
+  which only covers Dependabot's own PRs, not a manual `npm install` an
+  agent or developer runs; this closes that gap with the same number.
+  `.npmrc` is user-owned (`cp_safe`), so a re-run never overwrites a
+  project's own copy without `--force`.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Tests run in CI by default: a plain install also drops `.github/workflows/tests.
 ./install.sh --zizmor-ci    # also install the zizmor GitHub Actions audit gate (opt-in: adds a third-party pip package)
 ./install.sh --socket-ci    # also install the Socket Firewall supply-chain gate (opt-in: adds a third-party action dependency)
 ./install.sh --npm-cooldown # also install .npmrc's min-release-age package cooldown (opt-in: needs npm >= 11.10.0, older npm just warns and ignores it)
+./install.sh --claude-skill # also install an on-demand Claude Code Skill wrapping coding-rules.md/operational-rules.md
 ./install.sh --all-langs    # install every language's forbidden-pattern file
 ./install.sh --coverage-gate # swap the default tests.yml for coverage.yml (tests + patch-coverage gate)
 ./install.sh --no-test-workflow # opt out of the default CI test-execution workflow (loud recorded skip)

--- a/README.md
+++ b/README.md
@@ -215,7 +215,8 @@ You can use `operational-rules.md` (and/or `coding-rules.md`) standalone, withou
   @coding-rules.md
   ```
   The `@` directive auto-loads on session start.
-- **Cursor / Aider / Cline / etc.** — add the filename(s) to whatever config the tool reads every session (`.cursorrules`, `.aider.conf.yml`, `.clinerules`).
+- **Cursor:** create `.cursor/rules/rules.mdc` (or use the command palette's "New Cursor Rule") with the frontmatter `alwaysApply: true` and one line under it: `Follow the rules in operational-rules.md and coding-rules.md.` The root-level `.cursorrules` file older guides point to is [legacy and will be deprecated](https://cursor.com/help/customization/rules).
+- **Aider / Cline / etc.** — add the filename(s) to whatever config the tool reads every session (`.aider.conf.yml`, `.clinerules`).
 
 No `install.sh`, no hooks, no CI — the docs are useful in isolation. The full scaffold layers on the enforcement (commit hooks + CI mirror) that turns the rules into machine-checkable failures.
 

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ You can use `operational-rules.md` (and/or `coding-rules.md`) standalone, withou
   ```
   The `@` directive auto-loads on session start.
 - **Cursor:** create `.cursor/rules/rules.mdc` (or use the command palette's "New Cursor Rule") with the frontmatter `alwaysApply: true` and one line under it: `Follow the rules in operational-rules.md and coding-rules.md.` The root-level `.cursorrules` file older guides point to is [legacy and will be deprecated](https://cursor.com/help/customization/rules).
-- **Aider / Cline / etc.** — add the filename(s) to whatever config the tool reads every session (`.aider.conf.yml`, `.clinerules`).
+- **Aider / Cline / etc.**: add the filename(s) to whatever config the tool reads every session (`.aider.conf.yml`, `.clinerules`).
 
 No `install.sh`, no hooks, no CI — the docs are useful in isolation. The full scaffold layers on the enforcement (commit hooks + CI mirror) that turns the rules into machine-checkable failures.
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Tests run in CI by default: a plain install also drops `.github/workflows/tests.
 ./install.sh --dependency-review # also install the dependency-review CI gate (opt-in: needs GitHub Advanced Security on a private repo, or it errors)
 ./install.sh --zizmor-ci    # also install the zizmor GitHub Actions audit gate (opt-in: adds a third-party pip package)
 ./install.sh --socket-ci    # also install the Socket Firewall supply-chain gate (opt-in: adds a third-party action dependency)
+./install.sh --npm-cooldown # also install .npmrc's min-release-age package cooldown (opt-in: needs npm >= 11.10.0, older npm just warns and ignores it)
 ./install.sh --all-langs    # install every language's forbidden-pattern file
 ./install.sh --coverage-gate # swap the default tests.yml for coverage.yml (tests + patch-coverage gate)
 ./install.sh --no-test-workflow # opt out of the default CI test-execution workflow (loud recorded skip)

--- a/TECHNICAL.md
+++ b/TECHNICAL.md
@@ -344,6 +344,28 @@ minimal; turn them on per project.
   `--force`. See the template header for the `before` config interaction
   (an exact date wins over the relative window when both are set).
 
+- **Claude Code Skill (`install.sh --claude-skill` →
+  `.claude/skills/coding-rules/SKILL.md`, issue #118 part 2).** Wraps
+  `coding-rules.md` and `operational-rules.md` in a Claude Code
+  [Skill](https://code.claude.com/docs/en/skills): frontmatter that tells
+  Claude Code when to trigger it (before writing/editing code, before a
+  commit, or when asked about this project's conventions) and a body that
+  tells the agent to read both files in full. This is a **third**, distinct
+  loading path, not a replacement for either existing one: `--claude`
+  installs _runtime hooks_ (`.claude/settings.json` plus the `PreToolUse`
+  precheck) that block a bad tool call as it happens; the plain AGENTS.md
+  path (always installed) is _always-loaded summary_: CLAUDE.md's
+  `@AGENTS.md` import pulls a condensed version of these rules, with links
+  to the full files, into every turn's context by design, to keep that
+  always-loaded context small. `--claude-skill` is what actually pulls the
+  **full text** of `coding-rules.md` / `operational-rules.md` into context,
+  **on demand**, at the moments they matter, rather than relying on the
+  summary alone or paying their full size on every turn. Opt-in because it is
+  Claude Code specific; combine freely with `--claude` and with the default
+  AGENTS.md install. `.claude/skills/coding-rules/SKILL.md` is USER-OWNED
+  (`cp_safe`): a project may hand-edit it, so a re-run never overwrites it
+  without `--force`.
+
 - **Patch-coverage gate (`install.sh --coverage-gate` →
   `.github/workflows/coverage.yml`, installed _instead of_ the default-on
   `tests.yml` above).** The one mechanism here that _forces tests

--- a/TECHNICAL.md
+++ b/TECHNICAL.md
@@ -254,9 +254,12 @@ minimal; turn them on per project.
   wired to Cursor's `beforeShellExecution` hook via `.cursor/hooks.json`, so a
   `curl | bash` / `rm -rf /` / `chmod 777` the agent is about to run is scanned
   against `.forbidden-patterns/shell.txt` and blocked (exit 2 = Cursor deny).
-  Cursor has no before-write hook, so unlike `--claude` the secret-on-write scan
-  and credential read deny-list aren't portable — the shell-command scan is the
-  high-ROI piece that is. `--claude` and `--cursor` can be combined; they share
+  Cursor has no hook that can block a write (`afterFileEdit` fires only after
+  the edit has landed), so unlike `--claude` the secret-on-write scan isn't
+  portable; the shell-command scan is the high-ROI piece that is. Cursor's
+  `beforeReadFile` can deny a read, so the credential read deny-list is portable
+  in principle, but `--cursor` does not wire it today. `--claude` and `--cursor`
+  can be combined; they share
   the one precheck script, which (like `--claude`) needs `jq` and fails open
   without it.
 

--- a/TECHNICAL.md
+++ b/TECHNICAL.md
@@ -327,6 +327,23 @@ minimal; turn them on per project.
   account needed for firewall-free mode. Opt-in, not default-on: it adds a
   third-party action dependency. Pinned to a commit SHA; bump via Dependabot.
 
+- **npm install-layer cooldown (`install.sh --npm-cooldown` → `.npmrc`,
+  issue #117).** Sets `min-release-age=7`: npm resolves to an older version
+  instead of a package version published fewer than 7 days ago. Requires npm
+  `>= 11.10.0` (shipped 2026-02-11, npm/cli PR #8965); an older npm treats the
+  key as unrecognized, warns, and ignores it, so the install still proceeds
+  (fail-open, same shape as `--gitleaks-hook` with no `gitleaks` binary on
+  PATH). `.github/dependabot.yml`'s own `cooldown: default-days: 7` only
+  holds back Dependabot's own update PRs; it does nothing for an `npm install
+<pkg>` a developer or an agent runs by hand, which is exactly the window a
+  compromised-and-yanked release (chalk/debug, Shai-Hulud class) is
+  installable in. This closes that install-time gap with the same 7-day
+  number, rather than a second one to reconcile. `.npmrc` is USER-OWNED
+  (`cp_safe`, not `cp_scaffold_preserve`): a project may already have one, or
+  may hand-edit the shipped copy, so a re-run never overwrites it without
+  `--force`. See the template header for the `before` config interaction
+  (an exact date wins over the relative window when both are set).
+
 - **Patch-coverage gate (`install.sh --coverage-gate` →
   `.github/workflows/coverage.yml`, installed _instead of_ the default-on
   `tests.yml` above).** The one mechanism here that _forces tests

--- a/claude-skill/coding-rules/SKILL.md.template
+++ b/claude-skill/coding-rules/SKILL.md.template
@@ -1,0 +1,27 @@
+---
+name: coding-rules
+description: Load this project's installed coding rules on demand. Use before writing, editing, or reviewing code in this repo, before staging a commit, or whenever asked about this project's guardrails, conventions, forbidden patterns, or engineering/process rules. Complements AGENTS.md, which imports the same two files for always-on context; this Skill exists for a session or tool that does not load AGENTS.md into every turn.
+---
+
+# Coding rules (on demand)
+
+This project has ai-coding-rules-scaffold installed (install.sh --claude-skill,
+issue #118). Two files at the project root carry the actual rules:
+
+- `coding-rules.md`, code-level rules: forbidden patterns, style, security.
+- `operational-rules.md`, process and collaboration rules: pre-flight checks
+  before long jobs, commit discipline, scope discipline, surfacing
+  uncertainty instead of guessing.
+
+When this Skill triggers, read both files in full before writing or editing
+code, before a commit, or before answering a question about this project's
+conventions, and treat every rule in them as binding for the current task.
+
+AGENTS.md (imported into every turn via CLAUDE.md's `@AGENTS.md`) already
+summarizes some of this and links to both files by name; it does not inline
+their full text on every turn, by design, to keep the always-loaded context
+small. This Skill is what actually pulls the full text in, on demand, at the
+moments it matters, instead of relying on the summary alone.
+
+If either file is missing from the project root, say so plainly rather than
+guessing at rules that were never installed; do not fabricate a rule.

--- a/claude-skill/coding-rules/SKILL.md.template
+++ b/claude-skill/coding-rules/SKILL.md.template
@@ -1,6 +1,6 @@
 ---
 name: coding-rules
-description: Load this project's installed coding rules on demand. Use before writing, editing, or reviewing code in this repo, before staging a commit, or whenever asked about this project's guardrails, conventions, forbidden patterns, or engineering/process rules. Complements AGENTS.md, which imports the same two files for always-on context; this Skill exists for a session or tool that does not load AGENTS.md into every turn.
+description: Load this project's installed coding rules on demand. Use before writing, editing, or reviewing code in this repo, before staging a commit, or whenever asked about this project's guardrails, conventions, forbidden patterns, or engineering/process rules. Complements AGENTS.md, which links to the same two files but does not inline their full text; this Skill pulls the full text into context on demand.
 ---
 
 # Coding rules (on demand)

--- a/cursor-hooks.json.template
+++ b/cursor-hooks.json.template
@@ -12,5 +12,5 @@
     ]
   },
 
-  "//note": "Cursor has no before-WRITE hook that can block, so unlike the Claude setup the secret-on-write scan and the credential-file read deny-list are not portable here; beforeShellExecution is the high-ROI piece that is. The pre-commit secret scanner still catches a hardcoded credential at commit time on either runtime."
+  "//note": "Cursor has no hook that can block a WRITE (afterFileEdit fires only after the edit has landed), so unlike the Claude setup the secret-on-write scan is not portable here; beforeShellExecution is the high-ROI piece that is. Cursor's beforeReadFile CAN deny a read, so the Claude credential-file deny-list is portable in principle; this template does not wire it. The pre-commit secret scanner still catches a hardcoded credential at commit time on either runtime. Schema verified against https://cursor.com/docs/agent/hooks (2026-08-28)."
 }

--- a/install-lib.sh
+++ b/install-lib.sh
@@ -37,19 +37,14 @@
 #                additions survive in .scaffold-bak for manual merge-back.
 #   cp_scaffold_preserve  scaffold-owned CI workflows that a project is expected
 #                to hand-edit or that commonly arrive pre-authored: today,
-#                .github/workflows/lint.yml, tests.yml, coverage.yml and
-#                gitleaks.yml. Same drift-preserving behavior as cp_pattern:
-#                a re-run only NOTIFIES on drift and keeps the user's edits;
-#                --force backs up + replaces. Added for lint.yml in #105: a
-#                plain cp_scaffold refresh there silently discarded a
-#                consumer's CI customization (measured on a real downstream
-#                repo: 23 deletions, 0 insertions) with no signal beyond a log
-#                line and no way back except the .scaffold-bak. #110 extended
-#                the same policy to tests.yml, coverage.yml and gitleaks.yml:
-#                the same silent-discard risk applies to any hand-edited or
-#                pre-existing workflow file, not just lint.yml, and there was
-#                no principled reason to keep those three on the overwrite
-#                policy once the mechanism existed.
+#                lint.yml, tests.yml, coverage.yml and gitleaks.yml. Same
+#                drift-preserving behavior as cp_pattern: a re-run only
+#                NOTIFIES on drift and keeps the user's edits; --force backs
+#                up + replaces. Added for lint.yml in #105 (a plain
+#                cp_scaffold refresh there measurably discarded a consumer's
+#                CI customization with no way back except the .scaffold-bak)
+#                and extended to the other three in #110; see its own
+#                function comment below for the full history.
 #
 # The four policies share one write MECHANISM (_cp_replace) and one backup
 # routine (_backup), so the A7 symlink defenses live in exactly one place.
@@ -138,26 +133,20 @@ cp_safe() {
 # at a scaffold-owned path is always replaced with the real scanner (better than
 # leaving a dead link there) and never written through.
 #
-# ALWAYS backs up before overwriting — not just under --force (issue #72). The
-# old policy skipped the routine-refresh backup on the premise that "the prior
-# bytes are scaffold code, recoverable from git history and the scaffold repo."
-# That premise is TRUE for an untouched destination and FALSE for an edited one,
-# and nothing tested which it was. .githooks/pre-commit is the file a project
-# MUST edit to wire in a local check (.github/workflows/lint.yml used to be the
-# other one, until #105 moved it to cp_scaffold_preserve below: a project
-# customizing its CI turned out to be at least as common as one customizing the
-# hook, and losing it needed more than a backup, it needed not being
-# overwritten at all), so the false case was the likely one, and its symptom
-# was silent: the local check script stayed on disk, its call site was reset,
-# nothing errored, and the guardrail became decoration. Backing up unconditionally
-# makes the loss recoverable AND prints a "backed up:" line, which is the
-# signal that was missing. Cost is a .scaffold-bak beside each file that
-# actually changed in the upgrade; `.githooks/local.d/` now exists so local
-# checks need not live in a scaffold-owned file at all.
+# ALWAYS backs up before overwriting, not just under --force (issue #72). The
+# old policy skipped the refresh backup on the premise that the prior bytes
+# were recoverable scaffold code: true for an untouched destination, false for
+# an edited one, and nothing tested which case applied. That mattered most for
+# .githooks/pre-commit, the file a project MUST edit to wire in a local check:
+# a reset call site failed silently, the guardrail became decoration, and
+# nothing said so. Unconditional backup makes the loss recoverable and prints
+# a "backed up:" line, the signal that was missing. Cost is one .scaffold-bak
+# per changed file; `.githooks/local.d/` now exists so local checks need not
+# live in a scaffold-owned file at all.
 #
-# If _backup fails (>99 slots), we skip this ONE file rather than overwrite it
-# unbacked — same policy as cp_safe/cp_pattern (B12). That defers a scanner
-# refresh, so _backup prints why and tells the user to clean up and re-run.
+# If _backup fails (>99 slots), skip this ONE file rather than overwrite it
+# unbacked, same policy as cp_safe/cp_pattern (B12); _backup prints why and
+# tells the user to clean up and re-run.
 cp_scaffold() {
   local src=$1 dst=$2
   if [ -e "$dst" ] || [ -L "$dst" ]; then
@@ -330,15 +319,16 @@ install_test_workflow_ci() {
   fi
 }
 
-# install_opt_in_zizmor_ci / install_opt_in_socket_ci: same shape as
-# --gitleaks-ci / --dependency-review in install.sh: a dedicated flag installs
-# the workflow via cp_scaffold_preserve (drift-preserving, same policy as
-# gitleaks.yml / dependency-review.yml since #110 / #113) and prints one
-# explanatory note. Extracted here rather than left inline (unlike
-# --gitleaks-ci / --dependency-review) for the same reason
-# install_test_workflow_ci and install-verify.sh exist: install.sh is pinned
-# at its own 500-line module cap (issue #84), and these two opt-ins were the
-# lines that pushed it over.
+# install_opt_in_* functions below (zizmor CI, Socket CI, npm cooldown #117):
+# each is a dedicated flag installing one opt-in artifact plus an explanatory
+# note, extracted here rather than left inline in install.sh for the same
+# reason install_test_workflow_ci and install-verify.sh exist: install.sh is
+# pinned at its own 500-line module cap (issue #84), and these were the lines
+# that pushed it over. zizmor/socket use cp_scaffold_preserve (CI workflows,
+# drift-preserving, #110/#113 policy); npm-cooldown uses cp_safe instead:
+# .npmrc is USER-OWNED (a project may already have one, or may hand-edit the
+# shipped copy), not scaffold-owned CI, the same policy as ruff.toml /
+# .scaffold.toml.
 install_opt_in_zizmor_ci() {
   if [ "$ZIZMOR_CI" -eq 1 ]; then
     cp_scaffold_preserve "$SCAFFOLD_DIR/.github/workflows/zizmor.yml.template" ".github/workflows/zizmor.yml"
@@ -350,6 +340,13 @@ install_opt_in_socket_ci() {
   if [ "$SOCKET_CI" -eq 1 ]; then
     cp_scaffold_preserve "$SCAFFOLD_DIR/.github/workflows/socket-security.yml.template" ".github/workflows/socket-security.yml"
     echo "note: socket-security.yml blocks a known-malicious or typosquat/hallucinated package AT INSTALL TIME, before its code runs. No API key needed for the default firewall-free mode."
+  fi
+}
+
+install_opt_in_npm_cooldown() {
+  if [ "$NPM_COOLDOWN" -eq 1 ]; then
+    cp_safe "$SCAFFOLD_DIR/.npmrc.template" ".npmrc"
+    echo "note: .npmrc sets min-release-age=7 (npm >=11.10.0 only; an older npm just warns and ignores the key, install still proceeds). See the template header for the 7-day choice and the 'before' interaction."
   fi
 }
 
@@ -462,6 +459,7 @@ print_not_enabled_summary() {
   [ -f .github/workflows/dependency-review.yml ] || { echo "  - dependency-review CI gate (blocks vulnerable/malicious deps on a PR): not enabled. Enable with ./install.sh --dependency-review"; any=1; }
   [ -f .github/workflows/zizmor.yml ]            || { echo "  - zizmor CI gate (audits your own GitHub Actions workflows): not enabled. Enable with ./install.sh --zizmor-ci"; any=1; }
   [ -f .github/workflows/socket-security.yml ]   || { echo "  - Socket Firewall CI gate (blocks a malicious/typosquat package at install time): not enabled. Enable with ./install.sh --socket-ci"; any=1; }
+  [ -f .npmrc ]                                  || { echo "  - npm install-layer cooldown (.npmrc min-release-age, delays freshly published versions): not enabled. Enable with ./install.sh --npm-cooldown"; any=1; }
   [ -f .claude/settings.json ]                   || { echo "  - Claude Code agent guardrails: not enabled. Enable with ./install.sh --claude"; any=1; }
   [ -f .cursor/hooks.json ]                      || { echo "  - Cursor agent guardrails: not enabled. Enable with ./install.sh --cursor"; any=1; }
   [ -f .githooks/commit-msg ]                    || { echo "  - commit-msg hook (Conventional Commits): not enabled. Enable with ./install.sh --commit-msg"; any=1; }

--- a/install-lib.sh
+++ b/install-lib.sh
@@ -319,16 +319,16 @@ install_test_workflow_ci() {
   fi
 }
 
-# install_opt_in_* functions below (zizmor CI, Socket CI, npm cooldown #117):
-# each is a dedicated flag installing one opt-in artifact plus an explanatory
-# note, extracted here rather than left inline in install.sh for the same
-# reason install_test_workflow_ci and install-verify.sh exist: install.sh is
-# pinned at its own 500-line module cap (issue #84), and these were the lines
-# that pushed it over. zizmor/socket use cp_scaffold_preserve (CI workflows,
-# drift-preserving, #110/#113 policy); npm-cooldown uses cp_safe instead:
-# .npmrc is USER-OWNED (a project may already have one, or may hand-edit the
-# shipped copy), not scaffold-owned CI, the same policy as ruff.toml /
-# .scaffold.toml.
+# install_opt_in_* functions below (zizmor CI, Socket CI, npm cooldown #117,
+# Claude Skill #118): each is a dedicated flag installing one opt-in artifact
+# plus an explanatory note, extracted here rather than left inline in
+# install.sh for the same reason install_test_workflow_ci and
+# install-verify.sh exist: install.sh is pinned at its own 500-line module
+# cap (issue #84), and these were the lines that pushed it over. zizmor/socket
+# use cp_scaffold_preserve (CI workflows, drift-preserving, #110/#113 policy);
+# npm-cooldown and claude-skill use cp_safe instead: .npmrc and SKILL.md are
+# USER-OWNED (a project may hand-edit either), not scaffold-owned CI, the same
+# policy as ruff.toml / .scaffold.toml.
 install_opt_in_zizmor_ci() {
   if [ "$ZIZMOR_CI" -eq 1 ]; then
     cp_scaffold_preserve "$SCAFFOLD_DIR/.github/workflows/zizmor.yml.template" ".github/workflows/zizmor.yml"
@@ -347,6 +347,13 @@ install_opt_in_npm_cooldown() {
   if [ "$NPM_COOLDOWN" -eq 1 ]; then
     cp_safe "$SCAFFOLD_DIR/.npmrc.template" ".npmrc"
     echo "note: .npmrc sets min-release-age=7 (npm >=11.10.0 only; an older npm just warns and ignores the key, install still proceeds). See the template header for the 7-day choice and the 'before' interaction."
+  fi
+}
+
+install_opt_in_claude_skill() {
+  if [ "$CLAUDE_SKILL" -eq 1 ]; then
+    cp_safe "$SCAFFOLD_DIR/claude-skill/coding-rules/SKILL.md.template" ".claude/skills/coding-rules/SKILL.md"
+    echo "note: SKILL.md gives Claude Code on-demand loading of coding-rules.md / operational-rules.md, a complement to the always-loaded AGENTS.md summary (--claude installs runtime hooks instead, a different mechanism)."
   fi
 }
 
@@ -460,6 +467,7 @@ print_not_enabled_summary() {
   [ -f .github/workflows/zizmor.yml ]            || { echo "  - zizmor CI gate (audits your own GitHub Actions workflows): not enabled. Enable with ./install.sh --zizmor-ci"; any=1; }
   [ -f .github/workflows/socket-security.yml ]   || { echo "  - Socket Firewall CI gate (blocks a malicious/typosquat package at install time): not enabled. Enable with ./install.sh --socket-ci"; any=1; }
   [ -f .npmrc ]                                  || { echo "  - npm install-layer cooldown (.npmrc min-release-age, delays freshly published versions): not enabled. Enable with ./install.sh --npm-cooldown"; any=1; }
+  [ -f .claude/skills/coding-rules/SKILL.md ]    || { echo "  - Claude Code Skill (on-demand rules loading): not enabled. Enable with ./install.sh --claude-skill"; any=1; }
   [ -f .claude/settings.json ]                   || { echo "  - Claude Code agent guardrails: not enabled. Enable with ./install.sh --claude"; any=1; }
   [ -f .cursor/hooks.json ]                      || { echo "  - Cursor agent guardrails: not enabled. Enable with ./install.sh --cursor"; any=1; }
   [ -f .githooks/commit-msg ]                    || { echo "  - commit-msg hook (Conventional Commits): not enabled. Enable with ./install.sh --commit-msg"; any=1; }

--- a/install.sh
+++ b/install.sh
@@ -20,6 +20,8 @@
 #                            # default-on)
 #   install.sh --zizmor-ci   # also install the zizmor GitHub Actions audit gate
 #   install.sh --socket-ci   # also install the Socket Firewall supply-chain gate
+#   install.sh --npm-cooldown # also install .npmrc's min-release-age (delays
+#                            # newly published npm versions, needs npm >=11.10)
 #   install.sh --all-langs  # install every language's forbidden-pattern file
 #   install.sh --coverage-gate # install the patch-coverage gate INSTEAD of the
 #                            # plain tests.yml (tests still run, plus a stricter
@@ -33,23 +35,22 @@
 # Test execution in CI is DEFAULT-ON (#97): a plain install writes
 # `.github/workflows/tests.yml` so pytest/vitest run on every PR/push, no
 # coverage threshold. `--coverage-gate` swaps that for `.github/workflows/coverage.yml`
-# (same tests, plus a diff-cover patch-coverage gate) rather than installing both,
-# never both, so a repo's tests never run twice in the same CI run. Only
-# `--no-test-workflow` leaves a repo with no test execution in CI, and it says so
-# loudly in the summary below, per the "record every skip" rule.
+# (same tests, plus a diff-cover patch-coverage gate), never both installed at
+# once, so a repo's tests never run twice in the same CI run. Only
+# `--no-test-workflow` leaves a repo with no test execution in CI, and it says
+# so loudly in the summary below, per the "record every skip" rule.
 #
 # On re-run (upgrade): scaffold-owned code (the hook, .githooks/lib/*, the
 # commit-msg hook) is REFRESHED when it differs from the shipped version, so
-# security fixes reach you just by re-running, and every file it overwrites
-# is BACKED UP to .scaffold-bak first, so an edit you made to one is
-# recoverable and the "backed up:" line tells you it happened. User-owned
-# configs are left alone. A drifted .forbidden-patterns/*.txt, or a drifted
-# CI workflow (lint.yml, tests.yml, coverage.yml, gitleaks.yml,
-# dependency-review.yml, zizmor.yml, socket-security.yml), only prints
-# a notice and keeps your file (use --force to replace it: your
-# customizations are backed up to .scaffold-bak first).
-# .githooks/local.d/ is never written to at all: it's where project-local checks
-# live precisely so an upgrade cannot unwire them.
+# security fixes reach you just by re-running, and every file it overwrites is
+# BACKED UP to .scaffold-bak first, so an edit you made to one is recoverable
+# and the "backed up:" line tells you it happened. User-owned configs are left
+# alone. A drifted .forbidden-patterns/*.txt or CI workflow (lint.yml,
+# tests.yml, coverage.yml, gitleaks.yml, dependency-review.yml, zizmor.yml,
+# socket-security.yml) only prints a notice and keeps your file (--force
+# replaces it, backed up first). .githooks/local.d/ is never written to at
+# all: it's where project-local checks live precisely so an upgrade cannot
+# unwire them.
 
 set -euo pipefail
 
@@ -65,6 +66,7 @@ GITLEAKS_CI=0
 DEPENDENCY_REVIEW=0
 ZIZMOR_CI=0
 SOCKET_CI=0
+NPM_COOLDOWN=0
 ALL_LANGS=0
 COVERAGE_GATE=0
 NO_TEST_WORKFLOW=0
@@ -86,11 +88,12 @@ for arg in "$@"; do
     --dependency-review) DEPENDENCY_REVIEW=1 ;;
     --zizmor-ci)  ZIZMOR_CI=1 ;;
     --socket-ci)  SOCKET_CI=1 ;;
+    --npm-cooldown) NPM_COOLDOWN=1 ;;
     --all-langs)  ALL_LANGS=1 ;;
     --coverage-gate) COVERAGE_GATE=1 ;;
     --no-test-workflow) NO_TEST_WORKFLOW=1 ;;
     --no-install) NO_INSTALL=1 ;;
-    --help|-h)    sed -n '2,52p' "$0"; exit 0 ;;
+    --help|-h)    sed -n '2,53p' "$0"; exit 0 ;;
     *) echo "error: unknown argument: $arg" >&2; exit 1 ;;
   esac
 done
@@ -145,17 +148,12 @@ if [ "$MODE" = "auto" ]; then
 fi
 
 # --- file ownership & the install/upgrade model -----------------------------
-# The install/upgrade policy helpers: cp_scaffold (scaffold-owned CODE,
-# refreshed on re-run), cp_safe (USER-OWNED, never auto-replaced), cp_pattern
-# (.forbidden-patterns/*.txt, notify-on-drift), cp_scaffold_preserve
-# (scaffold-owned CI workflows: lint.yml, tests.yml, coverage.yml,
-# gitleaks.yml, dependency-review.yml, zizmor.yml, socket-security.yml,
-# notify-on-drift like cp_pattern, since #110), and the shared
-# _cp_replace / _backup mechanism (where the A7 symlink defenses live) plus
-# mkx, are defined in install-lib.sh. They're SOURCED (not exec'd) so they
-# run in this shell with its globals (FORCE) and `set -euo pipefail`.
-# Extracted to keep this script under the scaffold's own 500-line
-# module-size cap; see install-lib.sh for the full policy rationale.
+# The install/upgrade policy helpers (cp_scaffold, cp_safe, cp_pattern,
+# cp_scaffold_preserve, the shared _cp_replace / _backup mechanism where the
+# A7 symlink defenses live, and mkx) are defined in install-lib.sh; see its
+# own header comment for the full per-helper policy. SOURCED (not exec'd) so
+# they run in this shell with its globals (FORCE) and `set -euo pipefail`.
+# Extracted to keep this script under the scaffold's own 500-line cap.
 # shellcheck source=install-lib.sh
 . "$SCAFFOLD_DIR/install-lib.sh"
 
@@ -164,11 +162,9 @@ fi
 # the pointer template. If present, append a marked block importing AGENTS.md
 # once, and only if no @AGENTS.md import already exists.
 install_claude_md() {
-  # A symlink at CLAUDE.md is suspicious: `[ -e ]` is false for a DANGLING link
-  # (so the create branch's cp would write the pointer THROUGH it, outside the
-  # repo) and FOLLOWS a live one (so the `>>` append would append through it).
-  # Test `-L` first and never write through it — the same A7 defense the cp_*
-  # helpers carry, which this bespoke handler had been missing (B1).
+  # A symlink at CLAUDE.md is suspicious (`[ -e ]` is false for a dangling one
+  # and follows a live one): test `-L` first and never write through it, the
+  # same A7 defense the cp_* helpers carry, missing from this handler (B1).
   if [ -L "CLAUDE.md" ]; then
     echo "skip (exists, symlink): CLAUDE.md — left untouched; a scaffold path that is a symlink is suspicious. Replace it with a real file to wire the AGENTS.md import."
     return
@@ -193,10 +189,9 @@ install_claude_md() {
 }
 
 # warn_pair_gap / warn_pair_note: install.sh's reporters for install-lib.sh's
-# check_paired_artifacts (#96). install.sh never fails the run over one of
-# these findings (they are advisory, not install errors), so both just print;
-# the gap/note distinction stays in the wording, matching how scaffold-doctor.sh
-# reports the exact same states with a real exit-status difference.
+# check_paired_artifacts (#96); advisory only, so both just print (install.sh
+# never fails the run over one), matching scaffold-doctor.sh's wording for
+# the same states, which DO carry a real exit-status difference there.
 warn_pair_gap() {
   echo "warning: $1"
   echo "         fix: $2"
@@ -209,9 +204,8 @@ warn_pair_note() {
 # so an existing one is never clobbered (even with --force). Skip if present;
 # create from template only when absent.
 install_agents_md() {
-  # `[ -e ]` is false for a dangling symlink, so the create branch's cp would
-  # write the template THROUGH it to an outside path. Test `-L` first and skip
-  # (same A7 defense as the cp_* helpers, missing from this handler — B1).
+  # `[ -e ]` is false for a dangling symlink; test `-L` first and skip (same
+  # A7 defense as the cp_* helpers, missing from this handler, B1).
   if [ -L "AGENTS.md" ]; then
     echo "skip (exists, symlink): AGENTS.md — left untouched; a scaffold path that is a symlink is suspicious. Replace it with a real file to install the template."
     return
@@ -435,12 +429,12 @@ if [ "$DEPENDENCY_REVIEW" -eq 1 ]; then
   echo "note: dependency-review.yml needs GitHub's Dependency Graph (on by default for public repos; needs GitHub Advanced Security for private repos, or it errors)."
 fi
 
-# Opt-in zizmor / Socket Firewall CI gates (--zizmor-ci, --socket-ci). Same
-# shape as --gitleaks-ci / --dependency-review above (cp_scaffold_preserve,
-# opt-in, --force replaces); the function bodies live in install-lib.sh to
-# keep this file under its own 500-line cap (issue #84).
+# Opt-in zizmor / Socket Firewall CI gates (--zizmor-ci, --socket-ci) and the
+# npm install-layer cooldown (--npm-cooldown, #117); function bodies live in
+# install-lib.sh to keep this file under its own 500-line cap (issue #84).
 install_opt_in_zizmor_ci
 install_opt_in_socket_ci
+install_opt_in_npm_cooldown
 
 # Test-execution CI workflow (#97): DEFAULT-ON, exactly one of two shapes,
 # plus a recorded opt-out (--no-test-workflow). See install-lib.sh's

--- a/install.sh
+++ b/install.sh
@@ -22,6 +22,8 @@
 #   install.sh --socket-ci   # also install the Socket Firewall supply-chain gate
 #   install.sh --npm-cooldown # also install .npmrc's min-release-age (delays
 #                            # newly published npm versions, needs npm >=11.10)
+#   install.sh --claude-skill # also install an on-demand Claude Code Skill
+#                            # that loads coding-rules.md/operational-rules.md
 #   install.sh --all-langs  # install every language's forbidden-pattern file
 #   install.sh --coverage-gate # install the patch-coverage gate INSTEAD of the
 #                            # plain tests.yml (tests still run, plus a stricter
@@ -67,6 +69,7 @@ DEPENDENCY_REVIEW=0
 ZIZMOR_CI=0
 SOCKET_CI=0
 NPM_COOLDOWN=0
+CLAUDE_SKILL=0
 ALL_LANGS=0
 COVERAGE_GATE=0
 NO_TEST_WORKFLOW=0
@@ -89,11 +92,12 @@ for arg in "$@"; do
     --zizmor-ci)  ZIZMOR_CI=1 ;;
     --socket-ci)  SOCKET_CI=1 ;;
     --npm-cooldown) NPM_COOLDOWN=1 ;;
+    --claude-skill) CLAUDE_SKILL=1 ;;
     --all-langs)  ALL_LANGS=1 ;;
     --coverage-gate) COVERAGE_GATE=1 ;;
     --no-test-workflow) NO_TEST_WORKFLOW=1 ;;
     --no-install) NO_INSTALL=1 ;;
-    --help|-h)    sed -n '2,53p' "$0"; exit 0 ;;
+    --help|-h)    sed -n '2,55p' "$0"; exit 0 ;;
     *) echo "error: unknown argument: $arg" >&2; exit 1 ;;
   esac
 done
@@ -429,12 +433,14 @@ if [ "$DEPENDENCY_REVIEW" -eq 1 ]; then
   echo "note: dependency-review.yml needs GitHub's Dependency Graph (on by default for public repos; needs GitHub Advanced Security for private repos, or it errors)."
 fi
 
-# Opt-in zizmor / Socket Firewall CI gates (--zizmor-ci, --socket-ci) and the
-# npm install-layer cooldown (--npm-cooldown, #117); function bodies live in
-# install-lib.sh to keep this file under its own 500-line cap (issue #84).
+# Opt-in zizmor / Socket Firewall CI gates (--zizmor-ci, --socket-ci), npm
+# install-layer cooldown (--npm-cooldown, #117), and Claude Skill packaging
+# (--claude-skill, #118); function bodies live in install-lib.sh to keep this
+# file under its own 500-line cap (issue #84).
 install_opt_in_zizmor_ci
 install_opt_in_socket_ci
 install_opt_in_npm_cooldown
+install_opt_in_claude_skill
 
 # Test-execution CI workflow (#97): DEFAULT-ON, exactly one of two shapes,
 # plus a recorded opt-out (--no-test-workflow). See install-lib.sh's

--- a/operational-rules.md
+++ b/operational-rules.md
@@ -15,9 +15,10 @@ drop it in your project root and add `@operational-rules.md` to your
 `install.sh`, no hooks, no CI workflow needed.
 
 For Cursor, Cline, Aider, or other AI tools, add an equivalent
-reference to whatever config file the tool uses (`.cursorrules`,
-`.clinerules`, `CONVENTIONS.md`, etc.). The goal is that the agent
-sees this document at the start of every session.
+reference to whatever config file the tool uses (an `alwaysApply: true`
+project rule under `.cursor/rules/`, `.clinerules`, `CONVENTIONS.md`,
+etc.). The goal is that the agent sees this document at the start of
+every session.
 
 If you're using this without an AI agent, the document still works
 as a reference for human engineers. Read it before writing code,

--- a/operational-rules.md
+++ b/operational-rules.md
@@ -315,6 +315,19 @@ victory based on surface pattern matching rather than verified
 behavior; reserving the verdict for the human prevents premature
 "fixed" claims.
 
+### Close every handoff with a plain-language summary
+
+The artifact that makes the rule above usable. Before handing back a
+commit, a PR, or the session itself, state in plain language what
+changed and why, anything destructive or hard to reverse, every check
+you turned down by name, and what the user should verify before calling
+it done. That summary is the decision surface for anyone who does not
+read diffs; it feeds the verdict, it never delivers it.
+_Anchor:_ every enforced output of an AI-assisted change (the diff, the
+failing check, the CI log) assumes a reader who reads code; where the
+accountable human did not, a downgraded guardrail shipped with nothing
+but the diff recording it.
+
 ### Plans default to PROPOSED; mark every assumption
 
 Each value the agent picked itself gets PROPOSED plus a one-line

--- a/operational-rules.md
+++ b/operational-rules.md
@@ -389,6 +389,19 @@ confidently, the right move is to ask, not to guess and proceed.
 Confident-sounding wrong answers are more expensive than honest
 "I'm not sure, here's what I'd need to know" responses.
 
+### Nudge a stalled delegate; a promise to wait is not a report
+
+A delegated agent that ends its turn saying it will wait for a
+background run has stalled: the notification it is waiting for is not
+coming. Prompt-level "run everything in the foreground" instructions
+reduce but do not prevent this. Send the agent one direct message to
+run the remaining work in the foreground and deliver its full report;
+the nudge reliably recovers both the agent and the work.
+_Anchor:_ two implementation agents in one session each launched their
+final test suite in the background and stopped to "wait" despite
+explicit foreground-only instructions; both delivered complete results
+after a one-line nudge.
+
 ---
 
 ## Adding rules to this document

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     ".github/workflows/gitleaks.yml.template",
     ".github/workflows/dependency-review.yml.template",
     ".github/workflows/zizmor.yml.template",
-    ".github/workflows/socket-security.yml.template"
+    ".github/workflows/socket-security.yml.template",
+    ".npmrc.template"
   ],
   "engines": {
     "node": ">=14"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     ".github/workflows/dependency-review.yml.template",
     ".github/workflows/zizmor.yml.template",
     ".github/workflows/socket-security.yml.template",
-    ".npmrc.template"
+    ".npmrc.template",
+    "claude-skill/coding-rules/SKILL.md.template"
   ],
   "engines": {
     "node": ">=14"

--- a/scaffold-doctor.sh
+++ b/scaffold-doctor.sh
@@ -322,6 +322,7 @@ _pne() { note "$1"; PNE_ANY=1; }
 [ -f .claude/settings.json ]                   || _pne "Claude Code agent guardrails: not installed. Enable with install.sh --claude"
 [ -f .cursor/hooks.json ]                      || _pne "Cursor agent guardrails: not installed. Enable with install.sh --cursor"
 [ -f .githooks/commit-msg ]                    || _pne "commit-msg hook (Conventional Commits): not installed. Enable with install.sh --commit-msg"
+[ -f .npmrc ]                                   || _pne "npm install-layer cooldown (.npmrc min-release-age, delays freshly published versions): not installed. Enable with install.sh --npm-cooldown"
 [ "$PNE_ANY" -eq 1 ] || ok "every opt-in protection is enabled in this project"
 
 # --- summary ----------------------------------------------------------------

--- a/scaffold-doctor.sh
+++ b/scaffold-doctor.sh
@@ -323,6 +323,7 @@ _pne() { note "$1"; PNE_ANY=1; }
 [ -f .cursor/hooks.json ]                      || _pne "Cursor agent guardrails: not installed. Enable with install.sh --cursor"
 [ -f .githooks/commit-msg ]                    || _pne "commit-msg hook (Conventional Commits): not installed. Enable with install.sh --commit-msg"
 [ -f .npmrc ]                                   || _pne "npm install-layer cooldown (.npmrc min-release-age, delays freshly published versions): not installed. Enable with install.sh --npm-cooldown"
+[ -f .claude/skills/coding-rules/SKILL.md ]     || _pne "Claude Code Skill (on-demand rules loading): not installed. Enable with install.sh --claude-skill"
 [ "$PNE_ANY" -eq 1 ] || ok "every opt-in protection is enabled in this project"
 
 # --- summary ----------------------------------------------------------------

--- a/tests/cases/11-npm-bundle.sh
+++ b/tests/cases/11-npm-bundle.sh
@@ -39,10 +39,14 @@ else
     REQUIRED=$(
       {
         # SC2016 off on purpose: we match the LITERAL text "$SCAFFOLD_DIR" / "${"
-        # as it appears in install.sh's source, so single quotes (no expansion)
-        # are exactly right.
+        # as it appears in install.sh's / install-lib.sh's source, so single
+        # quotes (no expansion) are exactly right. install-lib.sh is scanned
+        # too (not just install.sh): the install_opt_in_* functions extracted
+        # there to stay under install.sh's 500-line cap (zizmor/socket/
+        # npm-cooldown/claude-skill) reference their own $SCAFFOLD_DIR/...
+        # template paths, which a install.sh-only grep would never see.
         # shellcheck disable=SC2016
-        grep -oE '\$SCAFFOLD_DIR/[^"'"'"' ]+' "$SCAFFOLD_DIR/install.sh" \
+        grep -ohE '\$SCAFFOLD_DIR/[^"'"'"' ]+' "$SCAFFOLD_DIR/install.sh" "$SCAFFOLD_DIR/install-lib.sh" \
           | sed 's#\$SCAFFOLD_DIR/##' | grep -v '\${'
         ( cd "$SCAFFOLD_DIR" \
             && ls forbidden-patterns/*.txt.template githooks/*.template githooks/lib/*.template \

--- a/tests/cases/23-npm-cooldown.sh
+++ b/tests/cases/23-npm-cooldown.sh
@@ -16,7 +16,7 @@ _npmc_fixture() {
   printf '%s' "$t"
 }
 
-# (T) a default install (no flag) writes no .npmrc — stays opt-in.
+# (T) a default install (no flag) writes no .npmrc: stays opt-in.
 D=$(_npmc_fixture)
 if [ ! -e "$D/.npmrc" ]; then
   echo "  ✓ a default install creates no .npmrc"; PASS=$((PASS + 1))

--- a/tests/cases/23-npm-cooldown.sh
+++ b/tests/cases/23-npm-cooldown.sh
@@ -1,0 +1,68 @@
+# shellcheck shell=bash
+# cases/23-npm-cooldown.sh: the opt-in npm install-layer cooldown
+# (--npm-cooldown, #117). .npmrc is USER-OWNED (a project may already have
+# one, or may hand-edit the shipped copy), so it installs via cp_safe, not
+# cp_scaffold_preserve like the CI-workflow opt-ins cases/21 already covers:
+# install if absent, skip on drift unless --force (back up first), never a
+# drift NOTE. Sourced into the driver's shell, so PASS/FAIL/SCAFFOLD_DIR/
+# HOOK_OUT are already in scope.
+
+echo "cases/23: --npm-cooldown opt-in flag (#117)"
+
+_npmc_fixture() {
+  local t; t=$(mktemp -d)
+  ( cd "$t" && git init --quiet && echo '{"name":"x"}' >package.json \
+    && "$SCAFFOLD_DIR/install.sh" --frontend --no-verify "$@" ) >/dev/null 2>&1
+  printf '%s' "$t"
+}
+
+# (T) a default install (no flag) writes no .npmrc — stays opt-in.
+D=$(_npmc_fixture)
+if [ ! -e "$D/.npmrc" ]; then
+  echo "  ✓ a default install creates no .npmrc"; PASS=$((PASS + 1))
+else
+  echo "  ✗ a default install should not create .npmrc"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$D"
+
+# (T) --npm-cooldown installs .npmrc with min-release-age=7, byte-identical
+# to the shipped template.
+N=$(_npmc_fixture --npm-cooldown)
+if [ -f "$N/.npmrc" ] && grep -q '^min-release-age=7$' "$N/.npmrc" \
+   && cmp -s "$SCAFFOLD_DIR/.npmrc.template" "$N/.npmrc"; then
+  echo "  ✓ --npm-cooldown installs .npmrc with min-release-age=7"; PASS=$((PASS + 1))
+else
+  echo "  ✗ --npm-cooldown should install .npmrc matching the shipped template"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$N"
+
+# (T) cp_safe semantics: a hand-edited .npmrc is left alone on a plain
+# re-run (no drift note, no backup), and --force backs it up then replaces
+# it with the shipped version.
+S=$(_npmc_fixture --npm-cooldown)
+printf '\n# local override\nregistry=https://example.invalid/\n' >>"$S/.npmrc"
+( cd "$S" && "$SCAFFOLD_DIR/install.sh" --frontend --no-verify --npm-cooldown ) >"$HOOK_OUT" 2>&1
+if grep -qF "local override" "$S/.npmrc" && [ ! -e "$S/.npmrc.scaffold-bak" ] \
+   && grep -q "skip (exists): .npmrc" "$HOOK_OUT"; then
+  echo "  ✓ a hand-edited .npmrc is left alone on a plain re-run (cp_safe)"; PASS=$((PASS + 1))
+else
+  echo "  ✗ a hand-edited .npmrc should be skipped, not replaced, on a plain re-run"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+( cd "$S" && "$SCAFFOLD_DIR/install.sh" --frontend --no-verify --npm-cooldown --force ) >"$HOOK_OUT" 2>&1
+if [ -f "$S/.npmrc.scaffold-bak" ] && grep -qF "local override" "$S/.npmrc.scaffold-bak" \
+   && cmp -s "$SCAFFOLD_DIR/.npmrc.template" "$S/.npmrc"; then
+  echo "  ✓ --force backs up the edited .npmrc then installs the shipped version"; PASS=$((PASS + 1))
+else
+  echo "  ✗ --force should back up the edited .npmrc then replace it"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$S"
+
+# (T) uninstall.sh removes an unmodified .npmrc.
+U=$(_npmc_fixture --npm-cooldown)
+( cd "$U" && "$SCAFFOLD_DIR/uninstall.sh" ) >"$HOOK_OUT" 2>&1
+if [ ! -e "$U/.npmrc" ]; then
+  echo "  ✓ uninstall.sh removes an unmodified .npmrc"; PASS=$((PASS + 1))
+else
+  echo "  ✗ uninstall.sh should remove an unmodified .npmrc"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$U"

--- a/tests/cases/24-claude-skill.sh
+++ b/tests/cases/24-claude-skill.sh
@@ -1,0 +1,76 @@
+# shellcheck shell=bash
+# cases/24-claude-skill.sh: the opt-in Claude Code Skill packaging
+# (--claude-skill, #118 part 2). SKILL.md is USER-OWNED (a project may
+# hand-edit it), so it installs via cp_safe, not cp_scaffold_preserve like
+# the CI-workflow opt-ins cases/21 already covers: install if absent, skip
+# on drift unless --force (back up first), never a drift NOTE. Sourced into
+# the driver's shell, so PASS/FAIL/SCAFFOLD_DIR/HOOK_OUT are already in
+# scope.
+
+echo "cases/24: --claude-skill opt-in flag (#118 pt 2)"
+
+_cskill_fixture() {
+  local t; t=$(mktemp -d)
+  ( cd "$t" && git init --quiet && echo '{"name":"x"}' >package.json \
+    && "$SCAFFOLD_DIR/install.sh" --frontend --no-verify "$@" ) >/dev/null 2>&1
+  printf '%s' "$t"
+}
+
+# (T) a default install (no flag) writes no Skill file — stays opt-in.
+D=$(_cskill_fixture)
+if [ ! -e "$D/.claude/skills/coding-rules/SKILL.md" ]; then
+  echo "  ✓ a default install creates no Claude Skill"; PASS=$((PASS + 1))
+else
+  echo "  ✗ a default install should not create the Claude Skill"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$D"
+
+# (T) --claude-skill installs SKILL.md, byte-identical to the shipped
+# template, with valid frontmatter naming both installed rules files.
+K=$(_cskill_fixture --claude-skill)
+SKILL_PATH="$K/.claude/skills/coding-rules/SKILL.md"
+if [ -f "$SKILL_PATH" ] \
+   && cmp -s "$SCAFFOLD_DIR/claude-skill/coding-rules/SKILL.md.template" "$SKILL_PATH" \
+   && head -1 "$SKILL_PATH" | grep -qx -- '---' \
+   && grep -q '^name: coding-rules$' "$SKILL_PATH" \
+   && grep -q '^description:' "$SKILL_PATH" \
+   && grep -q 'coding-rules.md' "$SKILL_PATH" \
+   && grep -q 'operational-rules.md' "$SKILL_PATH"; then
+  echo "  ✓ --claude-skill installs SKILL.md with frontmatter naming both rules files"; PASS=$((PASS + 1))
+else
+  echo "  ✗ --claude-skill should install a SKILL.md with name/description frontmatter"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$K"
+
+# (T) cp_safe semantics: a hand-edited SKILL.md is left alone on a plain
+# re-run (no drift note, no backup), and --force backs it up then replaces
+# it with the shipped version.
+S=$(_cskill_fixture --claude-skill)
+SKILL_PATH="$S/.claude/skills/coding-rules/SKILL.md"
+printf '\nlocal note\n' >>"$SKILL_PATH"
+( cd "$S" && "$SCAFFOLD_DIR/install.sh" --frontend --no-verify --claude-skill ) >"$HOOK_OUT" 2>&1
+if grep -qF "local note" "$SKILL_PATH" && [ ! -e "$SKILL_PATH.scaffold-bak" ] \
+   && grep -q "skip (exists): .claude/skills/coding-rules/SKILL.md" "$HOOK_OUT"; then
+  echo "  ✓ a hand-edited SKILL.md is left alone on a plain re-run (cp_safe)"; PASS=$((PASS + 1))
+else
+  echo "  ✗ a hand-edited SKILL.md should be skipped, not replaced, on a plain re-run"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+( cd "$S" && "$SCAFFOLD_DIR/install.sh" --frontend --no-verify --claude-skill --force ) >"$HOOK_OUT" 2>&1
+if [ -f "$SKILL_PATH.scaffold-bak" ] && grep -qF "local note" "$SKILL_PATH.scaffold-bak" \
+   && cmp -s "$SCAFFOLD_DIR/claude-skill/coding-rules/SKILL.md.template" "$SKILL_PATH"; then
+  echo "  ✓ --force backs up the edited SKILL.md then installs the shipped version"; PASS=$((PASS + 1))
+else
+  echo "  ✗ --force should back up the edited SKILL.md then replace it"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$S"
+
+# (T) uninstall.sh removes an unmodified SKILL.md and sweeps the now-empty
+# .claude/skills/coding-rules + .claude/skills directories.
+U=$(_cskill_fixture --claude-skill)
+( cd "$U" && "$SCAFFOLD_DIR/uninstall.sh" ) >"$HOOK_OUT" 2>&1
+if [ ! -e "$U/.claude/skills/coding-rules/SKILL.md" ] && [ ! -d "$U/.claude/skills" ]; then
+  echo "  ✓ uninstall.sh removes an unmodified SKILL.md and sweeps the emptied dirs"; PASS=$((PASS + 1))
+else
+  echo "  ✗ uninstall.sh should remove the unmodified SKILL.md and the emptied dirs"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$U"

--- a/tests/cases/24-claude-skill.sh
+++ b/tests/cases/24-claude-skill.sh
@@ -16,7 +16,7 @@ _cskill_fixture() {
   printf '%s' "$t"
 }
 
-# (T) a default install (no flag) writes no Skill file — stays opt-in.
+# (T) a default install (no flag) writes no Skill file: stays opt-in.
 D=$(_cskill_fixture)
 if [ ! -e "$D/.claude/skills/coding-rules/SKILL.md" ]; then
   echo "  ✓ a default install creates no Claude Skill"; PASS=$((PASS + 1))

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -57,7 +57,8 @@ for case_file in \
   "$HERE/cases/19-test-workflow.sh" \
   "$HERE/cases/20-paired-artifacts.sh" \
   "$HERE/cases/21-ci-workflow-drift.sh" \
-  "$HERE/cases/22-large-file-guard.sh"; do
+  "$HERE/cases/22-large-file-guard.sh" \
+  "$HERE/cases/23-npm-cooldown.sh"; do
   # shellcheck source=/dev/null
   . "$case_file"
 done

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -58,7 +58,8 @@ for case_file in \
   "$HERE/cases/20-paired-artifacts.sh" \
   "$HERE/cases/21-ci-workflow-drift.sh" \
   "$HERE/cases/22-large-file-guard.sh" \
-  "$HERE/cases/23-npm-cooldown.sh"; do
+  "$HERE/cases/23-npm-cooldown.sh" \
+  "$HERE/cases/24-claude-skill.sh"; do
   # shellcheck source=/dev/null
   . "$case_file"
 done

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -173,6 +173,9 @@ remove_if_unmodified ".github/workflows/socket-security.yml" "$SCAFFOLD_DIR/.git
 # Opt-in npm install-layer cooldown (only present if installed with
 # --npm-cooldown, #117).
 remove_if_unmodified ".npmrc" "$SCAFFOLD_DIR/.npmrc.template"
+# Opt-in Claude Code Skill (only present if installed with --claude-skill,
+# #118 pt 2).
+remove_if_unmodified ".claude/skills/coding-rules/SKILL.md" "$SCAFFOLD_DIR/claude-skill/coding-rules/SKILL.md.template"
 
 # Likely-customized files — only with --all
 if [ "$REMOVE_ALL" -eq 1 ]; then
@@ -184,7 +187,8 @@ fi
 
 # Clean up empty dirs the installer created
 # local.d before .githooks, so an emptied local.d lets .githooks go too.
-for dir in .githooks/lib .githooks/local.d .githooks .github/workflows .github .claude .cursor; do
+for dir in .githooks/lib .githooks/local.d .githooks .github/workflows .github \
+           .claude/skills/coding-rules .claude/skills .claude .cursor; do
   [ -d "$dir" ] || continue
   if rmdir "$dir" 2>/dev/null; then
     echo "removed empty: $dir"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -170,6 +170,9 @@ remove_if_unmodified ".github/workflows/zizmor.yml" "$SCAFFOLD_DIR/.github/workf
 # Opt-in Socket Firewall supply-chain CI gate (only present if installed
 # with --socket-ci).
 remove_if_unmodified ".github/workflows/socket-security.yml" "$SCAFFOLD_DIR/.github/workflows/socket-security.yml.template"
+# Opt-in npm install-layer cooldown (only present if installed with
+# --npm-cooldown, #117).
+remove_if_unmodified ".npmrc" "$SCAFFOLD_DIR/.npmrc.template"
 
 # Likely-customized files — only with --all
 if [ "$REMOVE_ALL" -eq 1 ]; then


### PR DESCRIPTION
## Summary

Completes the three follow-up issues from the 2026-08-28 rules audit, finishing the deferred pile.

- **Plain-language change summary (#116):** AGENTS.md now requires the agent to close every session, commit, and PR handoff with a plain-language summary: what changed and why, anything destructive or hard to reverse, every guardrail downgrade by name, and what the user should check before calling it done. Framed explicitly as the human's decision surface, not a substitute reviewer; the existing name-every-downgrade rule folds into it without duplication. A matching rule lands in operational-rules.md for the standalone path.
- **npm install-layer cooldown (#117):** new opt-in `--npm-cooldown` flag ships an `.npmrc` with `min-release-age=7`, matching the repo's Dependabot cooldown, so freshly published (possibly freshly compromised) package versions wait a week before an agent's `npm install` will take them. Semantics verified against npm's own docs this time: key introduced in npm 11.10.0, unit is days, an explicit `before` date wins, and older npm fails open with a warning. Preserves any existing `.npmrc`; uninstall removes only an unmodified one.
- **Cursor docs currency (#118 part 1):** `.cursorrules` guidance replaced with the current `.cursor/rules` + `.mdc` mechanism (Cursor marks `.cursorrules` legacy), and the stale claim that Cursor cannot deny file reads corrected: `beforeReadFile` now exists. Shipped hooks.json schema verified claim-by-claim against live Cursor docs.
- **Claude Skill packaging (#118 part 2):** new opt-in `--claude-skill` flag installs `.claude/skills/coding-rules/SKILL.md`, giving Claude Code on-demand loading of the full rules text as a complement to the always-loaded AGENTS.md summary.

Both new flags follow the house opt-in pattern end to end: installer flag, preserve-on-existing copy, uninstall removal, doctor and not-enabled-summary self-announcement, README flag table, TECHNICAL.md opt-in layers, npm bundle, and dedicated test cases (23, 24).

## Verification

Implemented by two parallel worktree agents, merged, then independently verified with fresh context: full suite on the merged tree (357 passed, 5 known local-environment failures), shellcheck and prettier clean, both flags exercised end to end in scratch repos including uninstall and preserve-on-existing behavior, and every npm and Cursor claim checked against live primary docs. The verification found one minor defect (a mechanism misstatement in the Skill description) and three em dashes on added lines; all fixed and re-gated.

Closes #116
Closes #117
Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)