### PR TITLE
chore(homebrew): sync canonical formula to v0.15.0

### DIFF
--- a/packaging/homebrew/ai-coding-rules-scaffold.rb
+++ b/packaging/homebrew/ai-coding-rules-scaffold.rb
@@ -9,8 +9,8 @@
 class AiCodingRulesScaffold < Formula
   desc "Pre-commit and CI guardrails: size, pattern, secret, and hygiene checks"
   homepage "https://github.com/Sting25/ai-coding-rules-scaffold"
-  url "https://github.com/Sting25/ai-coding-rules-scaffold/archive/refs/tags/v0.14.0.tar.gz"
-  sha256 "bc15a220477c7d8bba6170661e6ed85f1fce3633a9e1bac75df755ce6fa62dcb"
+  url "https://github.com/Sting25/ai-coding-rules-scaffold/archive/refs/tags/v0.15.0.tar.gz"
+  sha256 "975e5159790eb5cd237545ecb61a1331d7737cd7b43e791c4884526418588d91"
   license "MIT"
 
   def install


### PR DESCRIPTION
Follow-up per RELEASING.md: the tap already self-bumped; this keeps the canonical copy in lockstep. sha256 verified independently against the v0.15.0 tag tarball.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TcsSJD7kaR8DqoP4q1FBet