### PR TITLE
Restore choose-the-strongest-approach, with the anchor it never had

### DIFF
--- a/operational-rules.md
+++ b/operational-rules.md
@@ -121,6 +121,18 @@ _Anchor:_ a guardrail flagged a file; exempting it was one line and
 fixing it a few — but an exemption, unlike a fix, never expires, so
 suppressions accrete until the scanner no longer scans.
 
+### Choose the strongest approach at the fork, not after the work is built
+
+Decide between the robust approach and the quick one BEFORE writing the
+fix. Once the fast path is built, sunk cost decides for you and the
+question becomes a postmortem. When speed or simplicity is the only
+reason to prefer a path, treat that as a reason to slow down, not a
+green light.
+_Anchor:_ denylist rules written quickly and checked only for syntax
+were then measured against real third-party code: three fired on
+legitimate code every time they fired, and had to be deleted after a
+full rework round. Measuring first was the same work, once.
+
 ### Hold shared-resource locks for contiguous work, not per operation
 
 When multiple processes contend for a single shared resource (GPU,


### PR DESCRIPTION
Follow-up to #165, which retired this rule. One rule, one file.

## Why it was retired, and why that was half right

The prune gave two grounds:

1. **Its own anchor admitted it was not tied to an incident** — literally "restated explicitly and independently across multiple sessions as a standing directive, not tied to one incident". That fails this file's own add-criteria, and it is true.
2. **"Fix the file, not the guardrail" absorbs it.** Verified during that work: it does not.

The second ground is the one that matters. `Fix the file` governs what you do *after* a check goes red — don't suppress, don't weaken, don't delete the test. This rule governs the decision *before* any fix is written: which approach you commit to at the fork. Nothing that survived the prune carries that.

So the idea was lost rather than merged, and #165 said so in its own description rather than claiming absorption. This closes it.

## What changed on re-entry

The original failed the add-criteria for lack of an incident. It now has one, from the denylist work in #161:

> Denylist rules were written quickly and validated only as syntax — valid regex, right separators. Measured afterwards against real third-party corpora, three of them fired on legitimate code **every time they fired** and were deleted outright, after a full rework round. Measuring first would have been the same work, once.

That is the rule's exact shape: the fast path was chosen at the fork, and the cost landed later as rework rather than as a decision.

Also shortened from 12 lines to 5 plus the anchor, within the file's own cap. Placed next to `Fix the file, not the guardrail` so the relationship between the two is visible — the fork decision, then what you do when a check goes red.

## Verification

- `operational-rules.md` 361 → 373 lines, still under the 500 cap #165 brought it back below.
- Prettier clean, checked with the repo's pinned `self-lint` binary rather than an approximation.
- Suite: **535 passed, 0 failed, 15 skipped** — unchanged.
- Rebased on `main` at `00311dc`; verified `main` had not moved past that base before committing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Hfii6p4mxHXAYb4cUQtbb

---
_Generated by [Claude Code](https://claude.ai/code/session_019Hfii6p4mxHXAYb4cUQtbb)_