### PR TITLE
Prune the shipped rules: 551 → 361 lines, and fix a shipped contradiction

### DIFF
--- a/.github/workflows/lint.yml.template
+++ b/.github/workflows/lint.yml.template
@@ -216,7 +216,7 @@ jobs:
         if: steps.detect.outputs.present == 'true'
         # Project-wide type-check, guarded: only runs when a tsconfig.json is
         # present AND TypeScript is installed — mirrors the pre-commit hook so
-        # the two layers stay in lockstep. coding-rules.md rule 9 mandates a
+        # the two layers stay in lockstep. coding-rules.md rule 7 mandates a
         # type-checker; this is where it runs server-side.
         run: |
           # NOTE: a type-check is inherently WHOLE-PROGRAM (types are interdependent),

--- a/AGENTS.md.template
+++ b/AGENTS.md.template
@@ -48,7 +48,7 @@ you do it, it goes in the plain-language change summary below, by name.
 change or run it against the base commit — a test written against code that
 already exists passes by construction and constrains nothing. If a new test
 legitimately passes on base (characterization before a refactor, coverage
-backfill), say so and why. See `coding-rules.md` rule 8.
+backfill), say so and why. See `coding-rules.md` rule 6.
 
 In a monorepo, run `pytest` from the directory holding the pytest config, not
 from the repo root. pytest reads exactly one ini-file and the rootdir one wins,
@@ -78,13 +78,13 @@ Give it unprompted, and give it even when the answer is "nothing destructive, no
 
 ## Operational rules
 
-See [`operational-rules.md`](./operational-rules.md) for process, collaboration, and judgment patterns extracted from real incidents — pre-flight checks before long jobs, smoke at the smallest scale that exercises the full path, "agent reports measurements / user calls done", scope discipline, and surfacing uncertainty rather than guessing. Not tool-enforceable; meant to be skimmed before non-trivial work.
+See [`operational-rules.md`](./operational-rules.md) for process, collaboration, and judgment patterns extracted from real incidents — pre-flight checks before long jobs, smoke at the smallest scale that exercises the full path, "agent reports measurements / user calls done", scope discipline, and capturing what you notice or defer instead of dropping it silently. Not tool-enforceable; meant to be skimmed before non-trivial work.
 
 ## Git discipline
 
 - **Never `--amend` a commit that has been pushed.** Amending public history forces everyone else to reset.
 - **Never `push --force` or `push --force-with-lease`** without explicit instruction for this specific push. On `main` / `master`, refuse even with instruction — ask first.
-- **Never `git commit --no-verify`.** The pre-commit hook is the enforcement layer; bypassing it defeats the whole scaffold. If the hook is wrong, fix the hook.
+- **Never `git commit --no-verify` to get past a check that is failing.** The pre-commit hook is the enforcement layer; bypassing it defeats the whole scaffold. If the hook is wrong, fix the hook. The one exception is a commit the hook is built to refuse and whose own message offers the bypass: deliberately removing forbidden-pattern config (an uninstall, or `uninstall.sh --drop-lang=<lang>`), or a confirmed false positive in the secret scan. Never assume it — take it only when the hook printed it, name it in your change summary, and mark the line `# scaffold-allow: <reason>` if it lives in a committed script (`shell.txt` blocks the flag otherwise).
 - **Never push unless asked.** Committing is local and reversible; pushing is not. Wait for explicit "push it" / "open a PR" before `git push`.
 - **Never `reset --hard`, `checkout .`, or `clean -fd`** on a dirty tree without confirming — those destroy uncommitted work silently.
 - **Make a restore point before risky multi-step work.** Tag a green point (`git tag pre-<name>`), never a dirty checkpoint commit: the pre-commit hook rejects those and `--no-verify` is not the way out. Editor rewind/checkpoint features don't cover shell-command changes.

--- a/RECOMMENDATIONS.md
+++ b/RECOMMENDATIONS.md
@@ -74,7 +74,7 @@ _Added 2026-06-11._
 
 **Adopt if:** `ty` reaches 1.0 stable (0.0.x beta as of mid-2026) **and** type errors are reaching CI more than ~1/week from agent sessions.
 
-**What it is.** `coding-rules.md` rule 9 wires `tsc --noEmit` into the pre-commit hook for TypeScript but defers Python type-checking (`pyright`/`mypy`) to CI because they're too slow for a hook. The Rust-based `ty` / `pyrefly` remove the speed objection (10–60× faster). When `ty` is stable, the hook can gain `ty check` behind the same guard as `tsc` — run only when the binary is on PATH and a config is present, silently skip otherwise, CI stays authoritative. Rule 8's `pyright`/`mypy` remain the conformance reference and stay unchanged. Docs-only until then — no change to any `check-*` script.
+**What it is.** `coding-rules.md` rule 7 wires `tsc --noEmit` into the pre-commit hook for TypeScript but defers Python type-checking (`pyright`/`mypy`) to CI because they're too slow for a hook. The Rust-based `ty` / `pyrefly` remove the speed objection (10–60× faster). When `ty` is stable, the hook can gain `ty check` behind the same guard as `tsc` — run only when the binary is on PATH and a config is present, silently skip otherwise, CI stays authoritative. Rule 6's `pyright`/`mypy` remain the conformance reference and stay unchanged. Docs-only until then — no change to any `check-*` script.
 
 ---
 

--- a/TECHNICAL.md
+++ b/TECHNICAL.md
@@ -595,6 +595,42 @@ the Conventional-Commits `commit-msg` hook. Edit a `*.template`, re-run the scri
 to refresh. Only the `*.template` files are tracked; the rendered copies are
 build artifacts.
 
+### Shell rules for the scaffold's own scripts
+
+Two rules that used to live in `operational-rules.md` are shell- and
+CI-specific and anchored to this repo's own scripts, so they belong here rather
+than in a file that installs into other people's projects.
+
+**A conditional must not be a shell function's last command under errexit.**
+Under `set -euo pipefail`, a trailing `[[ ... ]] && cmd` makes the function
+return 1 on the false path, and a failed command substitution in a bare
+assignment aborts the whole script. End helpers with an explicit if/fi so the
+negative path returns 0.
+_Anchor:_ a sid-guard tightening made a session-start hook abort on routine
+stray files; context loading silently stopped, and only independent
+verification caught it because the suite passed.
+
+**In cross-platform fallback chains, the noisy-failure variant goes last.**
+Order `A || B` so the variant that misbehaves on the wrong platform never runs
+first. Some commands "fail" by succeeding partially with garbage on stdout (GNU
+`stat -f` prints filesystem stats), which poisons the captured value even
+though the fallback also runs.
+_Anchor:_ a BSD-first stat chain made a required Linux CI job a coin flip; it
+passed for weeks by luck, then failed an unrelated PR.
+
+### End every session on this repo with a rules retrospective
+
+Before handoff, walk the session's incidents against the add-criteria in
+`operational-rules.md` and propose additions through this repo's issue flow; a
+lesson that lives only in a transcript or a repo-local issue is lost to every
+other project. This is a contributor practice for the scaffold itself, which is
+why it is not in `operational-rules.md`: that file ships into other people's
+repositories, where an instruction to file issues against this tracker does not
+belong.
+_Anchor:_ an orchestration session filed its lessons as a repo-local issue
+only; the owner had to ask explicitly before the generalizable rules were
+proposed to the global file every session actually loads.
+
 ### Why `scaffold-doctor.sh` reports 2 guardrails "installed but NOT running"
 
 This is expected and deliberate. Read this before "fixing" it.

