### PR TITLE
Report a failed .gitignore write instead of dying silently

### DIFF
--- a/install-manifest.sh
+++ b/install-manifest.sh
@@ -296,6 +296,37 @@ _gitignore_write_failed() {
   printf '%s\n' "$SCAFFOLD_GITIGNORE_RULES" | sed 's/^/         /' >&2
 }
 
+# _gitignore_append TEXT PATH — the ONE place anything is appended to
+# .gitignore, and the reason there is a helper at all: the shell's own
+# diagnostic is the only thing that knows WHY an append failed, and the old
+# `{ ... } 2>/dev/null >>"$gi"` threw it away. Redirection order is
+# load-bearing and it is why this is written as a group: `2>&1` on the group
+# points stderr at the command substitution FIRST, then the inner `>>"$path"`
+# moves only stdout to the file, so a failure to OPEN the file still has
+# somewhere to report itself. (`>>file 2>/dev/null` is the opposite order and
+# the trap MF10 documents: the file redirection is applied first, so the shell
+# prints its complaint before stderr is silenced — or, here, after, and it is
+# lost.) Prints the trimmed reason on stdout and returns 1 on failure; silent
+# and returns 0 on success.
+_GITIGNORE_NL='
+'
+_gitignore_append() {
+  local text=$1 path=$2 err
+  if err=$( { printf '%s' "$text" >>"$path"; } 2>&1 ); then
+    return 0
+  fi
+  # "install-manifest.sh: line 372: .gitignore: Is a directory" -> "Is a
+  # directory", so _gitignore_write_failed's "could not write .gitignore (...)"
+  # reads as one sentence instead of naming the path twice. Anything that does
+  # not carry the path is passed through whole rather than guessed at.
+  err=${err%%"$_GITIGNORE_NL"*}
+  case $err in
+    *"$path: "*) err=${err##*"$path: "} ;;
+  esac
+  printf '%s' "${err:-the append to $path failed}"
+  return 1
+}
+
 # print_gitignore_failure_summary: end-of-run half, so the failure survives in
 # the summary rather than only in scrollback. Returns 1 so install.sh's
 # `print_refused_writes_summary || exit 1` fails the run.
