### PR TITLE
feat(test-guard): advisory diff-scoped mutation layer via mutmut (#145)

### DIFF
--- a/.github/workflows/test-guard.yml.template
+++ b/.github/workflows/test-guard.yml.template
@@ -4,18 +4,37 @@ name: test-guard
 # Installed by the scaffold's opt-in `--test-guard` flag.
 #
 # The anti-gaming layer. Every other gate in this scaffold assumes the test
-# suite is an honest witness; this workflow checks the witness. Today it runs
-# one check:
+# suite is an honest witness; this workflow checks the witness. It runs two
+# checks:
 #
-#   check-red-green   a NEW test that passes against the base branch was
-#                     never observed failing, and is therefore not evidence
-#                     that anything was fixed
+#   check-red-green      a NEW test that passes against the base branch was
+#                         never observed failing, and is therefore not
+#                         evidence that anything was fixed
+#
+#   check-mutation-diff  a NEW test can pass red-green while still asserting
+#                         nothing about the new code's behaviour. This check
+#                         mutates the lines the PR changed and reports, per
+#                         file, every mutant the suite fails to kill.
+#                         It is advisory-first (issue #145): surviving
+#                         mutants print a warning but never fail the job.
+#                         Exit code 2 (mutmut missing or the wrong pinned
+#                         version, a broken baseline suite, a bad worktree
+#                         or config, or a timeout) IS a failure and does
+#                         fail the job, since that means the check could not
+#                         evaluate anything, not that it evaluated cleanly.
+#
+# INTERPLAY between the two checks. A file check-red-green reports
+# "unevaluable" (its imports don't resolve against base, so no test in it
+# can be run there at all) is exactly where a vacuous test is most likely to
+# hide, since the file was already opaque to red-green. A surviving mutant
+# check-mutation-diff finds in that same file is this workflow's single
+# highest-signal finding.
 #
 # A suite generated against an implementation passes by construction. The
-# check runs each new test node ID against a scratch worktree of the base
-# commit and requires it to fail there. New tests that legitimately pass on
-# base (characterization tests pinning behaviour before a refactor, coverage
-# backfill for already-correct code) must say so out loud:
+# red-green check runs each new test node ID against a scratch worktree of
+# the base commit and requires it to fail there. New tests that legitimately
+# pass on base (characterization tests pinning behaviour before a refactor,
+# coverage backfill for already-correct code) must say so out loud:
 #
 #     @pytest.mark.characterization(reason="pinning invoice rounding before refactor")
 #
@@ -100,3 +119,15 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: python3 .githooks/lib/check-red-green --base "$BASE_SHA" --ci
+
+      # Diff-scoped mutation testing, advisory-first (issue #145): surviving
+      # mutants warn but never fail this step, exit 2 (cannot evaluate) does.
+      # No continue-on-error here on purpose; the script's own exit codes
+      # already carry the pass/warn/fail semantics this workflow wants.
+      - name: Mutation testing (diff-scoped, advisory)
+        if: steps.detect.outputs.present == 'true'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          pip install mutmut==3.7.0
+          python3 .githooks/lib/check-mutation-diff --base "$BASE_SHA" --ci

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Tests run in CI by default: a plain install also drops `.github/workflows/tests.
 ./install.sh --dependency-review # also install the dependency-review CI gate (opt-in: needs GitHub Advanced Security on a private repo, or it errors)
 ./install.sh --zizmor-ci    # also install the zizmor GitHub Actions audit gate (opt-in: adds a third-party pip package)
 ./install.sh --socket-ci    # also install the Socket Firewall supply-chain gate (opt-in: adds a third-party action dependency)
-./install.sh --test-guard   # also install the red-green test-integrity gate (a new test must fail on the PR base before it may pass)
+./install.sh --test-guard   # also install the red-green test-integrity gate (a new test must fail on the PR base before it may pass), plus an advisory diff-scoped mutation layer
 ./install.sh --npm-cooldown # also install .npmrc's min-release-age package cooldown (opt-in: needs npm >= 11.10.0, older npm just warns and ignores it)
 ./install.sh --claude-skill # also install an on-demand Claude Code Skill wrapping coding-rules.md/operational-rules.md
 ./install.sh --all-langs    # install every language's forbidden-pattern file

--- a/TECHNICAL.md
+++ b/TECHNICAL.md
@@ -335,6 +335,20 @@ minimal; turn them on per project.
   advisory check a merging agent can route around), which the install note
   says out loud. From the harness review, issue #140 item 2.
 
+  The same gate also runs `check-mutation-diff`, a second layer closing a
+  gap red-green cannot: a test can be red on base and still assert nothing
+  about the new code's behaviour. It mutates only the lines the PR changed
+  and reports every mutant on them the suite fails to kill, per file, using
+  mutmut==3.7.0, pinned in CI (`pip install mutmut==3.7.0`, nothing needed
+  locally). Per issue #145's advisory-first design, surviving mutants print
+  a warning but never fail the job, so the layer can be turned on everywhere
+  without becoming a second red-green; only exit code 2 (mutmut missing or
+  the wrong pinned version, a broken baseline, a bad worktree/config, or a
+  timeout) fails the job, since that means the check could not evaluate
+  anything at all, not that it evaluated cleanly. Scoping is file-glob only:
+  mutmut 3.x has no function-level scoping, so a large file with one changed
+  line still has its whole file mutated.
+
 - **Socket Firewall CI gate (`install.sh --socket-ci` →
   `.github/workflows/socket-security.yml`).** Verifies a package is
   legitimate _before_ it is installed, not after: an LLM coding agent

--- a/githooks/lib/check-mutation-diff.template
+++ b/githooks/lib/check-mutation-diff.template
@@ -1,0 +1,476 @@
+#!/usr/bin/env python3
+"""
+.githooks/lib/check-mutation-diff: diff-scoped mutation testing, the phase-2
+layer for the test-guard family (see check-red-green.template first).
+
+THE GAP THIS CLOSES. check-red-green proves a new test depends on the new
+code existing (it fails on base). It cannot prove the test constrains the
+new code's BEHAVIOUR. A test that calls the new function and asserts
+nothing, or asserts something trivially true, is red on base (the import
+does not exist yet) and therefore passes red-green cleanly, while catching
+nothing. Red-green's own source names the real answer: "mutation testing on
+the diff is the real one." This script is that answer: mutate the lines a
+PR changed, run the tests, and require the mutants to die. A test that kills
+at least one mutant of the diff has proven it constrains the new behaviour;
+one that does not has proven the opposite, regardless of whether it passes.
+
+INTERPLAY WITH check-red-green, stated explicitly rather than left implicit.
+red-green documents its own honest limit: a new test in a file whose imports
+do not resolve on base cannot be executed there at all, so every test in
+that file is reported as "unevaluable", not "offending": the check simply
+cannot see inside it. This is precisely where a vacuous test is most likely
+to hide, because the file already had a reason to be opaque to red-green.
+A surviving or uncovered mutant in a file check-red-green reported
+unevaluable is therefore the single highest-signal finding this check can
+produce, and is called out as such in the per-file warning below.
+
+MECHANISM, verified against mutmut 3.7.0 (pinned; see MUTMUT_PIN below) on
+2026-09-01, ground truth in the U0 fact sheet, not from memory of older
+mutmut majors, whose CLI and config surface differ substantially:
+
+  - mutmut 3.x has almost no CLI flags. There is no --paths-to-mutate, no
+    --tests-dir, no dry-run/count-only mode. All scoping is config-file
+    based: `only_mutate` (glob, file-level only, no function-level
+    scoping exists in this major) plus `source_paths`. So this script
+    writes a [tool.mutmut] table into a disposable worktree, it does not
+    pass CLI flags to mutmut.
+  - `mutmut --help`/`--version` import Config at IMPORT TIME and crash with
+    a bare traceback if no source directory is guessable from cwd. Because
+    of this, mutmut's presence and pinned version are verified via
+    importlib.metadata in a subprocess, never via `mutmut --version`,
+    which is cwd-dependent and unreliable as a preflight probe.
+  - mutmut ALWAYS copies sources into mutants/ under wherever it is
+    invoked; it never mutates in place and does not require git. This
+    script still builds an isolated `git worktree` copy of HEAD so the
+    synthesized config never touches the real checkout and so a crashed
+    or slow run cannot leave stray mutants/ artifacts in the repo.
+  - mutmut's own process exit code is NOT the verdict. A run with
+    surviving mutants exits 0, identically to a run where everything was
+    killed. The only reliable exit-code signal is a NONZERO code paired
+    with one of two specific strings: "failed to collect stats" (the
+    baseline suite itself failed, before mutation testing starts) or
+    "BadTestExecutionCommandsException" (the configured test-selection
+    args are not runnable by pytest at all). Everything else must be read
+    from the artifacts mutmut writes under mutants/, never from $?.
+  - A bad/nonexistent source_paths entry produces NO distinct error: 0
+    files get mutated, the baseline suite runs and passes, and mutmut
+    then exits 1 with "Stopping early, because we could not find any test
+    case for any mutant", the exact same code and a near-identical
+    message as "your tests genuinely do not cover the changed lines".
+    Since this is ambiguous from mutmut's own output, this script
+    verifies every source path it writes into the config actually exists
+    in the worktree BEFORE invoking mutmut, so that signal is never relied
+    on to distinguish the two cases.
+  - Per-mutant status lives in mutants/<path>/<file>.py.meta as
+    exit_code_by_key, mapped through mutmut's own status table (copied
+    verbatim below, from mutmut/__main__.py::status_by_exit_code). This is
+    the ONLY artifact with per-file granularity; the aggregate
+    mutants/mutmut-cicd-stats.json produced by `mutmut export-cicd-stats`
+    is a whole-run rollup with no file breakdown, so it cannot alone drive
+    the "per file" warning this check is required to produce. This script
+    therefore glob-parses the .meta files as its primary source, which is
+    also mutmut's own recommended path for "which files have survivors"
+    (see the U0 fact sheet, section 3), and falls back to parsing
+    `mutmut results --all=true` stdout only if no .meta files exist at
+    all, saying so explicitly when it does.
+  - Measured but easy to miss: a run that aborts early via "Stopping
+    early..." still writes .meta files, but every mutant in them has
+    exit_code None, i.e. status "not checked", the SAME empty-bucket
+    signature as a genuinely broken baseline. Text-matching
+    "failed to collect stats" is what actually tells the two apart; the
+    JSON alone cannot. "not checked" mutants that survive this
+    disambiguation are folded into the advisory count below, on the
+    reasoning that a mutant nothing ever ran is exactly as unconstrained
+    as one that ran and survived.
+
+WHAT COUNTS AS "COULD NOT EVALUATE" (exit 2) VS ADVISORY (exit 0).
+Per #145's design: advisory first, strict later. Exit 2 is reserved for
+infrastructure failure: mutmut missing or the wrong pinned version, a
+broken baseline suite, a bad worktree/config/path, or a timeout. It is
+NEVER used for "the tests did not kill enough mutants": that is exactly
+what the advisory warnings below exist to report, at exit 0, so this check
+can be turned on everywhere without becoming a second red-green. A source
+path that resolves to zero mutants (a comment-only or already-fully-tested
+diff) is not a failure either; it prints the positive line.
+
+KNOWN LIMITATIONS, stated rather than silently absorbed:
+  - No dry-run mutant count exists in this mutmut major, so --max-mutants
+    is enforced AFTER the full run completes, not as a fast preflight. The
+    run itself is not cheaper just because the cap will reject it.
+  - Config injection merges into pyproject.toml only; a project configured
+    solely via setup.cfg's [mutmut] section is not merged and gets a fresh
+    pyproject.toml written into the worktree instead, which may or may not
+    take precedence over setup.cfg depending on mutmut's own load order
+    (unverified for 3.7.0).
+  - mutmut's trampoline hard-asserts against qualnames starting with
+    "src.": a src-layout project whose tests import as `from src.pkg import
+    x` rather than `from pkg import x` will crash mutmut at collection,
+    unrelated to anything this script does.
+
+USAGE
+  check-mutation-diff --base <ref> [--ci] [--max-mutants N]
+
+Exit: 0 evaluated cleanly (killed-clean, or advisory warnings emitted)
+      1 more mutants than --max-mutants; split the PR
+      2 could not evaluate: mutmut missing/wrong version, broken baseline,
+        config/path failure, or timeout
+
+Exit 2 is a FAILURE, not a skip, same boundary as check-red-green and
+check-secrets. CI-only / PR-only by design (#145 point 1): mutation runs
+are minutes, not the seconds a pre-commit hook budgets for.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pathlib
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+# Pinned per the U0 fact sheet: mutmut 3.7.0 is the newest stable release as
+# of 2026-09-01, requires Python >=3.10, and its config/CLI surface changed
+# materially from the 1.x/2.x line this repo must not silently drift onto.
+MUTMUT_PIN = "3.7.0"
+RUN_TIMEOUT = 1800  # seconds; mutation runs are minutes, generously capped
+
+# Kept in sync with check-red-green.template's regexes by hand; both scripts
+# need the same "what counts as a test file / what counts as build noise"
+# answer and neither is worth a shared-module dependency for two lines.
+TEST_DIR_RE = re.compile(r"(^|/)(tests?|testing)(/|$)")
+NOISE_RE = re.compile(r"(^|/)(__pycache__|\.pytest_cache|node_modules)(/|$)|\.pyc$")
+
+# Copied verbatim from mutmut/__main__.py::status_by_exit_code (U0 fact
+# sheet, section 2). Ground truth from source, not from mutmut's docs.
+STATUS_BY_EXIT_CODE = {
+    1: "killed", 3: "killed",
+    0: "survived",
+    5: "no tests", 33: "no tests",
+    2: "check was interrupted by user",
+    34: "skipped",
+    35: "suspicious",
+    36: "timeout", 24: "timeout", 152: "timeout", 255: "timeout", -24: "timeout",
+    -11: "segfault", -9: "segfault",
+    37: "caught by type check",
+}
+
+
+def run(cmd: list[str], cwd: str | None = None, timeout: int = RUN_TIMEOUT):
+    return subprocess.run(
+        cmd, cwd=cwd, capture_output=True, text=True, check=False, timeout=timeout
+    )
+
+
+def emit(sev: str, msg: str, ci: bool) -> None:
+    if ci:
+        print(f"::{sev}::{msg}")
+    else:
+        print(f"  {sev}: {msg}", file=sys.stderr)
+
+
+def is_real_source(p: str) -> bool:
+    return not NOISE_RE.search(p)
+
+
+def is_test_path(p: str) -> bool:
+    name = pathlib.PurePosixPath(p).name
+    return bool(TEST_DIR_RE.search(p)) or name.startswith("test_") or name.endswith("_test.py")
+
+
+def is_python_source(p: str) -> bool:
+    return p.endswith(".py") and is_real_source(p) and not is_test_path(p)
+
+
+def status_for(exit_code) -> str:
+    if exit_code is None:
+        return "not checked"
+    return STATUS_BY_EXIT_CODE.get(exit_code, "suspicious")
+
+
+def verify_mutmut(ci: bool) -> int:
+    """Verify mutmut is importable and pinned, without invoking its CLI.
+
+    `mutmut --version` crashes with a bare traceback unless a source
+    directory happens to be guessable from cwd (see docstring). Reading
+    the installed version via importlib.metadata sidesteps that entirely.
+    """
+    r = run([sys.executable, "-c",
+             "import importlib.metadata as m; print(m.version('mutmut'))"])
+    if r.returncode != 0:
+        emit("error",
+             f"mutmut is not importable with {sys.executable}. Install "
+             f"mutmut=={MUTMUT_PIN} in this environment first.", ci)
+        return 2
+    found = r.stdout.strip()
+    if found != MUTMUT_PIN:
+        emit("error",
+             f"mutmut version mismatch: found {found or '(empty)'}, pinned "
+             f"{MUTMUT_PIN}. Reinstall the pinned version; mutmut's config "
+             "and CLI surface changed materially across majors.", ci)
+        return 2
+    return 0
+
+
+def toml_list(items: list[str]) -> str:
+    # A JSON string array is valid TOML inline-array syntax for plain
+    # strings, so json.dumps is a safe, dependency-free TOML-list writer
+    # here without hand-rolling escaping.
+    return json.dumps(items)
+
+
+TABLE_RE = re.compile(r"^\[tool\.mutmut\]\n(?:(?!^\[).*\n?)*", re.MULTILINE)
+TEST_SELECTION_RE = re.compile(
+    r"^\s*pytest_add_cli_args_test_selection\s*=\s*(\[[^\]]*\])", re.MULTILINE
+)
+
+
+def inject_config(wt: str, src_files: list[str]) -> tuple[list[str], list[str]]:
+    """Scope mutmut to exactly the changed files via a [tool.mutmut] table.
+
+    Overrides source_paths/only_mutate unconditionally (that is the whole
+    point of a diff-scoped run). Carries over an existing
+    pytest_add_cli_args_test_selection value if the project already has
+    one, since dropping it could silently change which tests mutmut runs.
+    Any other pre-existing [tool.mutmut] keys are not preserved; this is a
+    stated, deliberate simplification, not an oversight (see docstring
+    "known limitations").
+    """
+    dirs = sorted({str(pathlib.PurePosixPath(p).parent) for p in src_files})
+    only_mutate = sorted(src_files)
+    pp = pathlib.Path(wt, "pyproject.toml")
+    text = pp.read_text() if pp.exists() else ""
+    carry_match = TEST_SELECTION_RE.search(text)
+    carry = (
+        f"pytest_add_cli_args_test_selection = {carry_match.group(1)}\n"
+        if carry_match else ""
+    )
+    text = TABLE_RE.sub("", text)
+    block = (
+        "\n[tool.mutmut]\n"
+        f"source_paths = {toml_list(dirs)}\n"
+        f"only_mutate = {toml_list(only_mutate)}\n"
+        f"{carry}"
+    )
+    pp.write_text(text.rstrip("\n") + "\n" + block if text.strip() else block.lstrip("\n"))
+    return dirs, only_mutate
+
+
+def parse_meta_files(wt: str, scope: set[str]) -> dict[str, dict[str, int]]:
+    """Per-file mutant status counts, parsed from mutants/**/*.py.meta.
+
+    This is mutmut's own recommended path for "which files have
+    survivors" (U0 fact sheet, section 3): it needs no further mutmut
+    invocation and is the only artifact with per-file granularity, unlike
+    the aggregate mutants/mutmut-cicd-stats.json.
+    """
+    mutants_dir = pathlib.Path(wt, "mutants")
+    per_file: dict[str, dict[str, int]] = {}
+    for mf in sorted(mutants_dir.rglob("*.py.meta")):
+        rel = str(mf.relative_to(mutants_dir))[: -len(".meta")]
+        if rel not in scope:
+            continue
+        try:
+            data = json.loads(mf.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+        stats = per_file.setdefault(
+            rel, {"killed": 0, "survived": 0, "no_tests": 0, "not_checked": 0, "other": 0, "total": 0}
+        )
+        for code in data.get("exit_code_by_key", {}).values():
+            st = status_for(code)
+            stats["total"] += 1
+            if st == "killed":
+                stats["killed"] += 1
+            elif st == "survived":
+                stats["survived"] += 1
+            elif st == "no tests":
+                stats["no_tests"] += 1
+            elif st == "not checked":
+                stats["not_checked"] += 1
+            else:
+                stats["other"] += 1
+    return per_file
+
+
+def parse_results_fallback(wt: str, scope: set[str], ci: bool) -> dict[str, dict[str, int]]:
+    """Fallback used only when no .meta files exist at all, said out loud.
+
+    `mutmut results --all=true` gives status by dotted module name, not by
+    file path. Attribution to a specific changed file is only unambiguous
+    when exactly one file is in scope; otherwise the pooled result is
+    reported under a synthetic key and the ambiguity is surfaced.
+    """
+    r = run([sys.executable, "-m", "mutmut", "results", "--all=true"], cwd=wt)
+    counts = {"killed": 0, "survived": 0, "no_tests": 0, "not_checked": 0, "other": 0, "total": 0}
+    for line in r.stdout.splitlines():
+        line = line.strip()
+        if ":" not in line:
+            continue
+        status = line.rsplit(":", 1)[1].strip()
+        counts["total"] += 1
+        if status == "killed":
+            counts["killed"] += 1
+        elif status == "survived":
+            counts["survived"] += 1
+        elif status == "no tests":
+            counts["no_tests"] += 1
+        elif status == "not checked":
+            counts["not_checked"] += 1
+        else:
+            counts["other"] += 1
+    if counts["total"] == 0:
+        return {}
+    if len(scope) == 1:
+        return {next(iter(scope)): counts}
+    emit("notice",
+         f"{len(scope)} changed files were mutated but mutants/*.py.meta was "
+         "absent, so per-file attribution fell back to `mutmut results`, "
+         "which is pooled across all scoped files. Reporting the pool "
+         "under a combined key.", ci)
+    return {"(pooled: " + ", ".join(sorted(scope)) + ")": counts}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--base", required=True, help="base ref to compare against")
+    ap.add_argument("--ci", action="store_true")
+    ap.add_argument(
+        "--max-mutants", type=int, default=400, dest="max_mutants",
+        help="refuse to report on more than this many mutants (guards CI time)",
+    )
+    args = ap.parse_args()
+
+    v = verify_mutmut(args.ci)
+    if v:
+        return v
+
+    base = run(["git", "rev-parse", "--verify", f"{args.base}^{{commit}}"])
+    if base.returncode != 0:
+        emit("error", f"cannot resolve base ref {args.base!r}. In CI make sure the "
+                      "checkout has fetch-depth: 0.", args.ci)
+        return 2
+    base_sha = base.stdout.strip()
+
+    head = run(["git", "rev-parse", "--verify", "HEAD"])
+    if head.returncode != 0:
+        emit("error", "cannot resolve HEAD.", args.ci)
+        return 2
+    head_sha = head.stdout.strip()
+
+    changed = run(
+        ["git", "diff", "--name-only", "--diff-filter=d", f"{base_sha}...HEAD"]
+    ).stdout.split()
+    src_files = sorted(p for p in changed if is_python_source(p))
+    if not src_files:
+        print("nothing to mutate, no changed non-test Python source files in this diff.")
+        return 0
+
+    tmp = tempfile.mkdtemp(prefix="mutdiff-")
+    wt = os.path.join(tmp, "wt")
+    try:
+        r = run(["git", "worktree", "add", "--detach", wt, head_sha])
+        if r.returncode != 0:
+            emit("error", f"git worktree add failed: {r.stderr.strip()}", args.ci)
+            return 2
+
+        dirs, only_mutate = inject_config(wt, src_files)
+
+        missing = [d for d in dirs if not pathlib.Path(wt, d).exists()]
+        missing += [f for f in only_mutate if not pathlib.Path(wt, f).exists()]
+        if missing:
+            emit("error",
+                 "configured mutmut source path(s) do not exist in the "
+                 f"worktree, checked independently before running mutmut "
+                 f"because mutmut's own error for this is indistinguishable "
+                 f"from zero coverage: {', '.join(missing)}", args.ci)
+            return 2
+
+        r = run([sys.executable, "-m", "mutmut", "run"], cwd=wt)
+        out = (r.stdout or "") + (r.stderr or "")
+
+        if "failed to collect stats" in out:
+            emit("error",
+                 "the baseline test suite fails before any mutation testing "
+                 "starts (mutmut: \"failed to collect stats\"). Fix the "
+                 "failing tests first; a mutation gate cannot run against a "
+                 "red baseline.", args.ci)
+            return 2
+        if "BadTestExecutionCommandsException" in out:
+            emit("error",
+                 "pytest could not run at all with the configured "
+                 "test-selection arguments (mutmut: "
+                 "BadTestExecutionCommandsException). Check "
+                 "pytest_add_cli_args_test_selection.", args.ci)
+            return 2
+
+        scope = set(only_mutate)
+        per_file = parse_meta_files(wt, scope)
+        stats_source = "mutants/*.py.meta"
+        if not per_file:
+            per_file = parse_results_fallback(wt, scope, args.ci)
+            stats_source = "mutmut results --all=true (meta files were absent)"
+        if not per_file:
+            emit("error",
+                 "mutmut run produced no readable results at all (neither "
+                 "mutants/*.py.meta nor `mutmut results` output any status). "
+                 "Treating as unable to evaluate.", args.ci)
+            return 2
+
+        total = sum(s["total"] for s in per_file.values())
+        killed = sum(s["killed"] for s in per_file.values())
+        bad_total = total - killed
+
+        if total > args.max_mutants:
+            emit("error",
+                 f"{total} mutants across {len(src_files)} changed file(s) "
+                 f"exceeds --max-mutants={args.max_mutants}; evaluating that "
+                 "many would dominate CI time. Split the PR - a change this "
+                 "large is not reviewable by any means available to you, "
+                 "mutation testing included.", args.ci)
+            return 1
+
+        if total == 0:
+            print("mutation OK: 0 mutants generated for the changed lines "
+                  f"(source: {stats_source}); nothing to evaluate.")
+            return 0
+
+        if bad_total == 0:
+            print(f"mutation OK: {total} mutants, all killed across "
+                  f"{len(src_files)} changed file(s) (source: {stats_source}).")
+            return 0
+
+        for rel, s in sorted(per_file.items()):
+            bad = s["survived"] + s["no_tests"] + s["not_checked"] + s["other"]
+            if bad:
+                emit("warning",
+                     f"{rel}: {s['survived']} survived, {s['no_tests']} no "
+                     f"tests, {s['not_checked']} not checked, {s['other']} "
+                     f"other mutant(s) out of {s['total']} on this diff. A "
+                     "surviving or uncovered mutant means some changed line "
+                     "has no test that actually constrains it.", args.ci)
+        emit("notice",
+             f"mutation summary: {killed} killed, {bad_total} not killed "
+             f"({total} total) across {len(src_files)} changed file(s), "
+             f"source: {stats_source}. Advisory only for this release "
+             "(#145 point 4): none of this fails the build yet. A survivor "
+             "in a file check-red-green reported unevaluable is the "
+             "highest-signal finding above.", args.ci)
+        return 0
+
+    finally:
+        run(["git", "worktree", "remove", "--force", wt])
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except subprocess.TimeoutExpired:
+        print("::error::mutation-diff check timed out. A mutation run too "
+              "slow to complete in CI is too slow to trust as a gate; scope "
+              "it to fewer files or raise the timeout deliberately.")
+        raise SystemExit(2)

--- a/install-optin.sh
+++ b/install-optin.sh
@@ -46,10 +46,17 @@ install_opt_in_claude_skill() {
   fi
 }
 
-# --test-guard (#140 item 2, red-green only): every NEW test must be shown
-# failing against the PR base before it may pass. Three artifacts:
-#   .githooks/lib/check-red-green   the check (scaffold-owned, refreshed)
-#   .github/workflows/test-guard.yml  the PR gate (drift-preserving)
+# --test-guard (#140 item 2, red-green, plus the advisory mutation layer
+# from #145): every NEW test must be shown failing against the PR base
+# before it may pass, and the lines a PR changed must kill at least one
+# mutant. Four artifacts:
+#   .githooks/lib/check-red-green       the red-green check (scaffold-owned,
+#                                        refreshed)
+#   .githooks/lib/check-mutation-diff   the mutation check (scaffold-owned,
+#                                        refreshed; needs no local tooling,
+#                                        CI installs mutmut==3.7.0 itself)
+#   .github/workflows/test-guard.yml    the PR gate running both
+#                                        (drift-preserving)
 #   a rules section appended once to coding-rules.md (user-owned, so
 #   append-if-marker-absent, same pattern as install-claude.sh's CLAUDE.md
 #   merge; a plain re-run never appends twice, and uninstall leaves it, like
@@ -61,6 +68,8 @@ install_opt_in_test_guard() {
   if [ "$TEST_GUARD" -eq 1 ]; then
     cp_scaffold "$SCAFFOLD_DIR/githooks/lib/check-red-green.template" ".githooks/lib/check-red-green"
     mkx ".githooks/lib/check-red-green"
+    cp_scaffold "$SCAFFOLD_DIR/githooks/lib/check-mutation-diff.template" ".githooks/lib/check-mutation-diff"
+    mkx ".githooks/lib/check-mutation-diff"
     cp_scaffold_preserve "$SCAFFOLD_DIR/.github/workflows/test-guard.yml.template" ".github/workflows/test-guard.yml"
     if [ -f "coding-rules.md" ] && ! grep -q 'ai-coding-rules-scaffold:test-guard:begin' "coding-rules.md" 2>/dev/null; then
       cat "$SCAFFOLD_DIR/coding-rules-test-guard.md" >>"coding-rules.md"
@@ -69,6 +78,7 @@ install_opt_in_test_guard() {
     echo "note: test-guard.yml runs check-red-green on every PR: each NEW test is run against the base commit and must FAIL there. Register the exemption marker in pytest.ini under [pytest]:"
     echo "          markers ="
     echo "              characterization: passes against the base branch by design; give a reason"
+    echo "      It also runs check-mutation-diff, an advisory mutation-testing layer scoped to the PR's changed lines: surviving mutants print a warning but never fail the job (advisory-first, issue #145). CI installs mutmut==3.7.0 itself, nothing to add locally."
     echo "      and make test-guard a REQUIRED status check on the default branch: an advisory check on a repo where the agent can also merge is a check the agent can route around."
   fi
 }

--- a/tests/cases/27-test-guard.sh
+++ b/tests/cases/27-test-guard.sh
@@ -1,14 +1,21 @@
 # shellcheck shell=bash
 # cases/27-test-guard.sh: the opt-in red-green test-integrity gate
-# (--test-guard, #140 item 2). Three artifacts, three copy policies:
-# .githooks/lib/check-red-green is scaffold-owned (cp_scaffold + mkx,
-# refreshed on upgrade), test-guard.yml is a drift-preserving CI workflow
-# (cp_scaffold_preserve; the drift semantics themselves are proven by
-# cases/21's _wd_case, not re-proven here), and the rules section is an
+# (--test-guard, #140 item 2, plus the advisory mutation layer from #145).
+# Four artifacts, three copy policies: .githooks/lib/check-red-green and
+# .githooks/lib/check-mutation-diff are both scaffold-owned (cp_scaffold +
+# mkx, refreshed on upgrade), test-guard.yml is a drift-preserving CI
+# workflow (cp_scaffold_preserve; the drift semantics themselves are proven
+# by cases/21's _wd_case, not re-proven here), and the rules section is an
 # append-if-marker-absent merge into user-owned coding-rules.md, the same
 # pattern as install-claude.sh's CLAUDE.md merge, so a re-run must never
-# append twice. Sourced into the driver's shell, so PASS/FAIL/SCAFFOLD_DIR/
-# HOOK_OUT are already in scope.
+# append twice. check-mutation-diff's own honesty contract is exercised
+# directly below: verify_mutmut() runs before anything else in main(),
+# including the "nothing to mutate" early return, so in this suite's
+# environment, which has no mutmut installed (measured, not assumed),
+# invoking the installed check with a real --base must exit 2 with a
+# distinctive "mutmut is not importable" message, never a false 0. Sourced
+# into the driver's shell, so PASS/FAIL/SCAFFOLD_DIR/HOOK_OUT are already
+# in scope.
 
 echo "cases/27: --test-guard opt-in red-green gate (#140)"
 
@@ -19,10 +26,11 @@ _tg_fixture() {
   printf '%s' "$t"
 }
 
-# (T) a default install (no flag) creates none of the three artifacts:
+# (T) a default install (no flag) creates none of the four artifacts:
 # stays opt-in.
 D=$(_tg_fixture)
-if [ ! -e "$D/.githooks/lib/check-red-green" ] && [ ! -e "$D/.github/workflows/test-guard.yml" ] \
+if [ ! -e "$D/.githooks/lib/check-red-green" ] && [ ! -e "$D/.githooks/lib/check-mutation-diff" ] \
+   && [ ! -e "$D/.github/workflows/test-guard.yml" ] \
    && ! grep -q 'ai-coding-rules-scaffold:test-guard:begin' "$D/coding-rules.md"; then
   echo "  ✓ a default install creates no test-guard artifacts"; PASS=$((PASS + 1))
 else
@@ -30,19 +38,21 @@ else
 fi
 rm -rf "$D"
 
-# (T) --test-guard installs all three: the check (executable, byte-identical
-# to the shipped template), the workflow (byte-identical), and the rules
-# section appended to coding-rules.md exactly once, with the original
-# coding-rules.md content still in place above it.
+# (T) --test-guard installs all four: both checks (executable,
+# byte-identical to their shipped templates), the workflow (byte-identical),
+# and the rules section appended to coding-rules.md exactly once, with the
+# original coding-rules.md content still in place above it.
 T=$(_tg_fixture --test-guard)
 if [ -x "$T/.githooks/lib/check-red-green" ] \
    && cmp -s "$SCAFFOLD_DIR/githooks/lib/check-red-green.template" "$T/.githooks/lib/check-red-green" \
+   && [ -x "$T/.githooks/lib/check-mutation-diff" ] \
+   && cmp -s "$SCAFFOLD_DIR/githooks/lib/check-mutation-diff.template" "$T/.githooks/lib/check-mutation-diff" \
    && cmp -s "$SCAFFOLD_DIR/.github/workflows/test-guard.yml.template" "$T/.github/workflows/test-guard.yml" \
    && grep -q '^# Coding rules$' "$T/coding-rules.md" \
    && [ "$(grep -c 'ai-coding-rules-scaffold:test-guard:begin' "$T/coding-rules.md")" -eq 1 ]; then
-  echo "  ✓ --test-guard installs the check, the workflow, and the rules section"; PASS=$((PASS + 1))
+  echo "  ✓ --test-guard installs both checks, the workflow, and the rules section"; PASS=$((PASS + 1))
 else
-  echo "  ✗ --test-guard should install check + workflow + appended rules section"; FAIL=$((FAIL + 1))
+  echo "  ✗ --test-guard should install both checks + workflow + appended rules section"; FAIL=$((FAIL + 1))
 fi
 
 # (T) the installed check is runnable python3 and exits 0 in a repo with no
@@ -52,6 +62,25 @@ if ( cd "$T" && python3 .githooks/lib/check-red-green --base HEAD ) >"$HOOK_OUT"
   echo "  ✓ installed check-red-green runs and exits 0 with no tests directory"; PASS=$((PASS + 1))
 else
   echo "  ✗ installed check-red-green should exit 0 with no tests directory"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+
+# (T) the installed check-mutation-diff is runnable python3 and honors its
+# documented exit contract: verify_mutmut() runs before anything else in
+# main(), including the "nothing to mutate" early return, so with mutmut
+# not importable it must exit 2 naming that reason, never a false 0 or a
+# generic crash. Guarded on a live re-check of the assumption (this suite's
+# environment has no mutmut installed) so environment drift fails loudly
+# here instead of silently validating the wrong path.
+if python3 -c 'import mutmut' >/dev/null 2>&1; then
+  echo "  ✗ check-mutation-diff honesty-contract assertion assumes mutmut is not importable here, but it now is; this assertion needs the other deterministic path"; FAIL=$((FAIL + 1))
+else
+  mut_rc=0
+  ( cd "$T" && python3 .githooks/lib/check-mutation-diff --base HEAD ) >"$HOOK_OUT" 2>&1 || mut_rc=$?
+  if [ "$mut_rc" -eq 2 ] && grep -q 'mutmut is not importable' "$HOOK_OUT"; then
+    echo "  ✓ installed check-mutation-diff exits 2 naming mutmut not importable"; PASS=$((PASS + 1))
+  else
+    echo "  ✗ installed check-mutation-diff should exit 2 naming mutmut not importable (got exit $mut_rc)"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+  fi
 fi
 
 # (T) a re-run with the same flag appends nothing: the marker section must
@@ -66,14 +95,15 @@ else
 fi
 rm -rf "$T"
 
-# (T) uninstall.sh removes the unmodified check and workflow, and leaves
+# (T) uninstall.sh removes the unmodified checks and workflow, and leaves
 # coding-rules.md (user-owned) with the appended section intact.
 U=$(_tg_fixture --test-guard)
 ( cd "$U" && "$SCAFFOLD_DIR/uninstall.sh" ) >"$HOOK_OUT" 2>&1
-if [ ! -e "$U/.githooks/lib/check-red-green" ] && [ ! -e "$U/.github/workflows/test-guard.yml" ] \
+if [ ! -e "$U/.githooks/lib/check-red-green" ] && [ ! -e "$U/.githooks/lib/check-mutation-diff" ] \
+   && [ ! -e "$U/.github/workflows/test-guard.yml" ] \
    && grep -q 'ai-coding-rules-scaffold:test-guard:begin' "$U/coding-rules.md"; then
-  echo "  ✓ uninstall.sh removes check + workflow, keeps the user-owned rules file"; PASS=$((PASS + 1))
+  echo "  ✓ uninstall.sh removes both checks + workflow, keeps the user-owned rules file"; PASS=$((PASS + 1))
 else
-  echo "  ✗ uninstall.sh should remove check + workflow and keep coding-rules.md"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+  echo "  ✗ uninstall.sh should remove both checks + workflow and keep coding-rules.md"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
 fi
 rm -rf "$U"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -176,6 +176,8 @@ remove_if_unmodified ".github/workflows/socket-security.yml" "$SCAFFOLD_DIR/.git
 # coding-rules.md is user-owned, same policy as every other user-owned edit.
 remove_if_unmodified ".github/workflows/test-guard.yml" "$SCAFFOLD_DIR/.github/workflows/test-guard.yml.template"
 remove_if_unmodified ".githooks/lib/check-red-green" "$SCAFFOLD_DIR/githooks/lib/check-red-green.template"
+# Advisory diff-scoped mutation layer for test-guard (#145).
+remove_if_unmodified ".githooks/lib/check-mutation-diff" "$SCAFFOLD_DIR/githooks/lib/check-mutation-diff.template"
 # Opt-in npm install-layer cooldown (only present if installed with
 # --npm-cooldown, #117).
 remove_if_unmodified ".npmrc" "$SCAFFOLD_DIR/.npmrc.template"


### PR DESCRIPTION
Phase 2 of the test-guard gate: implements #145, the advisory diff-scoped mutation-testing layer, closing the blind spot `check-red-green` documents in its own source (a test can be red on base and still assert nothing about the new code's behaviour).

**What ships.** `.githooks/lib/check-mutation-diff` (476 lines), installed by the existing `--test-guard` flag, plus an advisory step in `test-guard.yml`. It mutates only the Python source files the PR changed (mutmut==3.7.0 pinned in CI, file-glob scoping, the narrowest this mutmut major supports) and reports, per file, every mutant the suite fails to kill.

**Semantics (issue #145's advisory-first design):**
- surviving mutants: `::warning` per file plus a summary, exit 0, never fails the job
- more mutants than `--max-mutants`: exit 1, "split the PR"
- cannot evaluate (mutmut missing or off-pin, broken baseline suite, bad path, timeout): exit 2, a FAILURE, never a skip

**Measured design facts** (from a real mutmut 3.7.0, not memory): mutmut exits 0 even when mutants survive, so verdicts parse `mutants/*.py.meta`; a bad source path is indistinguishable from zero coverage in mutmut's own message, so paths are preflighted; zero-coverage aborts and broken baselines share an empty-stats signature and are split on mutmut's "failed to collect stats" marker.

**Verification:** suite 380 passed / 5 failed (the 5 are the documented eslint-cache environment flakes; +1 assertion over the 379 baseline). An independent verification pass re-ran the exit contract in nine scenarios (all-killed, survivors, cap, bad base ref, broken baseline, missing mutmut, wrong pinned version, timeout with worktree cleanup, empty diff), all matching the documented contract, plus an independent install/uninstall round-trip. Verdict ACCEPT-WITH-NITS; the five non-blocking nits are recorded on #145.

Closes #145. Follows #146 (red-green, merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TcsSJD7kaR8DqoP4q1FBet