--- a/claude-skill/coding-rules/SKILL.md.template
+++ b/claude-skill/coding-rules/SKILL.md.template
@@ -10,8 +10,8 @@ issue #118). Two files at the project root carry the actual rules:
 
 - `coding-rules.md`, code-level rules: forbidden patterns, style, security.
 - `operational-rules.md`, process and collaboration rules: pre-flight checks
-  before long jobs, commit discipline, scope discipline, surfacing
-  uncertainty instead of guessing.
+  before long jobs, commit discipline, scope discipline, and capturing what
+  you notice or defer instead of dropping it silently.
 
 When this Skill triggers, read both files in full before writing or editing
 code, before a commit, or before answering a question about this project's

--- a/coding-rules.md
+++ b/coding-rules.md
@@ -10,21 +10,19 @@ Short rule set. Most discipline is enforced by the linter (`ruff` / `eslint`) an
 
 2. **No copy-paste logic** — import existing helpers. Duplication invites drift.
 3. **Before creating a new file, check for extension candidates.** Search the codebase for existing modules that could absorb the new logic. When you do create, state in the commit or PR body what you considered and why it couldn't extend.
-4. **FastAPI endpoints return Pydantic response models**, not raw dicts. Applies if the project uses FastAPI.
-5. **SQLAlchemy 2.0 style only** (`Mapped[]`, `mapped_column()`). No `declarative_base` or pre-2.0 patterns. Applies if the project uses SQLAlchemy.
-6. **`asyncio.to_thread()` for blocking I/O** in async paths — under the GIL a CPU-bound function moved to a thread still stalls the event loop (the CPython `asyncio.to_thread` docs call this out), so CPU-bound work belongs in a process pool (`loop.run_in_executor` with a `ProcessPoolExecutor`); free-threaded 3.13t+/3.14 builds are the exception. Never block the event loop. `ruff`'s `ASYNC2xx` rules fail the build when a blocking HTTP / file / subprocess call is detected inside an `async def`, so this is now tool-enforced on the Python side (not just advice). _(TypeScript)_ Never leave a promise floating — `await` it or handle it explicitly. `eslint`'s `no-floating-promises` / `no-misused-promises` fail the build on the most common silent-async bug; they need type-aware linting (a `tsconfig.json`), which the shipped `eslint.config.js` enables by default.
+4. **`asyncio.to_thread()` for blocking I/O** in async paths — never block the event loop. Under the GIL a CPU-bound function moved to a thread still stalls the loop (the CPython `asyncio.to_thread` docs call this out), so CPU-bound work belongs in a process pool (`loop.run_in_executor` with a `ProcessPoolExecutor`); free-threaded 3.13t+/3.14 builds are the exception. _(TypeScript)_ Never leave a promise floating — `await` it or handle it explicitly.
 
 ## Pattern files
 
-Stack-specific deny patterns live in `.forbidden-patterns/*.txt` (one per language — `backend.txt`, `frontend.txt`, `php.txt`, `go.txt`, `rust.txt`, `java.txt`, `kotlin.txt`, `ruby.txt`, `shell.txt` — plus the language-agnostic `secrets.txt`). Add deprecated import paths, old service names, banned API keys, etc. — the hook scans them on every commit and so does CI. Format is `<regex><TAB><description>` per line; each file declares the extensions it scans with a `# scaffold-extensions:` header, so adding a language is just dropping a file. See `forbidden-patterns/README.md` for the full reference.
+Stack-specific deny patterns live in `.forbidden-patterns/*.txt` — one per language, plus the language-agnostic `secrets.txt`. Add deprecated import paths, old service names, banned API keys, etc.; the hook scans them on every commit and so does CI. Format is `<regex><TAB><description>` per line; each file declares the extensions it scans with a `# scaffold-extensions:` header, so adding a language is just dropping a file. See `forbidden-patterns/README.md` in the scaffold repo for the full reference.
 
 ## Communication
 
-7. **Cite `file:line` when flagging an issue.** "The config is wrong" is vague; "`config.py:43` is wrong because…" is actionable. Applies to code review, bug reports, memory entries, and mid-task observations.
+5. **Cite `file:line` when flagging an issue.** "The config is wrong" is vague; "`config.py:43` is wrong because…" is actionable. Applies to code review, bug reports, memory entries, and mid-task observations.
 
 ## Testing
 
-8. **Four-category baseline**, picked per stack. Every project ships with all four:
+6. **Four-category baseline**, picked per stack. Every project ships with all four:
    - **Linter/formatter** — catches sloppy edits before commit
    - **Type-checker** — catches contract drift before runtime
    - **Test runner** — unit + integration tests
