### PR TITLE
chore(release): v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,30 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+## [v0.13.0] - 2026-09-01
+
+A catch-up release: `main` had drifted 114 commits ahead of the last npm
+publish (#126), so `--zizmor-ci`, `--socket-ci`, `--npm-cooldown`, and
+`--claude-skill` existed on the repo but were unreachable via `npx`. This
+release ships them, plus the Cursor `beforeReadFile` credential guard, the
+paired-artifact half-install detector, the byte-size large-file guard, the
+dependency-review AGPL gate, and two new operational-rules.md entries.
+
 ### Added
 
+- **`operational-rules.md`: eight new entries adopted from issue #120.** A
+  conditional must not be a shell function's last command under errexit; assert
+  the positive outcome, not the absence of the symptom; in cross-platform
+  fallback chains, the noisy-failure variant goes last; version bumps travel
+  only in release commits; a check that can pass by luck is failing; track
+  work in at most two places; one writer per repo at a time, check before
+  merging; end every session with a rules retrospective.
+- **`operational-rules.md`: "Choose the strongest approach before starting,
+  not the fastest one to finish" (#124).** Decide between the correct/robust
+  approach and the quick one before writing the fix, not after: by the time
+  work is done and under review, the fast path is already built and sunk cost
+  pushes toward keeping it, so the decision has to happen at the fork, not as
+  a postmortem question.
 - **Cursor `beforeReadFile` credential-path guard.** `install.sh --cursor` now
   wires `.githooks/lib/agent-precheck` to Cursor's `beforeReadFile` hook too
   (previously only `beforeShellExecution` was wired), denying reads of

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ somewhere stable:
 
 ```sh
 # Recommended: pin to a tagged release for reproducibility
-git clone --branch v0.12.0 https://github.com/Sting25/ai-coding-rules-scaffold ~/src/ai-coding-rules-scaffold
+git clone --branch v0.13.0 https://github.com/Sting25/ai-coding-rules-scaffold ~/src/ai-coding-rules-scaffold
 # Or track main if you want the latest changes
 git clone https://github.com/Sting25/ai-coding-rules-scaffold ~/src/ai-coding-rules-scaffold
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-coding-rules-scaffold",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Agent-agnostic coding-rules scaffold: pre-commit + CI guardrails (file size, forbidden patterns, secret/credential scanning, hygiene) that install into your project, plus `scaffold-doctor` to check they are actually armed and not just present. Run via `npx ai-coding-rules-scaffold`. AI agents: run the installer, never hand-copy files.",
   "bin": {
     "ai-coding-rules-scaffold": "bin/cli.js"


### PR DESCRIPTION
## Summary
- Promotes `[Unreleased]` to `[v0.13.0]`, bumps the README clone pin and `package.json` version per RELEASING.md's checklist.
- Backfills two CHANGELOG entries that were merged but never logged: the 8 operational-rules.md rules from issue #120 (PR #122), and the "choose the strongest approach" rule from issue #124 (PR #125).
- Motivated by #126: `main` was 114 commits ahead of the last npm publish (`v0.12.0`), leaving `--zizmor-ci`, `--socket-ci`, `--npm-cooldown`, and `--claude-skill` unreachable via `npx`/`npm`. This release catches the registry up.

## Test plan
- [x] Self-lint dry run (RELEASING.md step 1.3): `check-secrets --ci` over the full tracked tree, clean
- [ ] CI green on both runners
- [ ] After merge: tag `v0.13.0` and push to trigger `release.yml` (npm publish + GitHub release) — separate step, needs a go/no-go since it's a real public publish

Fixes #126