### PR TITLE
feat(check-patterns): INCLUDE/EXCLUDE scoping (#149); fix JS tool gates that trusted the npx cache

### DIFF
--- a/.github/workflows/lint.yml.template
+++ b/.github/workflows/lint.yml.template
@@ -133,8 +133,12 @@ jobs:
           # be in package.json + the lockfile, or `npm ci` won't install them and
           # eslint crashes cryptically. Turn that into an actionable error instead.
           PEERS='eslint @eslint/js @eslint/compat typescript-eslint eslint-plugin-import-x eslint-plugin-unused-imports'
+          # "Installed" means resolvable from the project's node_modules. The
+          # gate is Node's resolver, not `npx --no-install --version`, which
+          # also answers from npm's global _npx cache on self-hosted or cached
+          # runners (same gate as the pre-commit hook).
           if [ -f eslint.config.js ]; then
-            if ! npx --no-install eslint --version >/dev/null 2>&1; then
+            if ! node -e "require.resolve('eslint/package.json')" >/dev/null 2>&1; then
               echo "::error file=eslint.config.js::eslint is not installed. Run: npm i -D $PEERS  — then commit package-lock.json (CI installs from the lockfile)."
               exit 1
             fi
@@ -159,7 +163,7 @@ jobs:
         # and the two intentionally don't overlap (no eslint-config-prettier).
         run: |
           if { [ -f .prettierrc ] || [ -f .prettierrc.json ] || [ -f .prettierrc.js ] || [ -f prettier.config.js ]; } \
-             && npx --no-install prettier --version >/dev/null 2>&1; then
+             && node -e "require.resolve('prettier/package.json')" >/dev/null 2>&1; then
             changed=()
             while IFS= read -r -d '' f; do changed+=("$f"); done <changed.nul
             if [ ${#changed[@]} -eq 0 ]; then echo "no changed files — skipping format check"; exit 0; fi
@@ -181,7 +185,7 @@ jobs:
           # so unlike eslint/ruff it can't be diff-scoped. If a freshly-installed
           # project has pre-existing type errors, narrow tsconfig "include" or fix
           # them — this is a real correctness signal, not lint noise.
-          if [ -f tsconfig.json ] && npx --no-install tsc --version >/dev/null 2>&1; then
+          if [ -f tsconfig.json ] && node -e "require.resolve('typescript/package.json')" >/dev/null 2>&1; then
             npx --no-install tsc --noEmit
           else
             echo "tsconfig.json or typescript missing — skipping tsc type-check"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,22 @@ versioning follows [SemVer](https://semver.org/).
   rather than scanning nothing. Unset means unchanged behavior; the shipped
   hook and CI leave both unset. Regression test: case 28.
 
+### Fixed
+
+- **Pre-commit no longer runs a JS tool that is not installed in the
+  project.** The hook gated ESLint, Prettier and tsc on
+  `npx --no-install <tool> --version`, which also answers from npm's
+  global `_npx` cache. A cached ESLint then ran against the shipped
+  config with none of the config's imports installed, crashed, and
+  failed the commit. The gate is now Node's own resolver
+  (`require.resolve` from the project, hoisted monorepos included),
+  which never reads that cache; a cached-only tool is treated as not
+  installed and skipped with the usual notice. The installer's
+  post-install verify used the same npx gate to decide whether to offer
+  an install and now uses the same resolver. Regression test: case
+  42b2. This is also why the test suite showed 5 machine-dependent
+  failures on any host with a stale `~/.npm/_npx` ESLint entry.
+
 ## [v0.15.0] - 2026-09-01
 
 The test-guard release: a new opt-in `--test-guard` flag installs the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 versioning follows [SemVer](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- **`check-patterns` honors `CHECK_PATTERNS_INCLUDE` / `CHECK_PATTERNS_EXCLUDE`
+  (#149).** Space-separated pattern-file basenames select or skip
+  `.forbidden-patterns/*.txt` files for one run, so a downstream wrapper
+  can scan a security-only subset whole-tree and the rest changed-files-
+  only without editing the scaffold-owned script. Previously the only way
+  to get this was a local edit that every `install.sh` re-run silently
+  reverted (#98, #149). An `INCLUDE` that matches nothing warns on stderr
+  rather than scanning nothing. Unset means unchanged behavior; the shipped
+  hook and CI leave both unset. Regression test: case 28.
+
 ## [v0.15.0] - 2026-09-01
 
 The test-guard release: a new opt-in `--test-guard` flag installs the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,9 @@ versioning follows [SemVer](https://semver.org/).
   which never reads that cache; a cached-only tool is treated as not
   installed and skipped with the usual notice. The installer's
   post-install verify used the same npx gate to decide whether to offer
-  an install and now uses the same resolver. Regression test: case
-  42b2. This is also why the test suite showed 5 machine-dependent
+  an install and now uses the same resolver, and so does the shipped
+  `lint.yml` workflow (self-hosted or cached runners carry an npx cache
+  too). Regression test: case 42b2. This is also why the test suite showed 5 machine-dependent
   failures on any host with a stale `~/.npm/_npx` ESLint entry.
 
 ## [v0.15.0] - 2026-09-01

--- a/forbidden-patterns/README.md
+++ b/forbidden-patterns/README.md
@@ -31,6 +31,22 @@ built-in fallback mapping, so an older copy without the header still works.
 (`go.mod`, `Cargo.toml`, `composer.json`, `pom.xml`/`build.gradle`, `Gemfile`,
 …), or all of them with `--all-langs`.
 
+### Scoping a run to a subset of pattern files
+
+`check-patterns` scans every discovered file by default. A caller that runs
+more than one tier (say, security rules against the whole tree and everything
+else against changed files only) can select pattern files by basename:
+
+```sh
+CHECK_PATTERNS_INCLUDE="security.txt" .githooks/lib/check-patterns <whole-tree.nul
+CHECK_PATTERNS_EXCLUDE="security.txt" .githooks/lib/check-patterns <changed.nul
+```
+
+Both variables take space-separated basenames and match whole names, so
+`frontend.txt` never selects `frontend-security.txt`. An `INCLUDE` that
+matches no file prints a warning to stderr instead of silently scanning
+nothing. The shipped pre-commit hook and CI workflow leave both unset.
+
 ## Format
 
 ```

--- a/githooks/lib/check-patterns.template
+++ b/githooks/lib/check-patterns.template
@@ -12,6 +12,16 @@
 # Pattern format: <regex><TAB><description>
 # (TAB is the field separator so regex can use literal `|` alternation.)
 #
+# Scope by pattern FILE (opt-in, for callers that run more than one tier):
+#   CHECK_PATTERNS_INCLUDE  space-separated basenames; ONLY these are scanned
+#   CHECK_PATTERNS_EXCLUDE  space-separated basenames; these are skipped
+# e.g. a wrapper can run `CHECK_PATTERNS_INCLUDE=security.txt` against the
+# whole tree and `CHECK_PATTERNS_EXCLUDE=security.txt` against changed files.
+# Unset means every discovered file, which is what pre-commit and CI use.
+# An INCLUDE that matches no file warns on stderr rather than scanning nothing
+# silently (#149). Both names are matched whole, so `a.txt` never selects
+# `a-extra.txt`.
+#
 # Like check-secrets, this scans the STAGED/INDEXED BLOB via
 # `git show ":0:<path>"` rather than the working-tree file, so symlinks, NUL
 # bytes, and post-stage edits cannot hide content from the scan. Every grep
@@ -231,11 +241,21 @@ exts_for() {
 }
 
 FAILED=0
+INCLUDED=0
 # Auto-discover every pattern file. secrets.txt is check-secrets' domain (it
-# scans all files, not by extension), so skip it here.
+# scans all files, not by extension), so skip it here. Then apply the optional
+# INCLUDE/EXCLUDE basename filter documented in the header.
 for cfg in .forbidden-patterns/*.txt; do
   [ -e "$cfg" ] || continue   # no glob match → literal string; skip
-  case "$(basename "$cfg")" in secrets.txt) continue ;; esac
+  base=$(basename "$cfg")
+  case "$base" in secrets.txt) continue ;; esac
+  if [ -n "${CHECK_PATTERNS_INCLUDE:-}" ]; then
+    case " $CHECK_PATTERNS_INCLUDE " in *" $base "*) ;; *) continue ;; esac
+  fi
+  if [ -n "${CHECK_PATTERNS_EXCLUDE:-}" ]; then
+    case " $CHECK_PATTERNS_EXCLUDE " in *" $base "*) continue ;; esac
+  fi
+  INCLUDED=$((INCLUDED + 1))
   cfg_exts=$(exts_for "$cfg")
   if [ -z "$cfg_exts" ]; then
     echo "warning: $cfg: no '# scaffold-extensions:' header and no built-in mapping — skipped" >&2
@@ -244,5 +264,9 @@ for cfg in .forbidden-patterns/*.txt; do
   # shellcheck disable=SC2086  # word-splitting $cfg_exts into separate args is intentional
   scan "$cfg" $cfg_exts
 done
+
+if [ -n "${CHECK_PATTERNS_INCLUDE:-}" ] && [ "$INCLUDED" -eq 0 ]; then
+  echo "warning: CHECK_PATTERNS_INCLUDE='$CHECK_PATTERNS_INCLUDE' matched no .forbidden-patterns/*.txt, nothing was scanned" >&2
+fi
 
 exit $FAILED

--- a/githooks/pre-commit.template
+++ b/githooks/pre-commit.template
@@ -171,6 +171,22 @@ fi
 # each check below prints a one-line notice to stderr and skips (exit stays
 # 0), so the hook stays usable on machines that haven't run `pip install
 # ruff` yet while still telling the developer why nothing ran.
+# "Installed" for a JS tool means resolvable from THIS project's node_modules
+# (walking upward, so hoisted monorepos count). `npx --no-install <tool>` is
+# not that test: it also answers from npm's global _npx cache (measured: an
+# empty directory reports eslint 10.9.1 when ~/.npm/_npx holds one). A cached
+# tool then runs against this project's config with none of the config's own
+# imports installed, crashes, and fails the commit for a tool the project never
+# asked for. Node's resolver never consults that cache, so it is the gate; npx
+# only launches the binary once the gate passes.
+js_tool_installed() {
+  if command -v node >/dev/null 2>&1 && command -v npx >/dev/null 2>&1 \
+     && node -e "require.resolve('$1/package.json')" >/dev/null 2>&1; then
+    return 0
+  fi
+  return 1
+}
+
 STAGED_PY=()
 STAGED_JS=()
 STAGED_PHP=()
@@ -195,10 +211,10 @@ if [ ${#STAGED_PY[@]} -gt 0 ] && { [ -f ruff.toml ] || [ -f pyproject.toml ]; };
 fi
 
 if [ ${#STAGED_JS[@]} -gt 0 ] && { [ -f eslint.config.js ] || [ -f package.json ]; }; then
-  if command -v npx >/dev/null 2>&1 && npx --no-install eslint --version >/dev/null 2>&1; then
+  if js_tool_installed eslint; then
     npx --no-install eslint -- "${STAGED_JS[@]}" || FAILED=1
   else
-    echo "note: eslint not installed (or not resolvable via npx), skipping the local lint pass on staged JS/TS files." >&2
+    echo "note: eslint not installed in this project's node_modules, skipping the local lint pass on staged JS/TS files." >&2
     echo "      CI's lint job is the authoritative gate; run 'npm install' for local feedback." >&2
   fi
 fi
@@ -210,10 +226,10 @@ fi
 # the linter above. `prettier --write` is the fix.
 if [ ${#STAGED_JS[@]} -gt 0 ] \
    && { [ -f .prettierrc ] || [ -f .prettierrc.json ] || [ -f .prettierrc.js ] || [ -f prettier.config.js ] || grep -qs '"prettier"' package.json; }; then
-  if command -v npx >/dev/null 2>&1 && npx --no-install prettier --version >/dev/null 2>&1; then
+  if js_tool_installed prettier; then
     npx --no-install prettier --check -- "${STAGED_JS[@]}" || FAILED=1
   else
-    echo "note: prettier not installed (or not resolvable via npx), skipping the local format check on staged JS/TS files." >&2
+    echo "note: prettier not installed in this project's node_modules, skipping the local format check on staged JS/TS files." >&2
     echo "      CI's lint job is the authoritative gate; run 'npm install' for local feedback." >&2
   fi
 fi
@@ -223,10 +239,10 @@ fi
 # tsconfig.json and its compiler options. A missing/unresolvable tsc prints a
 # notice and skips, like the checks above; CI is the authoritative backstop.
 if [ ${#STAGED_JS[@]} -gt 0 ] && [ -f tsconfig.json ]; then
-  if command -v npx >/dev/null 2>&1 && npx --no-install tsc --version >/dev/null 2>&1; then
+  if js_tool_installed typescript; then
     npx --no-install tsc --noEmit || FAILED=1
   else
-    echo "note: TypeScript not installed (or not resolvable via npx), skipping the local tsc type check." >&2
+    echo "note: TypeScript not installed in this project's node_modules, skipping the local tsc type check." >&2
     echo "      CI's lint job is the authoritative gate; run 'npm install' for local feedback." >&2
   fi
 fi

--- a/install-verify.sh
+++ b/install-verify.sh
@@ -35,6 +35,18 @@ py_install_cmd() {
 
 # offer <label> <presence-test-command> <install-base> <packages>
 # Prints ✓ when present; otherwise offers to install (auto-run only if safe).
+# Same gate the pre-commit hook uses: a JS tool counts as installed only when
+# Node can resolve it from this project's node_modules. `npx --no-install`
+# also answers from npm's global _npx cache, which would report "installed"
+# for a tool the project never added and then skip the offer.
+js_pkg_installed() {
+  if command -v node >/dev/null 2>&1 \
+     && node -e "require.resolve('$1/package.json')" >/dev/null 2>&1; then
+    return 0
+  fi
+  return 1
+}
+
 offer() {
   local label=$1 testcmd=$2 base=$3 pkgs=$4 reply
   if eval "$testcmd" >/dev/null 2>&1; then
@@ -84,10 +96,10 @@ run_toolchain_verify() {
     case "$MODE" in
       frontend|both)
         JSI=$(js_install_cmd)
-        offer "eslint" "npx --no-install eslint --version" "$JSI" "eslint @eslint/js @eslint/compat typescript-eslint eslint-plugin-import-x eslint-plugin-unused-imports"
-        offer "typescript (tsc)" "npx --no-install tsc --version" "$JSI" "typescript"
-        offer "prettier" "npx --no-install prettier --version" "$JSI" "prettier"
-        offer "vitest" "npx --no-install vitest --version" "$JSI" "vitest @vitest/coverage-v8"
+        offer "eslint" "js_pkg_installed eslint" "$JSI" "eslint @eslint/js @eslint/compat typescript-eslint eslint-plugin-import-x eslint-plugin-unused-imports"
+        offer "typescript (tsc)" "js_pkg_installed typescript" "$JSI" "typescript"
+        offer "prettier" "js_pkg_installed prettier" "$JSI" "prettier"
+        offer "vitest" "js_pkg_installed vitest" "$JSI" "vitest @vitest/coverage-v8"
         # The 'frontend' CI job loads eslint.config.js (and its plugins) from the
         # lockfile. If you skip the eslint prompt above, that job fails with an
         # actionable error until you install the deps AND commit the lockfile.

--- a/tests/cases/05-frontend-typescript.sh
+++ b/tests/cases/05-frontend-typescript.sh
@@ -88,7 +88,9 @@ assert_passes "console.warn allowed; clean .ts with no tsconfig passes"
 #     skip. Documents intent and exercises the path on machines that have a
 #     project-local tsc. The hook runs `tsc --noEmit` project-wide when a
 #     tsconfig.json exists.
-if npx --no-install tsc --version >/dev/null 2>&1; then
+#     The predicate is the hook's own gate (Node resolution from node_modules),
+#     not `npx --no-install`, which also answers from the global npx cache.
+if node -e "require.resolve('typescript/package.json')" >/dev/null 2>&1; then
   echo '{"compilerOptions":{"strict":true,"noEmit":true}}' >tsconfig.json
   echo 'const n: number = "definitely not a number";' >typeerr.ts
   git add tsconfig.json typeerr.ts
@@ -100,37 +102,57 @@ fi
 # 42b. eslint block rejection. The JS-linter integration in the pre-commit
 #      orchestrator had no rejection test — eslint isn't resolvable in the temp
 #      repo, so it silently skips, meaning a regression that stops eslint
-#      findings from setting FAILED would ship green. Stub `npx` on an isolated
-#      PATH so the --version gate passes and the lint run fails, proving the
-#      block propagates a non-zero exit into the hook's failure.
+#      findings from setting FAILED would ship green. Plant a project-local
+#      node_modules/eslint so the hook's Node-resolution gate passes, and stub
+#      `npx` on an isolated PATH so the lint run fails, proving the block
+#      propagates a non-zero exit into the hook's failure.
 ESB=$(mktemp -d)
 cat >"$ESB/npx" <<'STUB'
 #!/bin/sh
-# `--no-install eslint --version` → ok (gate); `eslint -- <files>` → fail (lint).
+# `eslint -- <files>` → fail (lint); anything else → ok.
 case "$*" in
-  *--version*) exit 0 ;;
-  *eslint*)    echo "eslint: problems found"; exit 1 ;;
-  *)           exit 0 ;;
+  *eslint*) echo "eslint: problems found"; exit 1 ;;
+  *)        exit 0 ;;
 esac
 STUB
 chmod +x "$ESB/npx"
+mkdir -p node_modules/eslint
+echo '{"name":"eslint","version":"0.0.0-test"}' >node_modules/eslint/package.json
 echo 'const x = 1' >lintme.js
 git add lintme.js
 if PATH="$ESB:$PATH" .githooks/pre-commit >"$HOOK_OUT" 2>&1; then
-  echo "  ✗ eslint block — hook accepted despite an eslint failure"; FAIL=$((FAIL + 1))
+  echo "  ✗ eslint block: hook accepted despite an eslint failure"; FAIL=$((FAIL + 1))
 elif grep -qF "Pre-commit failed" "$HOOK_OUT"; then
-  echo "  ✓ eslint findings fail the pre-commit hook"; PASS=$((PASS + 1))
+  echo "  ✓ eslint findings fail the pre-commit hook (project-local install)"; PASS=$((PASS + 1))
 else
-  echo "  ✗ eslint block — rejected but not via the linter path"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+  echo "  ✗ eslint block: rejected but not via the linter path"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+rm -rf node_modules
+reset_repo
+
+# 42b2. REGRESSION: a tool that npx can resolve (global _npx cache) but that is
+#       NOT in this project's node_modules must be treated as not installed:
+#       skip notice, exit 0. Same stub as 42b (npx "runs" eslint and fails),
+#       no node_modules planted. Before the Node-resolution gate this was the
+#       cached-eslint crash that failed 5 cases on any machine with a stale
+#       ~/.npm/_npx eslint entry, so this case is deterministic on purpose.
+echo 'const z = 1' >cachedonly.js
+git add cachedonly.js
+if PATH="$ESB:$PATH" .githooks/pre-commit >"$HOOK_OUT" 2>&1 \
+   && grep -qF "note: eslint not installed" "$HOOK_OUT"; then
+  echo "  ✓ npx-resolvable but not project-local eslint is skipped, not run"; PASS=$((PASS + 1))
+else
+  echo "  ✗ npx-resolvable but not project-local eslint: expected skip notice and exit 0"
+  sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
 fi
 rm -rf "$ESB"
 reset_repo
 
 # 42c. skip notice: when npx can't resolve eslint (a matching .js file is
 #      staged and eslint.config.js ships from the scaffold install), the hook
-#      must print a one-line notice to stderr and still exit 0. Stub `npx` so
-#      `--no-install eslint --version` always fails, regardless of whether
-#      eslint happens to be resolvable on this machine.
+#      must print a one-line notice to stderr and still exit 0. No node_modules
+#      exists in the temp repo, so the Node-resolution gate fails; the failing
+#      `npx` stub proves the hook never even launches the tool.
 NPXFAIL=$(mktemp -d)
 cat >"$NPXFAIL/npx" <<'STUB'
 #!/bin/sh

--- a/tests/cases/28-check-patterns-scope.sh
+++ b/tests/cases/28-check-patterns-scope.sh
@@ -1,0 +1,77 @@
+# shellcheck shell=bash
+# cases/28-check-patterns-scope.sh, CHECK_PATTERNS_INCLUDE / CHECK_PATTERNS_EXCLUDE
+# (#149). Sourced into the driver's shell. Exercises check-patterns directly with
+# a NUL list on stdin (the same way case 10 does), since the pre-commit hook
+# never sets either variable. Every case asserts the POSITIVE outcome (the file
+# that should be flagged IS flagged and the exit is non-zero), never only the
+# absence of the other file.
+echo ""
+echo "check-patterns INCLUDE/EXCLUDE scoping (#149):"
+
+# Fixtures: one backend.txt violation, one frontend.txt violation. Staged so
+# check-patterns' `git show :0:` scan can see them.
+printf 'print("debug")\n' >scope_debug.py
+printf 'console.log("debug");\n' >scope_debug.ts
+git add scope_debug.py scope_debug.ts
+
+# run_cp <name> <expected-flagged> <expected-clean> [<expected stderr substring>]
+# Environment for the run comes from the CP_ENV array (env(1) arguments), so
+# values with spaces survive and nothing leaks into the driver's shell.
+CP_ENV=()
+run_cp() {
+  local name=$1 want=$2 clean=$3 warn=${4:-} rc=0
+  printf '%s\0' scope_debug.py scope_debug.ts \
+    | env "${CP_ENV[@]}" .githooks/lib/check-patterns >"$HOOK_OUT" 2>&1 || rc=$?
+  if [ -n "$want" ] && ! grep -qF "$want" "$HOOK_OUT"; then
+    echo "  ✗ $name: $want was not flagged"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+  elif [ -n "$want" ] && [ "$rc" -eq 0 ]; then
+    echo "  ✗ $name: $want flagged but exit was 0"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+  elif [ -z "$want" ] && [ "$rc" -ne 0 ]; then
+    echo "  ✗ $name: expected exit 0, got $rc"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+  elif [ -n "$clean" ] && grep -qF "$clean" "$HOOK_OUT"; then
+    echo "  ✗ $name: $clean was flagged, expected out of scope"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+  elif [ -n "$warn" ] && ! grep -qF "$warn" "$HOOK_OUT"; then
+    echo "  ✗ $name: expected warning missing: $warn"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+  else
+    echo "  ✓ $name"; PASS=$((PASS + 1))
+  fi
+}
+
+# 28a. Baseline: both unset, both files flagged (unchanged default behavior).
+CP_ENV=(-u CHECK_PATTERNS_INCLUDE -u CHECK_PATTERNS_EXCLUDE)
+run_cp "unset: backend rule fires" scope_debug.py ""
+run_cp "unset: frontend rule fires" scope_debug.ts ""
+
+# 28b. INCLUDE=backend.txt: the .py violation fires, the .ts one is out of scope.
+CP_ENV=(CHECK_PATTERNS_INCLUDE=backend.txt)
+run_cp "INCLUDE=backend.txt scans only backend rules" scope_debug.py scope_debug.ts
+
+# 28c. EXCLUDE=backend.txt: the .ts violation fires, the .py one is skipped.
+CP_ENV=(CHECK_PATTERNS_EXCLUDE=backend.txt)
+run_cp "EXCLUDE=backend.txt skips backend rules" scope_debug.ts scope_debug.py
+
+# 28d. Space-separated lists: INCLUDE naming both files scans both.
+CP_ENV=(CHECK_PATTERNS_INCLUDE="backend.txt frontend.txt")
+run_cp "INCLUDE with two names scans both" scope_debug.py ""
+grep -qF scope_debug.ts "$HOOK_OUT" || { echo "  ✗ INCLUDE with two names missed frontend"; FAIL=$((FAIL + 1)); }
+
+# 28e. Whole-name match: `backend` (no .txt) selects nothing and warns loudly
+#      instead of scanning nothing silently. Exit 0 (no violations were scanned).
+CP_ENV=(CHECK_PATTERNS_INCLUDE=backend)
+run_cp "INCLUDE matching no file warns, exit 0" "" scope_debug.py "matched no .forbidden-patterns"
+
+# 28f. Reinstall preserves the contract (#149's actual failure mode): after a
+#      plain install.sh re-run refreshes the scaffold-owned check-patterns, the
+#      INCLUDE filter still works. Also asserts the variable name is present in
+#      the installed file, so a future template edit that drops it fails here.
+"$SCAFFOLD_DIR/install.sh" --both --all-langs --no-verify >/dev/null 2>&1
+git add scope_debug.py scope_debug.ts
+if [ "$(grep -c CHECK_PATTERNS_INCLUDE .githooks/lib/check-patterns)" -ge 1 ]; then
+  echo "  ✓ reinstall keeps CHECK_PATTERNS_INCLUDE in check-patterns"; PASS=$((PASS + 1))
+else
+  echo "  ✗ reinstall dropped CHECK_PATTERNS_INCLUDE from check-patterns"; FAIL=$((FAIL + 1))
+fi
+CP_ENV=(CHECK_PATTERNS_INCLUDE=backend.txt)
+run_cp "INCLUDE still honored after reinstall" scope_debug.py scope_debug.ts
+
+reset_repo

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -62,7 +62,8 @@ for case_file in \
   "$HERE/cases/24-claude-skill.sh" \
   "$HERE/cases/25-interactive-install.sh" \
   "$HERE/cases/26-repo-adaptation-warn.sh" \
-  "$HERE/cases/27-test-guard.sh"; do
+  "$HERE/cases/27-test-guard.sh" \
+  "$HERE/cases/28-check-patterns-scope.sh"; do
   # shellcheck source=/dev/null
   . "$case_file"
 done


### PR DESCRIPTION
## What

Two related things, four commits:

1. **`check-patterns` honors `CHECK_PATTERNS_INCLUDE` / `CHECK_PATTERNS_EXCLUDE`** (closes #149). Space-separated pattern-file basenames select or skip `.forbidden-patterns/*.txt` for one run, so a downstream wrapper can scan a security-only subset whole-tree and the rest changed-files-only without editing the scaffold-owned script. Whole-name match; an INCLUDE that matches nothing warns on stderr. Unset means unchanged behavior. Regression test: case 28 (8 assertions, including a reinstall that proves the contract survives the scaffold-owned refresh that #149 hit).

2. **JS tool gates no longer trust the npx cache.** The pre-commit hook, the installer's post-install verify, and the shipped `lint.yml` all decided a tool was installed via `npx --no-install <tool> --version`, which also answers from npm's global `_npx` cache. A cached ESLint then ran against the shipped config with none of its imports installed, crashed, and failed the commit. All three now gate on `require.resolve('<pkg>/package.json')` from the project. Regression test: case 42b2 (npx-resolvable, not project-local, must skip with the notice and exit 0). This was also the root cause of the "5 known eslint-cache flakes" the local suite had been carrying; see #152.

## Measurements

| Run | Result |
|---|---|
| Before the gate fix, stale npx cache present | 388 passed, 5 failed |
| After, same cache still present | 394 passed, 0 failed |

shellcheck and actionlint clean on the changed files. No checks weakened or suppressed.

## Not in this PR

#144 (ruff gate uses bare `command -v`, misses venv-only installs) is the same defect family and is left for its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vq1Jo7rkq92gf5gaudRyCD