@@ -32,34 +30,37 @@ Stack-specific deny patterns live in `.forbidden-patterns/*.txt` (one per langua
 
    Defaults: Python — `ruff`, `pyright`/`mypy`, `pytest`, `hypothesis`. TypeScript — `eslint`+`prettier`, `tsc`, `vitest`/`jest`, `fast-check`. New stacks pick equivalents and document the choice in the project's `AGENTS.md`.
 
-   **A test you have never watched fail is not evidence.** Write it before the change, or run it against the base commit yourself — a test written against code that already exists passes by construction and constrains nothing. A new test that legitimately passes on base (characterization before a refactor, coverage backfill) must say so and why. Never delete a test in the same change as the code it covered; deleting, skipping, or loosening a test to turn a build green is not a fix — see "Fix the file, not the guardrail" in `operational-rules.md`. `install.sh --test-guard` adds the red-green half of this as an opt-in CI gate.
+   **A test you have never watched fail is not evidence.** Write it before the change, or run it against the base commit — a test written against code that already exists passes by construction; a new test that legitimately passes on base (characterization before a refactor, coverage backfill) must say so and why. Never delete a test in the same change as the code it covered, and never delete, skip, or loosen a test to turn a build green — see `AGENTS.md` > "Checks" and "Fix the file, not the guardrail" in `operational-rules.md`. `install.sh --test-guard` adds the red-green half of this as an opt-in CI gate.
 
-9. **Don't skip the pre-commit hook (`--no-verify`) unless explicitly asked.** It runs the size/pattern/secret guards plus the linter (`ruff` / `eslint`), and — for TypeScript — `tsc --noEmit` whenever a `tsconfig.json` is present. Wire the rest of your type-checker (`pyright` / `mypy`) into CI per the project's `AGENTS.md`; the type-aware `eslint` config and `tsc` cover the TypeScript side at commit time and in CI.
+7. **The pre-commit hook is the gate.** It runs the size/pattern/secret guards plus the linter (`ruff` / `eslint`), and — for TypeScript — `tsc --noEmit` whenever a `tsconfig.json` is present. Wire the rest of your type-checker (`pyright` / `mypy`) into CI per the project's `AGENTS.md`. For when skipping the hook (`--no-verify`) is and is not legitimate, `AGENTS.md` > "Git discipline" is the single authority.
 
 ## Observability
 
-10. **Structured logging library**, picked per stack. Output JSON, not plain text — downstream tools (alerting, dashboards, log search) all depend on parseable structure. Defaults: Python — `structlog`. TypeScript — `pino` or `winston`. New stacks pick equivalents. On Python, `ruff`'s `G`/`LOG` rules fail the build on f-string/`%`/`.format()` formatting inside a log call (it defeats deferred/structured rendering) — pass fields as arguments. The idiomatic structured form `logger.info("event_name", key=val)` is not flagged.
+8. **Structured logging library**, picked per stack. Output JSON, not plain text — downstream tools (alerting, dashboards, log search) all depend on parseable structure, so pass fields as arguments rather than formatting them into the message string. Defaults: Python — `structlog`. TypeScript — `pino` or `winston`. New stacks pick equivalents.
 
-11. **Event names are `snake_case_verbs`**, not prose. Example: `request_received`, `cog_written`, `gpu_lock_acquired`. They must be filterable strings — log handlers, alerting rules, and grep all depend on stable identifiers. Prose like "the request came in fine" is not a log event name.
+9. **Event names are `snake_case_verbs`**, not prose. Example: `request_received`, `cog_written`, `gpu_lock_acquired`. They must be filterable strings — log handlers, alerting rules, and grep all depend on stable identifiers. Prose like "the request came in fine" is not a log event name.
 
-12. **Bind a request correlation ID to log context** when running multiple services. Prefer the W3C `traceparent` header — it's the cross-service standard and OpenTelemetry SDK middleware propagates it for you; `X-Request-Id` is an acceptable lighter-weight fallback. Either way: echo incoming, generate if missing, bind to log context. Every log line emitted during the request carries the same ID, so a single grep finds the full cross-service trace.
+10. **Bind a request correlation ID to log context** when running multiple services. Prefer the W3C `traceparent` header (`X-Request-Id` is an acceptable lighter-weight fallback). Either way: echo incoming, generate if missing, bind to log context — every log line in the request then carries the same ID, so a single grep finds the full cross-service trace.
 
 ## Versioning
 
-13. **Stable-additive only.** Adding new fields, files, endpoints, or columns is free and doesn't require coordination. Renaming, removing, or changing the type of existing fields requires: (a) a schema-version bump, (b) explicit notice to consumers before the change ships, (c) a deprecation window when feasible. Silent breaking changes are the most expensive kind because they fail downstream, far from the cause.
+11. **Stable-additive only.** Adding new fields, files, endpoints, or columns is free and doesn't require coordination. Renaming, removing, or changing the type of existing fields requires: (a) a schema-version bump, (b) explicit notice to consumers before the change ships, (c) a deprecation window when feasible. Silent breaking changes are the most expensive kind because they fail downstream, far from the cause.
 
 ## Dependencies
 
-14. **Before adding an external package, verify it is the package you think it is.** Rule 3's instinct, one layer out: prefer a library the project already depends on, then the standard library, and only then something new. When a new dependency is genuinely needed, check it on the registry _before_ the name reaches a manifest or a lockfile. Does the name resolve at all? Is it the well-known project you had in mind, rather than a near-miss spelling, a scoped look-alike, or a same-named package published last month? Does it have a version history and download history consistent with the project you meant? Does its listed source repository exist and match? AI tools invent plausible-but-nonexistent package names at measurable rates, and attackers pre-register the invented names to catch the install ("slopsquatting"), so a package that installs cleanly is not evidence that it is real. State in the commit or PR body which package you chose and what you checked. Dependency scanners (`dependency-review`, advisory databases) match known-bad packages; a freshly registered plausible name is by construction not in them yet.
+12. **Before adding an external package, verify it is the package you think it is.** Rule 3's instinct, one layer out: prefer a library the project already depends on, then the standard library, and only then something new. When a new dependency is genuinely needed, check it on the registry _before_ the name reaches a manifest or a lockfile. Does the name resolve at all? Is it the well-known project you had in mind, rather than a near-miss spelling, a scoped look-alike, or a same-named package published last month? Do its version history, download history, and listed source repository match the project you meant? AI tools invent plausible-but-nonexistent package names, and attackers pre-register the invented names to catch the install ("slopsquatting"), so a package that installs cleanly is not evidence that it is real — dependency scanners match known-bad packages, and a freshly registered plausible name is by construction not in them yet. State in the commit or PR body which package you chose and what you checked.
 
 ## Git
 
-See `AGENTS.md` for commit format and Git discipline (no amend, no force-push, no push unless asked).
+See `AGENTS.md` for commit format and Git discipline (no amend, no force-push, no push unless asked, no hook bypass).
 
 ## What the tooling enforces
 
-See [TECHNICAL.md > "What the tooling enforces"](https://github.com/Sting25/ai-coding-rules-scaffold/blob/main/TECHNICAL.md#what-the-tooling-enforces) for the full matrix of build-breaking (`ruff` / `eslint`) and commit-breaking (pre-commit hook + CI) checks. This file ships into every installed project, where a relative link would resolve against the consumer's own README instead, so the link above is absolute on purpose. Single source of truth: this doc stays focused on the human-readable rules above.
+See [TECHNICAL.md > "What the tooling enforces"](https://github.com/Sting25/ai-coding-rules-scaffold/blob/main/TECHNICAL.md#what-the-tooling-enforces) for the full matrix of build-breaking (`ruff` / `eslint`) and commit-breaking (pre-commit hook + CI) checks. Single source of truth: this doc stays focused on the human-readable rules above.
 
 ## Project-specific additions
 
-Each project adds its own tech-specific rules in `coding-rules.md` under a "Project-specific" section (library quirks, import-path conventions, architectural constraints). This scaffold file stays universal.
+Each project adds its own tech-specific rules here, under a "Project-specific" heading (library quirks, import-path conventions, architectural constraints). This scaffold file stays universal. The two below are worked examples of the shape — keep the ones your stack uses, delete the rest:
+
+- **FastAPI endpoints return Pydantic response models**, not raw dicts. Applies if the project uses FastAPI.
+- **SQLAlchemy 2.0 style only** (`Mapped[]`, `mapped_column()`). No `declarative_base` or pre-2.0 patterns. Applies if the project uses SQLAlchemy.

--- a/install-optin.sh
+++ b/install-optin.sh
@@ -137,7 +137,7 @@ ensure_test_guard_rules_section() {
 # ever executing), the bug this closes. Three end states, decided in order:
 # (1) --no-test-workflow installs NEITHER workflow, the one way a repo ends
 # up with no test execution in CI, and it must say so loudly per
-# operational-rules.md's "record every skip" (unless a workflow from a prior
+# operational-rules.md's "capture what you notice and what you defer" (unless a workflow from a prior
 # run is already on disk, which keeps running either way); (2) --coverage-gate
 # (or coverage.yml already on disk) installs coverage.yml, which already runs
 # the tests AND gates patch coverage of changed lines, not assertion quality,

--- a/install.sh
+++ b/install.sh
@@ -31,7 +31,7 @@
 # so pytest/vitest run on every PR/push, no coverage threshold. `--coverage-gate` swaps that for
 # `.github/workflows/coverage.yml` (same tests, plus a diff-cover patch-coverage gate), never both
 # installed at once. Only `--no-test-workflow` leaves a repo with no test execution in CI, and it
-# says so loudly in the summary below, per the "record every skip" rule.
+# says so loudly in the summary below, per the "capture what you notice and what you defer" rule.
 #
 # On re-run (upgrade): scaffold-owned code (the hook, .githooks/lib/*, the
 # commit-msg hook) is REFRESHED when it differs from the shipped version, so

--- a/operational-rules.md
+++ b/operational-rules.md
@@ -29,16 +29,6 @@ new failure mode.
 
 ## Engineering
 
-### Pass structured types, not primitive tuples, across boundaries
-
-The structured value is what crosses the wire. Tests should both
-`assert isinstance(...)` AND touch named attributes — a duck-typed
-stand-in with wrong fields fails the second check. Type annotations
-alone don't enforce structure; they only document intent.
-_Anchor:_ orchestrator returned a 4-tuple where worker expected a
-typed dataclass; the type annotation lied and the bug surfaced only
-after compute had been spent.
-
 ### Read schema constraints before composing writes
 
 Enum-style columns and check constraints have allowed-value lists
@@ -50,23 +40,11 @@ _Anchor:_ every per-record INSERT failed because the agent passed a
 descriptive string when the schema required a specific enum value
 defined elsewhere in the codebase.
 
-### Use the canonical helper; bench code is bench-only
-
-Before writing math, format, or utility helpers, grep production for
-existing implementations. Bench scripts and exploratory notebooks
-shortcut things that production must do correctly. AI tools will
-happily reach for bench-style patterns when generating production
-code if you don't redirect.
-_Anchor:_ a driver inherited bench-style coordinate math when a
-canonical helper already existed in production code; the bench
-version had edge-case bugs the canonical version had already fixed.
-
 ### Plan storage shape before scaling compute
 
 For any per-unit output (tile, record, document, embedding), multiply
 size by realistic scale before committing to a format. Tiered
-retention designed in from day 1, not retrofitted. Storage cost
-surprises kill more personal projects than any other failure mode.
+retention designed in from day 1, not retrofitted.
 _Anchor:_ per-unit output measured at multiple GB; full-scale
 projection ran into petabytes. Format and tiering decisions had to
 be redone after significant ingestion was already complete.
@@ -84,13 +62,17 @@ same synchronous I/O the worker was performing.
 ### Validate inputs at component boundaries
 
 Each component in a federated or distributed system should validate
-its inputs at the boundary, not assume the upstream component
-honored the contract. AI-generated code often skips boundary
-validation because it trusts the type system or the upstream
-implementation it just wrote.
-_Anchor:_ a downstream component crashed on malformed input that an
-upstream component should have rejected; both components were
-AI-generated and neither validated the contract between them.
+its inputs at the boundary, not assume the upstream component honored
+the contract. AI-generated code often skips boundary validation
+because it trusts the type system or the upstream implementation it
+just wrote. Type annotations document structure, they don't enforce
+it: tests should both `assert isinstance(...)` AND touch named
+attributes — a duck-typed stand-in with wrong fields fails only the
+second check.
+_Anchor:_ a downstream component crashed on malformed input an
+upstream component should have rejected; separately, an orchestrator
+returned a 4-tuple where the worker expected a typed dataclass and the
+annotation lied. Neither side validated the contract between them.
 
 ### Integration tests hit a real database, not mocks
 
@@ -98,76 +80,43 @@ Mocked tests pass against the mock's behavior, not against the
 database's actual behavior. Schema constraints, migration drift,
 and dialect quirks only surface against a real instance. Spin up
 an ephemeral DB per test run if isolation matters — but don't
-substitute a mock object for the connection.
+substitute a mock object for the connection. Run the full pre-prod
+check in a throwaway environment built from the same provisioning
+script as production, not on a standing QA box that drifts from it.
 _Anchor:_ mocked tests passed for months while the production
 migration silently broke; the divergence was invisible until a
 deploy hit the real schema.
 
-### Ephemeral environments replace a standing QA server
-
-Always test against a real database, never synthetic-only fixtures for
-anything load-bearing, and always do that testing inside a throwaway
-environment (a spun-up container, VM, or short-lived cloud host) rather
-than a persistent QA server. Stand it up, run the full pre-prod check,
-tear it down. A persistent QA server drifts from production configuration
-over time and becomes a second thing to maintain; an ephemeral one is
-defined by the same provisioning script that builds production, so it
-cannot drift.
-_Anchor:_ a search-index rework needed Linux-only measurements (systemd
-unit verification, anonymous-memory RSS) that a macOS dev machine could
-never produce; the fix was a disposable host built from the same
-provisioning script as production, checked and destroyed, not a
-standing QA box.
-
-### Tests cover every code path; back claims with measurement
-
-"We have tests" is not the same as "this is tested." Every branch,
-every error path, every contract assertion needs an explicit test.
-When claiming correctness or performance, back the claim with a
-number from a real run against a real system — not a narrative
-about what the code "should" do.
-_Anchor:_ untested code paths routinely shipped with undiscovered
-bugs that surfaced as production incidents months after merge,
-because "looks right" beat "measured to work."
-
 ### No silent failures
 
-When a unit of work fails — a request, a record, a cell, a job —
-log a WARN-or-higher event with the failure reason AND surface the
-failure in the response payload (e.g. via a `partial` status,
-explicit error field, or non-success HTTP code). Catching an
-exception and returning a "success" response without signaling
-the failure is the most expensive habit in production code;
-downstream consumers act on stale or wrong data, and the problem
-only surfaces hours later as a derived failure that's harder to
-trace back.
+When a unit of work fails — a request, a record, a cell, a job — log
+a WARN-or-higher event with the failure reason AND surface the failure
+in the response payload (a `partial` status, an explicit error field,
+a non-success HTTP code). Catching an exception and returning a
+"success" response without signaling the failure leaves downstream
+consumers acting on stale or wrong data, and surfaces hours later as
+a derived failure that is harder to trace back.
 _Anchor:_ a batch job swallowed per-record errors and reported
 "complete"; downstream pipelines built on the missing-rows-without-error
 state spent days untangling the resulting derived corruption.
 
 ### Fix the file, not the guardrail — don't weaken a check to pass
 
-When a check goes red — a secret/pattern/size/hygiene scan, a lint
-or type error, a failing test — the default is to fix the offending
-FILE, not to weaken the check. Suppressions (`scaffold-allow`, a
-`.scaffold.toml` disable/downgrade, a loosened pattern, a skip-list
-entry, `--no-verify`) are a last resort: only for a genuine false
-positive AND only when fixing the file truly isn't possible, and
-then narrowly and with a recorded reason. A check weakened to turn
-green silently lowers the bar for every later commit and every
-consumer that inherits it — catching the thing was the point. If the
-check itself is wrong, fix the check and add a test; don't bypass it.
-When you do take one, name it in the summary you give the person you
-are working for: which check, which file, which marker or config
-entry, and why. A one-line suppression is invisible to anyone not
-reading the diff, and the person deciding whether it was justified
-is usually not reading the diff.
-Deleting is weakening: removing a test file, a test case, or the CI
-workflow that runs them stops the check existing at all, and does it
-quietly — nothing goes red, the diff reads as cleanup. Never delete a
-test in the same change as the code it covered. Name the test, why it
-no longer applies, and where the coverage went; "removed outdated
-tests" is not a justification, it is the sentence that hides one.
+When a check goes red — a secret/pattern/size/hygiene scan, a lint or
+type error, a failing test — fix the offending FILE. Suppressions
+(`scaffold-allow`, a `.scaffold.toml` disable/downgrade, a loosened
+pattern, a skip-list entry, `--no-verify`) are a last resort: only for
+a genuine false positive, only when fixing the file truly isn't
+possible, and then narrowly, with a recorded reason, and named in the
+summary you give the person you are working for — which check, which
+file, which marker or config entry, and why. If the check itself is
+wrong, fix the check and add a test; don't bypass it. Deleting is
+weakening: removing a test file, a test case, or the CI workflow that
+runs them stops the check existing at all, and does it quietly —
+nothing goes red. Never delete a test in the same change as the code
+it covered; name the test, why it no longer applies, and where the
+coverage went. "Removed outdated tests" is not a justification, it is
+the sentence that hides one.
 _Anchor:_ a guardrail flagged a file; exempting it was one line and
 fixing it a few — but an exemption, unlike a fix, never expires, so
 suppressions accrete until the scanner no longer scans.
@@ -185,50 +134,15 @@ _Anchor:_ per-CUDA-call GPU lock acquisition caused worker thrash
 and out-of-memory failures because no single worker ever held the
 lock long enough to complete a contiguous compute unit.
 
-### Choose the strongest approach before starting, not the fastest one to finish
-
-Decide between the correct/robust approach and the quick one BEFORE
-writing the fix, not after. By the time work is done and under review,
-the fast path is already built and sunk cost pushes toward keeping it;
-the decision has to happen at the fork, not as a postmortem question.
-When speed or simplicity is the only reason to prefer one path over
-another, treat that as a reason to slow down and pick the stronger one,
-not a green light to proceed.
-_Anchor:_ restated explicitly and independently across multiple
-sessions as a standing directive, not tied to one incident: the fast
-path (first approach tried, workaround over root cause, suppression
-over fix) keeps winning by default unless it's weighed against a
-stronger alternative before work begins, since after the fact only a
-redo can fix a fast-but-wrong choice already shipped.
-
 ### Never print, cat, or echo secret files
 
-`.env` files, `credentials.json`, key files, OAuth tokens — never
-`cat`, `print`, `echo`, or log them. AI agents have a particular
-habit of running `cat .env` during debugging "to check something";
-the values then live in chat transcripts, log files, or git
-diffs forever and require rotation. To verify a value exists or
-matches an expected shape: check length, compare against a known
-hash, or count non-empty lines. The cheapest path is never to
-expose the secret in the first place.
-_Anchor:_ AI-agent-driven `cat .env` to "verify the file is
-loaded" landed credentials into a permanent chat transcript;
-rotation across multiple services took hours.
-
-### Create a restore point before risky work
-
-Before a sweeping or multi-step change, tag or branch a
-known-good point and name it out loud. Confirming a destructive
-command is not the same as being able to get back: the
-confirmation happens once, the restore point survives the
-mistake. Tag a green point rather than committing whatever is
-on disk, which the commit gate will reject. An editor's rewind
-feature is not the restore point either; those track edits made
-through the tool's own file editing, so whatever a shell
-command moved or deleted is outside them.
-_Anchor:_ an agent told to tidy up branch history ran a hard
-reset and destroyed a day of work; nothing had been tagged, and
-the tool's rewind had never seen the files.
+Never `cat`, `print`, `echo`, or log `.env`, `credentials.json`, key
+files, or tokens — verify by length, hash, or line count instead;
+pattern scanning backs this up only for credential shapes on paths it
+already knows.
+_Anchor:_ AI-agent-driven `cat .env` to "verify the file is loaded"
+landed credentials into a permanent chat transcript; rotation across
+multiple services took hours.
 
 ### Back up and confirm before destructive work on live data
 
@@ -237,24 +151,17 @@ migration, or a wipe of a bucket, document collection, or search
 index — a "reset the data and start clean" counts — against
 anything but a local throwaway store is a two-step action: confirm
 a current backup exists, then get an explicit yes that names the
-target and what will be lost. Automatic backups are the cheap
-half; the confirmation is the half that catches the wrong
-connection string. Quote the blast radius in the store's own units
-— table rows, bucket objects, collection documents — not as a
-pasted command.
-_Anchor:_ an agent ran a destructive operation against a
-production database it believed was a test instance and emptied
-it in seconds; there was no staging tier and no recent backup.
-
-### A conditional must not be a shell function's last command under errexit
-
-Under `set -euo pipefail`, a trailing `[[ ... ]] && cmd` makes the
-function return 1 on the false path, and a failed command substitution
-in a bare assignment aborts the whole script. End helpers with an
-explicit if/fi so the negative path returns 0.
-_Anchor:_ a sid-guard tightening made a session-start hook abort on
-routine stray files; context loading silently stopped, and only
-independent verification caught it because the suite passed.
+target and what will be lost. Quote the blast radius in the store's
+own units — table rows, bucket objects, collection documents — not
+as a pasted command. Before any sweeping or multi-step change, tag
+a known-good point and name it out loud, rather than committing
+whatever is on disk, which the commit gate will reject; an editor's
+rewind is not the restore point either, since it never sees what a
+shell command moved or deleted.
+_Anchor:_ an agent ran a destructive operation against a production
+database it believed was a test instance and emptied it in seconds;
+there was no staging tier and no recent backup. Another, told to tidy
+up branch history, hard-reset away a day of untagged work.
 
 ### Assert the positive outcome, not the absence of the symptom
 
@@ -266,29 +173,22 @@ _Anchor:_ a hook-killing crash sailed through a 1400-assertion suite
 because the new regression test asserted only that a warning string
 was absent; the crash made it absent too.
 
-### In cross-platform fallback chains, the noisy-failure variant goes last
-
-Order `A || B` so the variant that misbehaves on the wrong platform
-never runs first. Some commands "fail" by succeeding partially with
-garbage on stdout (GNU `stat -f` prints filesystem stats), which
-poisons the captured value even though the fallback also runs.
-_Anchor:_ a BSD-first stat chain made a required Linux CI job a coin
-flip; it passed for weeks by luck, then failed an unrelated PR.
-
 ---
 
 ## Process
 
-### One canonical decisions file; archive everything else
+### One durable home per kind of state
 
-All locked decisions live in a single file (`CURRENT.md`,
-`DECISIONS.md`, or similar). Old files move to `_archive/`. New
-decisions update the canonical file, not new files. AI agents take
-shortcuts when reading everything isn't tractable, so the canonical
-file must be loadable into context.
-_Anchor:_ project accumulated dozens of decision documents and
-memory entries; agent began making decisions inconsistent with
-locked ones because it couldn't read everything in a single pass.
+Open work (tasks, bugs, follow-ups) lives in one place and locked
+decisions in another; everything else holds pointers to them, never a
+second live list. Prune items when they close, resurface every open
+one at session start however old, and keep the state an agent must
+obey small enough to load in a single pass — an agent that cannot read
+all of it takes shortcuts and decides against what is already locked.
+_Anchor:_ a project accumulated dozens of decision documents and kept
+work state in three places; the agent made decisions inconsistent with
+locked ones, finished items were never pruned, open ones were never
+resurfaced, and a session scratchpad became a third divergent copy.
 
 ### Pre-flight catches beat mid-run discovery
 
@@ -310,32 +210,20 @@ _Anchor:_ a 4-unit smoke caught contention between workers; a
 1-unit smoke proved the fix. Both were necessary. A test that
 skipped any component would have failed to catch the bug.
 
-### Commit each fix immediately; don't batch
-
-Each logical fix is its own commit. Group only when tightly coupled
-(a fix plus the test that prevents its regression). AI tools love
-to batch fixes into larger diffs because each individual change
-feels small and the cumulative work feels productive.
-_Anchor:_ mixed commits become unrevertable when one fix turns out
-to be wrong; pre-commit failures force re-stage cycles when many
-unrelated changes are batched together.
-
-### Commit atomically without waiting for per-commit approval
+### Commit each passing unit of work atomically, without waiting for approval
 
 This overrides the generic "never commit unless explicitly asked"
-default some tools ship with. On a feature branch or worktree, once
-a logical unit of work passes its own gate (tests, lint, the checks
-this repo already runs), commit it immediately and move on. Do not
-pause mid-task to ask permission for each individual commit; that
-default exists to stop unwanted proactive commits, not to add a
-confirmation step to work the user already asked for. Pushing,
-merging into a protected branch, and force-pushing still need their
-own explicit approval every time; committing locally on a branch
-already in scope does not.
-_Anchor:_ mid-session, an agent kept asking before each commit on a
-branch the user had already scoped and approved the work for; the
-user had to explicitly say "always do atomic commits, do not wait
-for me" to stop the interruptions.
+default some tools ship with. On a feature branch or worktree, once a
+logical unit of work passes its own gate (tests, lint, the checks the
+repo already runs), commit it and move on — one commit per logical
+change, grouped only when tightly coupled (a fix plus the test that
+prevents its regression). Do not pause mid-task to ask permission for
+each commit. Pushing, merging into a protected branch, and
+force-pushing still need their own explicit approval every time.
+_Anchor:_ mixed commits become unrevertable when one fix turns out to
+be wrong; separately, an agent kept asking before each commit on a
+branch the user had already scoped and approved the work for, until
+told "always do atomic commits, do not wait for me".
 
 ### Locked decisions are revisitable on new evidence
 
@@ -349,29 +237,22 @@ noise, and warranted explicit revisit rather than silent override.
 
 ### Write down why, not just what
 
-Code comments and decision documents should explain why a choice
-was made, not just what the code does. AI tools regenerate "what"
-on demand from any "why." Without "why," future sessions can't
+Code comments and decision documents should explain why a choice was
+made, not just what the code does. AI tools regenerate "what" on
+demand from any "why"; without the why, future sessions can't
 distinguish load-bearing decisions from incidental ones.
 _Anchor:_ a refactor session removed a workaround whose reason had
-never been written down; the original bug returned weeks later
-and required rediscovery from scratch.
+never been written down; the original bug returned weeks later.
 
 ### Version bumps travel only in release commits
 
 A feature PR that bumps the version strands the mainline on an
 unreleased number the moment it merges, and consumers that track the
-branch install untagged builds. Bump, changelog heading, tag, and
-release move together in a dedicated release change. The trigger is
-narrow: a staged edit to the project's own top-level `version` in
-`package.json`, `pyproject.toml`, `Cargo.toml` or an equivalent
-packaging manifest — never a dependency's pinned `version`, which is
-an ordinary bump. If the project uses Conventional Commits, that edit
-belongs only in a commit subject spelled `chore(release): vX.Y.Z` —
-not `release:`, not `build(release):`.
+branch install untagged builds. For a published package, the bump,
+changelog heading, tag, and release move together in a dedicated
+release change; a dependency's pinned version is an ordinary bump.
 _Anchor:_ a feature merge bumped to 0.18.0 while the latest tag was
-v0.17.0; marketplace installs tracked main and picked up an unreleased
-version, and an earlier install matched no released version at all.
+v0.17.0; installs tracking the branch picked up an unreleased version.
 
 ### A check that can pass by luck is failing
 
@@ -383,18 +264,6 @@ _Anchor:_ a flaky assertion passed one PR's required CI job and failed
 the next identical run minutes later; the two-line fix existed only
 because the failure was investigated instead of rerun.
 
-### Track work in at most two places
-
-The issue tracker is the single home for open work items (tasks, bugs,
-follow-ups); memory and docs hold pointers to it, never a second live
-list of what's outstanding. This is distinct from the canonical-
-decisions-file rule above (that one governs locked decisions, not open
-work): prune finished items when they close, and resurface every open
-item at session start, however old.
-_Anchor:_ a project kept work state in three places; finished issues
-were never pruned, open issues were never resurfaced, and a session
-scratchpad list silently became a third divergent copy.
-
 ---
 
 ## Collaboration
@@ -403,10 +272,7 @@ scratchpad list silently became a third divergent copy.
 
 Concrete numbers (test counts, throughput, byte sizes, gate pass
 rates, latency) come from the agent. Verdicts ("fixed", "done",
-"verified", "working") come from the user. AI tools tend to declare
-victory based on surface pattern matching rather than verified
-behavior; reserving the verdict for the human prevents premature
-"fixed" claims.
+"verified", "working") come from the user.
 
 ### Close every handoff with a plain-language summary
 
@@ -414,12 +280,8 @@ The artifact that makes the rule above usable. Before handing back a
 commit, a PR, or the session itself, state in plain language what
 changed and why, anything destructive or hard to reverse, every check
 you turned down by name, and what the user should verify before calling
-it done. That summary is the decision surface for anyone who does not
-read diffs; it feeds the verdict, it never delivers it.
-_Anchor:_ every enforced output of an AI-assisted change (the diff, the
-failing check, the CI log) assumes a reader who reads code; where the
-accountable human did not, a downgraded guardrail shipped with nothing
-but the diff recording it.
+it done. See `AGENTS.md`, "Plain-language change summary", for the full
+form; it feeds the verdict, it never delivers it.
 
 ### Plans default to PROPOSED; mark every assumption
 
@@ -444,91 +306,39 @@ expansion as a separate question. Scope creep within a single
 change is one of the most common ways AI-assisted edits introduce
 unintended regressions.
 
-### Capture pre-existing issues; never silently drop them
+### Capture what you notice and what you defer; never drop it silently
 
-The complement to scope discipline: "out of scope" means don't
-silently EXPAND the change — it does NOT mean pretend you didn't
-see it. A pre-existing bug, drift, lint finding, or stale doc
-noticed while doing something else MUST land somewhere durable —
-a tracked fix-list, an issue, a flagged task — even when it won't
-be fixed now. Then let the human decide fix-now vs. later. Dropping
-it because "that's not what we're working on" is how known defects
-rot in place.
-_Anchor:_ a session noticed a pre-existing lint finding, labeled it
-"out of scope," and moved on; with nothing tracking it, it was
-forgotten until it resurfaced later as a failure.
-
-### Record every skip, deferral, and flag before moving on
-
-The complement to the rule above: that one covers what you NOTICE,
-this one covers what you DECIDE. A skipped test, a check that
-no-op'd because its tool was absent, a question left unanswered, a
-workaround taken "for now", scope deliberately not taken — each
-lands somewhere durable AT THE MOMENT it happens: an issue, a
-tracked fix-list, a TODO with an owner. Record why it was skipped
-and what would unblock it; a bare title is not actionable later.
-Chat is not durable — the transcript scrolls away and the next
-session starts from the code, not from what was said. A PR
-description is only durable if the item also exists outside it.
+"Out of scope" means don't silently EXPAND the change — it does NOT
+mean pretend you didn't see it. A pre-existing bug, drift, lint
+finding, or stale doc you noticed, and every skipped test, check that
+no-op'd because its tool was absent, unanswered question, workaround
+taken "for now", or scope deliberately not taken, lands somewhere
+durable AT THE MOMENT it happens — an issue, a tracked fix-list, a
+TODO with an owner — with why and what would unblock it; then the
+human decides fix-now vs. later. Chat is not durable, and a PR
+description counts only if the item also exists outside it.
 _Anchor:_ a harness printed "skipped (tool not installed)" on every
 runner for months; the check it guarded had never once executed,
 and nothing recorded that it wasn't running.
-
-### Surface uncertainty rather than guessing
-
-When the agent doesn't have enough context to make a decision
-confidently, the right move is to ask, not to guess and proceed.
-Confident-sounding wrong answers are more expensive than honest
-"I'm not sure, here's what I'd need to know" responses.
-
-### Nudge a stalled delegate; a promise to wait is not a report
-
-A delegated agent that ends its turn saying it will wait for a
-background run has stalled: the notification it is waiting for is not
-coming. Prompt-level "run everything in the foreground" instructions
-reduce but do not prevent this. Send the agent one direct message to
-run the remaining work in the foreground and deliver its full report;
-the nudge reliably recovers both the agent and the work.
-_Anchor:_ two implementation agents in one session each launched their
-final test suite in the background and stopped to "wait" despite
-explicit foreground-only instructions; both delivered complete results
-after a one-line nudge.
 
 ### One writer per repo at a time; check before merging
 
 Before merging or releasing, re-fetch and check for other active
 sessions' open PRs and recent mainline movement. A second writer
 merging mid-orchestration invalidates in-flight audits and can leave
-provenance untraceable after the fact.
+provenance untraceable after the fact. Deleting, moving, or repointing
+a path another session may be using (a checkout, a worktree, a symlink
+target) is a merge-grade write that the PR-and-mainline check cannot
+see: read the signals you can — issues or commits freshly filed from
+that path, recent file mtimes, open handles or processes. Any positive
+signal means stop and ask; true idleness is unprovable, so with no
+signals the bar is an explicit go-ahead naming the path, and prefer a
+rename over an immediate hard delete so a late writer fails loudly
+instead of by luck.
 _Anchor:_ a PR was merged by a concurrent session no one could later
-identify, minutes after another session's audit snapshot; the version
-drifted and the audit had to be redone against a moved main.
-
-### Destructive filesystem work needs the one-writer check too
-
-Deleting, moving, or repointing a path another session may be using
-(a checkout, a worktree, a symlink target) is a merge-grade write,
-and the merge-level check (open PRs, mainline movement) sees none of
-it. Check the signals you can actually read: issues or commits
-freshly filed from that path, recent file mtimes, open handles or
-processes. Any positive signal means stop and ask; true idleness is
-unprovable, so with no signals the bar is an explicit go-ahead naming
-the path, and prefer a rename over an immediate hard delete so a
-late writer fails loudly instead of by luck.
-_Anchor:_ a session deleted a duplicate repo checkout minutes after a
-concurrent session had filed an issue from inside that directory; the
-PR-and-mainline check had been run and caught nothing, and only luck
-decided whether the other session's next write hit a deleted path.
-
-### End every session with a rules retrospective
-
-Before handoff, walk the session's incidents against this file's
-add-criteria and propose additions through this repo's issue flow; a
-lesson that lives only in a transcript or a repo-local issue is lost
-to every other project.
-_Anchor:_ an orchestration session filed its lessons as a repo-local
-issue only; the owner had to ask explicitly before the generalizable
-rules were proposed to the global file every session actually loads.
+identify, minutes after another session's audit snapshot; separately, a
+duplicate repo checkout was deleted minutes after a concurrent session
+had filed an issue from inside it, with the PR-and-mainline check clean.
 
 ---
 

--- a/ruff.toml.template
+++ b/ruff.toml.template
@@ -16,9 +16,9 @@ select = [
     "SIM",   # flake8-simplify (collapsible ifs, ternaries, early returns)
     "PTH",   # enforce pathlib over os.path
     "ANN",   # type annotations
-    "ASYNC", # flake8-async (blocking HTTP/file/subprocess inside async def — ASYNC2xx; backs coding-rules.md rule 6)
-    "FAST",  # FastAPI (Annotated deps, unused path params) — no-ops on non-FastAPI code; backs rule 4
-    "G",     # flake8-logging-format (no f-string/%/format() in log calls — backs rules 10-11)
+    "ASYNC", # flake8-async (blocking HTTP/file/subprocess inside async def — ASYNC2xx; backs coding-rules.md rule 4)
+    "FAST",  # FastAPI (Annotated deps, unused path params) — no-ops on non-FastAPI code; backs the FastAPI entry under coding-rules.md "Project-specific additions"
+    "G",     # flake8-logging-format (no f-string/%/format() in log calls — backs rules 8-9)
     "LOG",   # flake8-logging (stdlib logging anti-patterns: .warn(), root logger, getLogger(__file__))
     "BLE",   # no blind except
     "C90",   # mccabe complexity

--- a/tests/cases/19-test-workflow.sh
+++ b/tests/cases/19-test-workflow.sh
@@ -11,7 +11,7 @@
 # tests.yml (removing the install.sh call site would fail it), --coverage-gate
 # must yield coverage.yml WITHOUT the plain tests.yml (reverting the
 # priority-order fix would fail it), and --no-test-workflow must both skip the
-# workflow AND print the recorded-skip line the "record every skip" rule
+# workflow AND print the recorded-skip line the "capture what you notice and what you defer" rule
 # demands (removing either half fails it).
 
 echo "cases/19: default-on test workflow (#97) + robustness fixes (#96)"


### PR DESCRIPTION
An audit of the rules files themselves, rather than additions to them.

`operational-rules.md` and `coding-rules.md` install into other people's repositories and load into every AI coding session there. Every rule is an instruction someone's agent follows in their codebase, so the bar for shipping one is higher than "it is true" — an agent's attention is finite, and a bloated file buries the rules that matter among the obvious ones.

**`operational-rules.md`: 551 → 361 lines.** It was over this repo's own 500-line cap.

## Why it got that big

The file states its own retirement criteria, and they had **never once run**. There is a rule requiring a rules retrospective every session — the add-criteria ran, the retire-criteria never did. That is the growth engine, and it is one of the rules being moved out.

Three independent read-only audits judged every rule against those criteria plus two tests that matter for a file that ships: is it universal or about this scaffold, and is it under the file's own 5-line cap. The verdicts were written to a plan the owner approved before anything was edited.

## The one real defect

`coding-rules.md` rule 9 said don't use `--no-verify` **"unless explicitly asked."** `AGENTS.md.template:87` said **"Never `git commit --no-verify`."** Both install onto the same machine and contradict; an agent picks whichever it likes.

Neither was right:

- **"Never" is a rule the scaffold itself breaks.** The deleted-pattern-config guard, `check-patterns`, `check-secrets` and `uninstall.sh --drop-lang` all *print* `--no-verify` as the intended way through. `check-gitleaks` names a confirmed false positive as a second legitimate case.
- **"Unless explicitly asked" is worse** — it lets an agent bargain for permission to skip a failing check.

Resolved to one statement in `AGENTS.md`, which already owns Git discipline: never to get past a *failing* check, with the exception scoped to a commit the hook is built to refuse and whose own message offers the bypass. **"Take it only when the hook printed it"** is the load-bearing clause — it makes the exception machine-checkable rather than a judgement call.

## Retired (4)

- **Canonical helper / bench-only** — duplicated `coding-rules.md` rules 2 and 3; anchor was one project's bench math.
- **Tests cover every code path; back claims with measurement** — its halves are the patch-coverage gate and the surviving "agent reports measurements" rule.
- **Choose the strongest approach before starting** — its own anchor admits it is not tied to an incident, failing the file's add-criteria.
- **Surface uncertainty rather than guessing** — no anchor, nothing checkable; already in every agent's system prompt.

## Moved, not deleted (3 → `TECHNICAL.md`)

- Two rules anchored to this scaffold's own shell tooling — an `errexit` gotcha from its session-start hook, a BSD/GNU `stat` chain from its CI. Neither reaches a Python API or a React app.
- **The session-retrospective rule**, which told agents in strangers' repos to file issues against *this* tracker. The practice stays; it stops shipping to other people.

## Merged (5 pairs that were one idea split in two)

Most telling: "One canonical decisions file" and "Track work in at most two places" — the second spent three lines disclaiming its overlap with the first. Also "Commit each fix immediately", which duplicated `AGENTS.md.template:92` shipping alongside it.

## Kept against the audit's advice

**"Never print, cat, or echo secret files."** The audit found it tool-enforced and recommended retiring it. The enforcement is one day old and matches known credential shapes on known paths — a novel path would not match. Compressed to one line instead. Retiring prose because day-old tooling covers it is over-trust.

## Framework rules moved to Project-specific

FastAPI and SQLAlchemy rules now sit in the file's own "Project-specific additions" section as its worked examples. The closing line already promised the file stays universal, and those two were dead weight in every Go and React install. Renumbering chased rule-number pointers through `ruff.toml.template`, `lint.yml.template` and `RECOMMENDATIONS.md`; all 10 surviving references verified to resolve to the intended rule.

## Recorded honestly

**One idea is gone, not relocated.** "Choose the strongest approach" carried a distinct instruction the plan assumed was absorbed elsewhere and is not: *decide between the robust and the quick path at the fork, before writing the fix, because sunk cost decides it afterwards.* `Fix the file, not the guardrail` covers suppression-over-fix but not that. If it should come back it needs re-adding as a short anchored rule.

**Two places the plan was wrong, left alone rather than forced.** The pattern-file format spec is *not* triplicated — neither other copy ships to a consumer, so `coding-rules.md` holds their only local reference. And rule 14 carried no statistics to cut; the stated rationale did not match the text.

**"Fix the file, not the guardrail"** was 26 lines, 5× the file's own cap. Cut to 20 with all nine of its distinct prohibitions enumerated before the edit and checked off after. Still the longest rule in the file, deliberately — further cutting would have cost a prohibition.

## Verification

- Suite: **535 passed, 0 failed, 15 skipped** — identical to baseline.
- Every one of the plan's 30 cited line numbers verified against the real text before editing.
- The "Adding rules to this document" section is **byte-identical** (md5-checked) — it is the standard, so it was not touched.
- Prettier verified by reproducing `self-lint.yml`'s method exactly, with the repo's pinned `prettier@3.9.6` and install-time filenames, not an approximation.
- Stale cross-references fixed in `install.sh`, `install-optin.sh`, `tests/cases/19`, and `claude-skill/coding-rules/SKILL.md.template` — that last one advertised a now-retired rule to every consumer of the skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Hfii6p4mxHXAYb4cUQtbb

---
_Generated by [Claude Code](https://claude.ai/code/session_019Hfii6p4mxHXAYb4cUQtbb)_