### PR TITLE
chore(homebrew): sync canonical formula to v0.14.0

### DIFF
--- a/packaging/homebrew/ai-coding-rules-scaffold.rb
+++ b/packaging/homebrew/ai-coding-rules-scaffold.rb
@@ -9,8 +9,8 @@
 class AiCodingRulesScaffold < Formula
   desc "Pre-commit and CI guardrails: size, pattern, secret, and hygiene checks"
   homepage "https://github.com/Sting25/ai-coding-rules-scaffold"
-  url "https://github.com/Sting25/ai-coding-rules-scaffold/archive/refs/tags/v0.12.0.tar.gz"
-  sha256 "d3d55ddbc9ba4e04739ac86f5179fd776c6eb6a2cb9f3581465d028f3f90fd03"
+  url "https://github.com/Sting25/ai-coding-rules-scaffold/archive/refs/tags/v0.14.0.tar.gz"
+  sha256 "bc15a220477c7d8bba6170661e6ed85f1fce3633a9e1bac75df755ce6fa62dcb"
   license "MIT"
 
   def install


### PR DESCRIPTION
Per RELEASING.md step 3's "update the canonical copy in the next convenient PR": bumps `packaging/homebrew/ai-coding-rules-scaffold.rb` from v0.12.0 (the v0.13.0 release never synced it) to v0.14.0, with the sha256 computed from the v0.14.0 GitHub source tarball using the formula header's own recipe.

Verified this release end to end before this PR: `release.yml` run succeeded; `npm view` shows 0.14.0; the GitHub Release v0.14.0 is marked Latest; the published npm tarball contains `install-claude.sh` and the updated `CLAUDE.md.pointer` (both imports), and `node package/bin/cli.js --help` runs. The tap's `bump-formula` workflow was triggered separately and updates the live tap on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xc6dGpriAQxKfHshGFF5NL