@@ -309,7 +340,7 @@ print_gitignore_failure_summary() {
 }
 
 ensure_backup_gitignore() {
-  local gi=".gitignore" rule missing=''
+  local gi=".gitignore" rule missing='' gi_err='' gi_block=''
   if [ -L "$gi" ]; then
     echo "skip (exists, symlink): .gitignore, left untouched. Add these rules by hand, or an install artifact can be committed:"
     printf '%s\n' "$SCAFFOLD_GITIGNORE_RULES" | sed 's/^/                        /'
@@ -329,11 +360,12 @@ ensure_backup_gitignore() {
 $SCAFFOLD_GITIGNORE_RULES
 RULES
   [ -n "$missing" ] || return 0
-  # Check writability up front. A failed append redirection does not reliably
-  # propagate a non-zero status out of a compound command, so the write is also
-  # verified after the fact below: the rules are load-bearing (they keep the
-  # backup copies out of a routine `git add -A`), and reporting "updated" when
-  # nothing landed is the silent-guardrail-failure shape this module refuses.
+  # Two questions here, in this order.
+  #
+  # The friendly one first, because it can be answered in the user's terms: a
+  # .gitignore that is a regular file with the write bit off, or a missing
+  # .gitignore under a read-only project root. Those get the short reason the
+  # user can act on ("not writable") rather than an errno string.
   if [ -f "$gi" ] && [ ! -w "$gi" ]; then
     _gitignore_write_failed "not writable"
     return 0
@@ -342,10 +374,25 @@ RULES
     _gitignore_write_failed "the project root is not writable"
     return 0
   fi
+  # Then the general one, which no stat test answers: CAN this be appended to?
+  # `-f` and `-w` only describe a regular file, so every other way an append
+  # can fail walked straight past both tests — a DIRECTORY at .gitignore (`-f`
+  # is false, so the not-writable branch never fired), a read-only filesystem,
+  # a full disk, a parent that went away mid-run. The append below was then a
+  # COMPOUND command carrying `2>/dev/null`, so under install.sh's `set -e` the
+  # failed redirection killed the whole run with rc=1 and not one byte on
+  # stdout or stderr: the exact "no silent failures" shape the rules forbid,
+  # and the worst one, since the user got a failed install with nothing to
+  # read. Ask by TRYING, through the same open the real write uses, and keep
+  # the shell's own diagnostic as the reason.
+  if ! gi_err=$(_gitignore_append '' "$gi"); then
+    _gitignore_write_failed "$gi_err"
+    return 0
+  fi
   # Append on its own line even if the existing file has no trailing newline.
   if [ -f "$gi" ] && [ -s "$gi" ] && [ -n "$(tail -c 1 "$gi")" ]; then
-    if ! printf '\n' 2>/dev/null >>"$gi"; then
-      _gitignore_write_failed "not writable"
+    if ! gi_err=$(_gitignore_append "$_GITIGNORE_NL" "$gi"); then
+      _gitignore_write_failed "$gi_err"
       return 0
     fi
   fi
@@ -355,7 +402,7 @@ RULES
   # `git add -A`. A silent failure here would report success while leaving the
   # artifacts unignored, which is the same shape as the manifest write failure
   # this module already refuses to swallow, so check it the same way.
-  {
+  gi_block=$(
     echo ""
     echo "# ai-coding-rules-scaffold:begin"
     echo "# Local install artifacts, never something to commit: the copy install.sh"
@@ -364,7 +411,13 @@ RULES
     echo "# behind. uninstall.sh removes this block."
     printf '%s' "$missing"
     echo "# ai-coding-rules-scaffold:end"
-  } 2>/dev/null >>"$gi"
+  )
+  # $( ) strips the trailing newline the last echo produced; put it back, so
+  # the file this writes is byte-for-byte what the old block redirection wrote.
+  if ! gi_err=$(_gitignore_append "${gi_block}${_GITIGNORE_NL}" "$gi"); then
+    _gitignore_write_failed "$gi_err"
+    return 0
+  fi
   # Verify rather than trust: confirm every rule is actually present now.
   while IFS= read -r rule; do
     [ -n "$rule" ] || continue

--- a/tests/cases/30-install-manifest.sh
+++ b/tests/cases/30-install-manifest.sh
@@ -334,14 +334,11 @@ rm -rf "$MF9"
 #       driver's floor counts PASS + SKIP), never a silent pass and never a red.
 #
 #       WHY IT IS NOT SUBSTITUTED. The root-proof trigger MF6 uses (a directory
-#       where a regular file is expected) reaches a DIFFERENT branch here: an
-#       unwritable .gitignore is refused up front, named, and summarised, but a
-#       .gitignore that is a directory passes install.sh's `-w` test for root,
-#       the block redirection then fails, and under `set -e` install.sh exits 1
-#       with no output at all (its stderr is already going to /dev/null).
-#       Asserting that would assert less, under messages these greps do not
-#       match, so root gets an honest skip and non-root still runs the real
-#       thing.
+#       where a regular file is expected) reaches a DIFFERENT branch here: this
+#       one is the mode bit, refused up front by name; the directory is the
+#       generic can-I-append branch. MF12 below covers that one on every
+#       machine, so what a skip here costs is this branch specifically, not the
+#       loud-failure behaviour as a whole.
 MFRO=$(mktemp -d)
 ( cd "$MFRO" && git init --quiet && git config user.email test@test.local && git config user.name "Scaffold Test" && echo '{"name":"x"}' >package.json \
   && printf 'node_modules/\n' >.gitignore ) >/dev/null 2>&1
@@ -394,6 +391,55 @@ else
   sed 's/^/      /' "$MFRO/.gitignore" 2>/dev/null; FAIL=$((FAIL + 1))
 fi
 rm -rf "$MFRO"
+
+# MF12. The same guarantee as MF10 for the case a mode bit cannot express, and
+#       the regression test for a real silent failure: `.gitignore` is a
+#       DIRECTORY. Reproduced as `git init; mkdir .gitignore; install.sh
+#       --shell` -> rc=1 and ZERO bytes on stdout AND stderr. No error line, no
+#       "INSTALL INCOMPLETE", nothing — a failed install with nothing to read,
+#       which is precisely the shape operational-rules.md's "No silent
+#       failures" forbids, and the worst one, since there is not even a wrong
+#       answer to argue with.
+#
+#       THE MECHANISM, confirmed under `bash -x`: the guard was
+#       `[ -f "$gi" ] && [ ! -w "$gi" ]`, and `-f` is FALSE for a directory, so
+#       the not-writable branch never fired. Execution reached the rule-block
+#       append, written as `{ ...; } 2>/dev/null >>"$gi"`. Opening a directory
+#       for append fails, the shell's own "Is a directory" went to the
+#       /dev/null the redirection had already installed, and because a failed
+#       redirection on a COMPOUND command is fatal under install.sh's `set -e`,
+#       the run died right there — before print_refused_writes_summary could
+#       report anything. The fix asks the question the stat tests could not:
+#       it TRIES the append and keeps the shell's diagnostic as the reason.
+#
+#       WHY IT RUNS EVERYWHERE. Unlike MF10 this needs no mode bit to hold, so
+#       there is no probe and no skip: uid 0 cannot append to a directory
+#       either. It is therefore the assertion that keeps a floor under this
+#       behaviour on the container this suite most often runs in.
+#
+#       WHAT IT ASSERTS. Not the exit code — a bare non-zero exit is exactly
+#       what the bug already produced. The output is the whole point: the
+#       error must name .gitignore, the end-of-run summary must carry it, and
+#       the run must never claim it updated the file.
+MFDIR=$(mktemp -d)
+( cd "$MFDIR" && git init --quiet && git config user.email test@test.local && git config user.name "Scaffold Test" && echo '{"name":"x"}' >package.json \
+  && mkdir .gitignore ) >/dev/null 2>&1
+# `|| dir_rc=$?` for the same reason MF10 uses it (issue #148): a bare subshell
+# exiting non-zero under `set -euo pipefail` would abort this whole case file.
+dir_rc=0
+( cd "$MFDIR" && "$SCAFFOLD_DIR/install.sh" --frontend --no-verify ) >"$HOOK_OUT" 2>&1 || dir_rc=$?
+if [ "$dir_rc" -ne 0 ] \
+   && [ -s "$HOOK_OUT" ] \
+   && grep -qF 'could not write .gitignore' "$HOOK_OUT" \
+   && grep -qF 'INSTALL INCOMPLETE: the ignore rules were not added' "$HOOK_OUT" \
+   && ! grep -qF 'updated:      .gitignore' "$HOOK_OUT"; then
+  echo "  ✓ a directory at .gitignore fails the install with a named reason, not in silence"
+  PASS=$((PASS + 1))
+else
+  echo "  ✗ a directory at .gitignore must exit non-zero AND say why (rc=$dir_rc, $(wc -c <"$HOOK_OUT") bytes of output)"
+  sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$MFDIR"
 
 rm -rf "$(dirname "$MFNEXT")"
 reset_repo

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -101,7 +101,7 @@ CASE_FLOORS=(
   "27-test-guard.sh:9"
   "28-check-patterns-scope.sh:26"
   "29-install-symlink-dirs.sh:4"
-  "30-install-manifest.sh:14"
+  "30-install-manifest.sh:15"
   "31-install-verify-offer.sh:5"
   "32-uninstall-report.sh:6"
   "33-harness-self-checks.sh:12"


### PR DESCRIPTION
Found while fixing MF10 during #161 and filed as known-but-unfixed there. This closes it.

## The bug

```
d=$(mktemp -d); cd "$d"; git init -q .; mkdir .gitignore
bash install.sh --shell
→ rc=1, 0 bytes on stdout AND stderr
```

A failed install with no error line, no `INSTALL INCOMPLETE` summary, nothing at all. `operational-rules.md` has a "No silent failures" rule; this is the scaffold breaking it in its own installer.

Note the exit code was already correct. **The missing output was the bug** — which is why the new test asserts on the message and not just on `rc`.

## Mechanism, confirmed with `bash -x` rather than assumed

In `install-manifest.sh`, `ensure_backup_gitignore`:

1. The `-L` symlink branch does not fire — a directory is not a symlink.
2. Guard 1, `[ -f "$gi" ] && [ ! -w "$gi" ]`: `-f` is false for a directory, so the friendly "not writable" branch never fires.
3. Guard 2, `[ ! -f "$gi" ] && [ ! -w "." ]`: the project root *is* writable, so it does not fire either.
4. Execution reaches `{ …; } 2>/dev/null >>"$gi"`. Opening a directory for append fails, the shell's own `Is a directory` goes into the `2>/dev/null` the redirection list already installed, and **a failed redirection on a compound command is fatal under `set -e`**. The run dies before the reporting path can say anything.

Isolated proof of step 4:

```
bash -c 'set -euo pipefail; { echo hi; } 2>/dev/null >>d; echo after'
→ rc=1, no output, "after" never printed
```

## The fix

The guards asked "is this a regular file I can write". The right question is **"can I append to this"**, which is answered by trying, not by stat-ing.

A new `_gitignore_append` is now the only thing that appends to `.gitignore`. It writes through a **simple** command, so its exit status is reliable and `set -e` cannot kill the run mid-way, and it *captures* the shell's diagnostic instead of discarding it:

```bash
if err=$( { printf '%s' "$text" >>"$path"; } 2>&1 ); then
```

Redirection order is load-bearing: `2>&1` points stderr at the command substitution **first**, then the inner `>>"$path"` moves only stdout to the file — so a failure to *open* the file still has somewhere to report itself. The trimmed message flows into the existing `_gitignore_write_failed` → `print_gitignore_failure_summary` → `exit 1` path, rather than inventing a second reporting style.

This covers the class, not the symptom: a directory, a read-only filesystem, an immutable file, a vanished parent — anything `-f`/`-w` cannot see. The stat-based checks are preserved and run first, so a plain read-only `.gitignore` still gets its friendly "not writable" message and an unwritable root still gets its own.

## Behaviour preserved

`.gitignore` output byte-compared old vs new for all three input shapes — no file, existing file, existing file with no trailing newline: **identical**. Normal install, idempotent re-run (zero further output, unchanged md5), and a repo with no `.gitignore` all still exit 0. Verified separately with `chattr +i` that an immutable file reports `could not write .gitignore (not writable)` plus the summary.

## Before / after

```
BEFORE:  rc=1   bytes=0       (nothing at all)
AFTER:   rc=1   bytes=3992
         error: could not write .gitignore (Is a directory).
         INSTALL INCOMPLETE: the ignore rules were not added to .gitignore.
           Reason: Is a directory
```

## Test

`MF12` in `tests/cases/30-install-manifest.sh` asserts non-zero exit **and** non-empty output **and** the error naming `.gitignore` **and** the `INSTALL INCOMPLETE` summary **and** the absence of a false `updated:      .gitignore`. Confirmed to go red against `git show HEAD:install-manifest.sh` with `rc=1, 0 bytes of output`, so it is a real regression test rather than a passing assertion.

Unlike MF10 it needs no permission probe and no skip — a directory is not permission-dependent, so it runs as uid 0 too. MF10's "why it is not substituted" comment claimed the directory case was an unavoidable silent exit; that comment is corrected and now points at MF12.

Suite: **535 passed, 0 failed, 15 skipped** (was 534). Floor for `30-install-manifest.sh` 14 → 15. `shellcheck -S info` and `bash -n` clean on both changed files, with no suppression directives added.

No `CHANGELOG.md` entry — no gate requires one, and you may want it worded with the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Hfii6p4mxHXAYb4cUQtbb

---
_Generated by [Claude Code](https://claude.ai/code/session_019Hfii6p4mxHXAYb4cUQtbb)_