### PR TITLE
docs(operational-rules): adopt rule proposal from issue #131

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ versioning follows [SemVer](https://semver.org/).
 
 ### Added
 
+- **New operational-rules.md entry: "Destructive filesystem work needs the
+  one-writer check too" (#131).** Extends "One writer per repo at a time"
+  down to filesystem-level writes (deleting a checkout, moving a
+  directory, repointing a symlink target): during the anchoring incident
+  the existing rule's check (open PRs, mainline movement) was run and
+  caught nothing, because the concurrent writer's only footprints were a
+  freshly filed issue and filesystem state. Adopted through the issue-flow
+  gate with two independent reviews; both said ADOPT-WITH-REVISIONS, and
+  both revisions landed (a checkable bar replacing an unprovable
+  "provably idle" standard, and the check-ran-and-missed fact recorded in
+  the anchor).
 - **`_backup` warns when an overwritten file carried a `# Repo adaptation:`
   marker (#127).** Root cause: before #110, `coverage.yml`/`tests.yml`/
   `gitleaks.yml` installed via `cp_scaffold` (unconditional refresh on

--- a/operational-rules.md
+++ b/operational-rules.md
@@ -489,6 +489,22 @@ _Anchor:_ a PR was merged by a concurrent session no one could later
 identify, minutes after another session's audit snapshot; the version
 drifted and the audit had to be redone against a moved main.
 
+### Destructive filesystem work needs the one-writer check too
+
+Deleting, moving, or repointing a path another session may be using
+(a checkout, a worktree, a symlink target) is a merge-grade write,
+and the merge-level check (open PRs, mainline movement) sees none of
+it. Check the signals you can actually read: issues or commits
+freshly filed from that path, recent file mtimes, open handles or
+processes. Any positive signal means stop and ask; true idleness is
+unprovable, so with no signals the bar is an explicit go-ahead naming
+the path, and prefer a rename over an immediate hard delete so a
+late writer fails loudly instead of by luck.
+_Anchor:_ a session deleted a duplicate repo checkout minutes after a
+concurrent session had filed an issue from inside that directory; the
+PR-and-mainline check had been run and caught nothing, and only luck
+decided whether the other session's next write hit a deleted path.
+
 ### End every session with a rules retrospective
 
 Before handoff, walk the session's incidents against this file's


### PR DESCRIPTION
Adopts the rule proposed in #131: **"Destructive filesystem work needs the one-writer check too"**, placed under Collaboration immediately after "One writer per repo at a time; check before merging", which it extends down to filesystem-level writes.

## Adoption gate (per the #124 precedent)

Two independent Fable-model reviews before adoption:

- **Criteria-grounded review** (given the file's add-criteria plus incident evidence): verified all claims against live data (issue #123's own text places the concurrent session inside the deleted directory; the path is measurably gone). All four add-criteria hold. Verdict: ADOPT-WITH-REVISIONS.
- **Unprimed review** (given only the raw rule text): independently corroborated the failure mode against two documented instances, confirmed the gap is real and not tool-enforceable. Verdict: ADOPT-WITH-REVISIONS.

Both revisions are incorporated in the final text:

1. "Provably idle" replaced with a checkable bar (any positive signal means stop and ask; with no signals, an explicit go-ahead naming the path), plus a rename-over-hard-delete margin so a late writer fails loudly. An unmeetable standard would be ignored in practice, and this document itself holds that a check that can pass by luck is failing.
2. The anchor now records the load-bearing fact: the existing one-writer check (open PRs, mainline movement) **was run** during the incident and caught nothing, which is what justifies a separate rule rather than an amendment.

CHANGELOG entry included up front (the #124/#125 adoption's entry had to be backfilled at release time).

Both files pass the shipped prettier config (pinned 3.9.6, checked locally with the same temp-dir setup CI uses).

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xc6dGpriAQxKfHshGFF5NL