### PR TITLE
Wire the agent write-guard and the gitleaks CI gate on this repo

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,59 @@
+{
+  "//": "ai-coding-rules-scaffold — OPT-IN agent-runtime guardrails for Claude Code (the scaffold's deferred 'layer three'). Copy to your project as .claude/settings.json, or merge these keys into an existing one. Two parts: a permissions deny-list (the agent can't read credential files or run a few catastrophic commands) and a PreToolUse hook that scans content the agent is about to write against .forbidden-patterns/secrets.txt — the same patterns the commit-time scanner uses. Trim the deny-list to taste; paths use gitignore-style matching.",
+
+  "permissions": {
+    "deny": [
+      "Read(**/.env)",
+      "Read(**/.env.*)",
+      "Read(**/*.pem)",
+      "Read(**/*.key)",
+      "Read(**/id_rsa)",
+      "Read(**/id_ed25519)",
+      "Read(**/id_ecdsa)",
+      "Read(**/id_dsa)",
+      "Read(**/credentials)",
+      "Read(~/.ssh/**)",
+      "Read(~/.aws/**)",
+      "Read(~/.config/gcloud/**)",
+      "Read(~/.kube/config)",
+      "Read(~/.netrc)",
+      "Read(~/.npmrc)",
+      "Bash(rm -rf /:*)",
+      "Bash(rm -rf ~:*)",
+      "Bash(rm -rf /*:*)",
+      "Bash(sudo rm:*)"
+    ],
+    "//deny": "The .env globs exempt the conventional .env.example/.sample/.template safe files only because those names match neither .env nor .env.<stack>; if you keep real secrets in an oddly-named file, add it here. A denied Read also stops the agent pulling the file into context to exfiltrate.",
+    "//ask": "Prefer 'ask' over 'deny' for anything you sometimes need (e.g. 'Bash(git push:*)') — deny is absolute, ask just prompts you."
+  },
+
+  "//sandbox": "OS-level Bash sandbox, built into Claude Code (macOS Seatbelt with nothing to install; Linux and WSL2 need two packages; no native Windows). It confines every Bash command and its child processes to a filesystem and network boundary the kernel enforces, which is the layer a deny-list of patterns can't reach: a novel command the regexes never anticipated is still boxed in. It is a companion to the deny-list above, not a replacement, because it wraps Bash only: Read, Edit, Write, MCP servers and hooks keep running on the host. Shipped OFF: set \"enabled\": true when you're ready, keep the filesystem layer on, and expect some breakage to configure around rather than to switch the sandbox off for. docker is incompatible (excludedCommands), Go CLIs like gh/gcloud/terraform can fail TLS verification under Seatbelt (excludedCommands), and git merge/checkout can fail with 'unable to unlink old'. Leave autoAllowBashIfSandboxed (default true) alone only if you actually trust the boundary you configured; it is what stops the per-command prompt. The credentials block below requires Claude Code 2.1.187 or later; an older version silently ignores it, so those paths are NOT sandboxed until you upgrade. Full reference: https://code.claude.com/docs/en/sandboxing",
+  "sandbox": {
+    "enabled": false,
+    "excludedCommands": ["docker *"],
+    "credentials": {
+      "files": [
+        { "path": "~/.ssh", "mode": "deny" },
+        { "path": "~/.aws", "mode": "deny" }
+      ]
+    }
+  },
+
+  "//mcp": "Never set enableAllProjectMcpServers to true — it auto-approves every MCP server a repo declares in .mcp.json, so a cloned/forked repo can exfiltrate source or env with no approval prompt (CVE-2026-21852). Keep it false and allowlist named servers in enabledMcpjsonServers instead; an un-allowlisted server then triggers an explicit approval prompt.",
+  "enableAllProjectMcpServers": false,
+  "enabledMcpjsonServers": [],
+
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.githooks/lib/agent-precheck"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,9 +1,13 @@
 name: gitleaks
 
-# OPT-IN secret-scanning backstop. Copy to your project as
-# `.github/workflows/gitleaks.yml`, or install it with
-# `install.sh --gitleaks-ci`. Not installed by default: it adds a third-party
-# action dependency, so opt in deliberately.
+# The scaffold's own gitleaks gate, dogfooding what install.sh --gitleaks-ci
+# installs for consumers. Rendered from .github/workflows/gitleaks.yml.template;
+# edit the template, not this file.
+#
+# Wired on 2026-09-02 because scaffold-doctor reported the local gitleaks pass
+# installed with no CI gate behind it. The pre-commit hook tells developers that
+# CI is the authoritative gate, so shipping the local pass without the server
+# side made that message untrue for this repo.
 #
 # Why this exists alongside check-secrets:
 #   The scaffold's `check-secrets` is a NARROW, offline regex gate — it catches

--- a/TECHNICAL.md
+++ b/TECHNICAL.md
@@ -586,6 +586,35 @@ the Conventional-Commits `commit-msg` hook. Edit a `*.template`, re-run the scri
 to refresh. Only the `*.template` files are tracked; the rendered copies are
 build artifacts.
 
+### Why `scaffold-doctor.sh` reports 2 guardrails "installed but NOT running"
+
+This is expected and deliberate. Read this before "fixing" it.
+
+Since 2026-09-02 the doctor reports a check as a GAP when the script is on disk
+but nothing invokes it, rather than calling it armed because the file exists. On
+this repo that surfaces two:
+
+| Reported not running      | Why it stays that way                                                                                                                                     |
+| ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `lib/check-red-green`     | Part of the opt-in `--test-guard` layer. This repo never opted in, and the gate is built around per-test suites rather than this repo's shell case files. |
+| `lib/check-mutation-diff` | Same layer, same reason. Also needs `mutmut`, which this repo does not depend on.                                                                         |
+
+They are present only because `scripts/dev-setup.sh` renders every template it
+finds. Wiring them is tracked as item 2 of the harness-adoption issue, not an
+oversight.
+
+Two others that used to appear in that list were genuine and were wired on
+2026-09-02:
+
+- **`lib/agent-precheck`** now has `.claude/settings.json` invoking it. It was
+  installed and unreferenced, so the agent write-guard was nominal.
+- **`lib/check-gitleaks`** now has `.github/workflows/gitleaks.yml` behind it.
+  The local pass tells developers CI is the authoritative gate; without the
+  workflow that statement was untrue for this repo.
+
+If the count changes, something moved. Two is the expected number; anything else
+deserves a look rather than a shrug.
+
 ## Using this without an AI
 
 The scaffold works fine without any AI tool. Drop the files in, run the hook — same enforcement. `coding-rules.md` is just a named place to put the rules humans should read.


### PR DESCRIPTION
Follow-up to the audit merge (#158). Owner-selected, not scope creep.

## Why now

The audit changed `scaffold-doctor.sh` so that a check with a script on disk but no caller is reported as a **gap** rather than "armed because the file exists". Run against this repo, that surfaced four guardrails installed and never invoked. They had been invisible behind a green "0 gaps" for as long as they had existed.

Two were genuine. Both are wired here.

| Guard | Was | Now |
|---|---|---|
| `lib/agent-precheck` | installed, nothing referenced it | `.claude/settings.json` committed, so the credential deny-list and the write scan actually run |
| `lib/check-gitleaks` | local pass with no CI gate behind it | `.github/workflows/gitleaks.yml`, rendered from the shipped template |

The gitleaks one mattered beyond the missing scan: the pre-commit hook tells developers that CI is the authoritative gate. Without the workflow, that statement was simply untrue for this repo.

`.claude/settings.json` is committed on purpose. Uncommitted, the guard protects whoever happened to run the installer and nobody else, which is the same nominal-protection problem being fixed.

## What is deliberately left unwired

`check-red-green` and `check-mutation-diff` stay as they are. Both belong to the opt-in `--test-guard` layer this repo never adopted, and they exist on disk only because `scripts/dev-setup.sh` renders every template it finds. Adopting them is item 2 of the harness-adoption tracker, which is fenced.

That decision is now written down where someone will actually hit it: `TECHNICAL.md`, under "Developing on the scaffold itself", in a subsection titled after the doctor's own wording so a confused reader finds it by searching the message. It gives the reason per check and, more usefully, the expected count. **Two is correct. A different number means something moved and deserves a look.**

A permanent red line in a health report decays into noise, and noise is exactly how the four real gaps stayed invisible. The note exists so the remaining two do not become that.

## Also

Corrects a stale claim in `gitleaks.yml.template` that it is "NOT installed by install.sh". The `--gitleaks-ci` flag has installed it for some time. Same documentation-drift family the audit catalogued.

## Verification

| Check | Result |
|---|---|
| `scaffold-doctor.sh` | 4 unwired guardrails down to 2, both remaining explained |
| Test suite | 510 passed, 0 failed |
| `actionlint` on the new workflow | clean |
| `prettier` on TECHNICAL.md | clean |
| `.claude/settings.json` | valid JSON |

The new gitleaks job runs for the first time on this PR, so its own result is part of the review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vq1Jo7rkq92gf5gaudRyCD
