### PR TITLE
chore(release): v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 versioning follows [SemVer](https://semver.org/).
 
-## [Unreleased]
+## [v0.14.0] - 2026-09-01
+
+The safety-harness adoption release: the two low-risk items from the
+harness review land (the `CLAUDE.md` rules import and the
+artifact-anchored change summary), plus the Repo-adaptation overwrite
+warning and a new operational rule. The remaining harness proposals are
+tracked in #140.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Either way, the `lib/check-*` scripts in `.githooks/lib/` are also runnable dire
 The scaffold follows the cross-tool **`AGENTS.md` standard** ([agents.md](https://agents.md)) — a single file at the project root that multiple agents already read (Cursor, Aider, Codex, and others). For tools that read a different filename, `install.sh` or a one-line pointer handles it:
 
 - **Cursor** — reads `AGENTS.md` natively. Nothing else needed.
-- **Claude Code** — reads `CLAUDE.md`. `install.sh` drops a one-line `CLAUDE.md` containing `@AGENTS.md`, which pulls `AGENTS.md` into context.
+- **Claude Code** — reads `CLAUDE.md`. `install.sh` drops a `CLAUDE.md` whose `@AGENTS.md` and `@coding-rules.md` imports pull both files into context at session start (`operational-rules.md` stays a link, read on demand: it's too large to pin into every turn).
 - **Aider** — add to `.aider.conf.yml`:
   ```yaml
   read:

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ somewhere stable:
 
 ```sh
 # Recommended: pin to a tagged release for reproducibility
-git clone --branch v0.13.0 https://github.com/Sting25/ai-coding-rules-scaffold ~/src/ai-coding-rules-scaffold
+git clone --branch v0.14.0 https://github.com/Sting25/ai-coding-rules-scaffold ~/src/ai-coding-rules-scaffold
 # Or track main if you want the latest changes
 git clone https://github.com/Sting25/ai-coding-rules-scaffold ~/src/ai-coding-rules-scaffold
 ```

--- a/TECHNICAL.md
+++ b/TECHNICAL.md
@@ -42,7 +42,7 @@ Language pattern files auto-install when their manifest is detected (`go.mod`, `
 | Scaffold file                                                           | Installed as                                                    | Purpose                                                                                                                                                                           |
 | ----------------------------------------------------------------------- | --------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `AGENTS.md.template`                                                    | `AGENTS.md`                                                     | Primary agent doc: git discipline + project section                                                                                                                               |
-| `CLAUDE.md.pointer`                                                     | `CLAUDE.md`                                                     | One-liner pointing Claude Code at `AGENTS.md`                                                                                                                                     |
+| `CLAUDE.md.pointer`                                                     | `CLAUDE.md`                                                     | Pointer importing `AGENTS.md` + `coding-rules.md` into Claude Code's context                                                                                                      |
 | `coding-rules.md`                                                       | `coding-rules.md`                                               | Short list of code-level rules that aren't tool-enforceable                                                                                                                       |
 | `operational-rules.md`                                                  | `operational-rules.md`                                          | Process and collaboration rules — failure modes that no linter can catch                                                                                                          |
 | `ruff.toml.template`                                                    | `ruff.toml`                                                     | Python lint config                                                                                                                                                                |
@@ -359,13 +359,14 @@ minimal; turn them on per project.
   loading path, not a replacement for either existing one: `--claude`
   installs _runtime hooks_ (`.claude/settings.json` plus the `PreToolUse`
   precheck) that block a bad tool call as it happens; the plain AGENTS.md
-  path (always installed) is _always-loaded summary_: CLAUDE.md's
-  `@AGENTS.md` import pulls a condensed version of these rules, with links
-  to the full files, into every turn's context by design, to keep that
-  always-loaded context small. `--claude-skill` is what actually pulls the
-  **full text** of `coding-rules.md` / `operational-rules.md` into context,
-  **on demand**, at the moments they matter, rather than relying on the
-  summary alone or paying their full size on every turn. Opt-in because it is
+  path (always installed) is _always-loaded context_: CLAUDE.md imports
+  `AGENTS.md` (the condensed summary) and the full `coding-rules.md`
+  (short by rule, cheap to pin into every turn), while the much larger
+  `operational-rules.md` stays a link on purpose, since paying its full
+  size on every turn is the wrong trade. `--claude-skill` is what pulls
+  the **full text** of `operational-rules.md` (alongside
+  `coding-rules.md`) into context **on demand**, at the moments it
+  matters, rather than relying on the summary alone. Opt-in because it is
   Claude Code specific; combine freely with `--claude` and with the default
   AGENTS.md install. `.claude/skills/coding-rules/SKILL.md` is USER-OWNED
   (`cp_safe`): a project may hand-edit it, so a re-run never overwrites it

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-coding-rules-scaffold",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Agent-agnostic coding-rules scaffold: pre-commit + CI guardrails (file size, forbidden patterns, secret/credential scanning, hygiene) that install into your project, plus `scaffold-doctor` to check they are actually armed and not just present. Run via `npx ai-coding-rules-scaffold`. AI agents: run the installer, never hand-copy files.",
   "bin": {
     "ai-coding-rules-scaffold": "bin/cli.js"


### PR DESCRIPTION
Release prep per RELEASING.md, plus the doc pass that goes with it.

- **docs commit**: README's Claude Code bullet, TECHNICAL's pointer-table row, and the `--claude-skill` rationale all still said `CLAUDE.md` imports only `AGENTS.md`; updated for the coding-rules import that landed in #141 (always-loaded set is now `AGENTS.md` + full `coding-rules.md`; `operational-rules.md` deliberately stays an on-demand link, which remains `--claude-skill`'s distinct value). npm `description` and the GitHub repo description were checked and are still accurate as written.
- **release commit**: `[Unreleased]` promoted to `[v0.14.0] - 2026-09-01` with a short intro naming the theme (safety-harness adoption; remainder tracked in #140), README clone pin `v0.13.0` → `v0.14.0`, `package.json` `0.13.0` → `0.14.0`.

Pre-push checks run per the checklist: check-secrets dry run over all tracked files (clean), prettier (shipped config) on both touched markdown files (clean).

After merge: tag `v0.14.0` on main, `release.yml` publishes npm (OIDC trusted publishing) + the GitHub Release from the CHANGELOG section, then the Homebrew tap's bump-formula workflow gets triggered and the canonical formula copy in `packaging/homebrew/` is updated with the new tag + sha in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xc6dGpriAQxKfHshGFF5NL