### PR TITLE
chore(release): v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 versioning follows [SemVer](https://semver.org/).
 
-## [Unreleased]
+## [v0.16.0] - 2026-09-02
 
 ### Added
 
@@ -49,8 +49,88 @@ versioning follows [SemVer](https://semver.org/).
   It exists so the auto-install branch can be tested; `CI` being set
   still forces print-only behavior.
 
+- **Security rules in every per-language denylist (#161).** Only
+  `backend.txt` and `frontend.txt` carried security rules; the other
+  six pattern files held debug and print rules alone. PHP had no guard
+  for `unserialize`, Go none for `InsecureSkipVerify: true`, Java none
+  for deserialization or `Runtime.exec`, Ruby none for `eval` or
+  `Marshal.load`: the same TLS-bypass and remote-code-execution surfaces
+  the Python and TypeScript files already banned. These rules block
+  commits in consumers' trees, so every new rule was measured against a
+  real third-party corpus before shipping (20.4k PHP files, 34.3k Ruby,
+  37.9k Java, 33k Kotlin, 26 Go projects, rust-src plus 18 crates).
+  That measurement dropped three rules outright (PHP request-data sink,
+  Go `exec.Command("sh","-c")`, Ruby shell interpolation: 37 hits, zero
+  true positives) and narrowed the Java, Kotlin and Rust sets. Rules
+  that could not be made precise ship commented out with a note on when
+  to enable them. Expect commits to be refused that previously passed;
+  that is the point. Untouched pattern files refresh on upgrade through
+  the install manifest; hand-edited ones are preserved and notified.
+- **`uninstall.sh --drop-lang=<name>` (#161)** removes one optional
+  pattern file together with its manifest entry. It is the supported way
+  to stop scanning a language, and the fail-closed guard below names it.
+  It refuses `secrets.txt` and `shell.txt`, which every install writes.
+- **The doctor reports shipped-rule drift (#161).** An installed
+  `secrets.txt` could be trimmed from 42 rules to 1 with the hook, the
+  CI scan and the doctor all green; the only guard was total emptiness.
+  The doctor now names shipped rules missing from an installed pattern
+  file. Locally added rules stay silent, so "missing shipped rules"
+  cannot quietly become "any difference". Regression test: case 37.
+- **`.gitignore` is no longer an unguarded linter kill-switch (#161).**
+  `eslint.config.js` derives its ignore list from `.gitignore`, so
+  adding a source path there silently un-linted it at pre-commit and in
+  CI. Where that derivation is used, the hook now checks tracked source
+  files against the root `.gitignore` with `git check-ignore --no-index`
+  and refuses the commit. Build, vendor and generated paths are excused
+  by path component; test and config paths deliberately are not.
+
+### Changed
+
+- **The shipped rules files were pruned (#165, #166).**
+  `operational-rules.md` and `coding-rules.md` install into consumers'
+  repositories and load into every AI session there, and the operational
+  file had grown past this repo's own 500-line cap because its stated
+  retirement criteria had never once been applied. Measured on the
+  shipped file: 536 lines at v0.15.0, 373 now. Four rules were retired,
+  three rules specific to this scaffold's own shell tooling moved to
+  `TECHNICAL.md`, five pairs that stated one idea twice were merged, and
+  the FastAPI and SQLAlchemy rules moved into the "Project-specific
+  additions" section as worked examples. One retired rule, "choose the
+  strongest approach before starting", turned out not to be absorbed by
+  anything that survived and came back shortened, with the incident
+  anchor it never had (#166). Rule numbers changed; the pointers in
+  `ruff.toml.template`, `lint.yml.template` and `RECOMMENDATIONS.md`
+  were chased and verified. **Existing installs do not receive this
+  automatically:** both rules files are installed with the preserve-if-
+  present policy, so a re-run leaves your copies alone and only
+  `install.sh --force` (with a backup) replaces them. If you rely on a
+  retired rule, keep your copy or re-add it under project-specific
+  additions.
+- **One `--no-verify` rule instead of two that contradicted each other
+  (#165).** `coding-rules.md` said not to use it "unless explicitly
+  asked"; `AGENTS.md.template` said "never". Both were wrong: the
+  scaffold's own guards print `--no-verify` as the intended way through
+  a commit they are built to refuse, and "unless asked" lets an agent
+  bargain past a failing check. The single statement now lives in
+  `AGENTS.md`: never to get past a failing check, with the one exception
+  scoped to a commit the hook itself refused and whose own message
+  offered the bypass.
+
 ### Fixed
 
+- **Untracking an optional pattern file no longer disables its rules
+  silently (#159, #161).** `check-patterns` could not tell a removed
+  config from a language the project never installed, so
+  `git rm --cached .forbidden-patterns/backend.txt` left the local hook
+  armed while CI and every fresh clone had no `backend.txt` and exited
+  clean. Every backend rule stopped running with nothing reporting it.
+  The install manifest supplies the missing fact: a recorded entry with
+  the file absent is unambiguously "removed", and the hook now fails
+  closed and names `uninstall.sh --drop-lang` as the way out. No entry and no
+  file stays "never installed" and silent; a repo without a manifest
+  keeps today's behavior. The manifest is never pruned automatically,
+  because absence must not authorize itself. Mutation-verified both
+  ways.
 - **Scanning scope: a type change no longer hides a file from every
   check.** The staged-file list used `--diff-filter=ACMR`, which omits
   `T`. Replacing a symlink with a regular file (or the reverse) produced
@@ -156,6 +236,15 @@ versioning follows [SemVer](https://semver.org/).
 
 ### Tests
 
+- **The runner counts skips (#161).** It reported only passed and
+  failed, so a case gated behind an absent tool was invisible: 14
+  assertions were silently not running. Skips are now a third column,
+  and assertion floors count attempted assertions (passed plus skipped)
+  rather than passes, so cases that sit entirely behind an optional
+  tool still guard something on a bare machine. The read-only
+  `.gitignore` check in the manifest case now probes whether the mode is
+  honored instead of assuming it, so the suite is no longer red under
+  root.
 - Coverage added for behavior that shipped untested and could have been
   deleted with the suite green: check-red-green's entire detection
   logic, the prettier, tsc and phpcs failure paths, the stash safety

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 versioning follows [SemVer](https://semver.org/).
 
-## [v0.16.0] - 2026-09-02
+## [v0.16.0] - 2026-09-03
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ somewhere stable:
 
 ```sh
 # Recommended: pin to a tagged release for reproducibility
-git clone --branch v0.15.0 https://github.com/Sting25/ai-coding-rules-scaffold ~/src/ai-coding-rules-scaffold
+git clone --branch v0.16.0 https://github.com/Sting25/ai-coding-rules-scaffold ~/src/ai-coding-rules-scaffold
 # Or track main if you want the latest changes
 git clone https://github.com/Sting25/ai-coding-rules-scaffold ~/src/ai-coding-rules-scaffold
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-coding-rules-scaffold",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Agent-agnostic coding-rules scaffold: pre-commit + CI guardrails (file size, forbidden patterns, secret/credential scanning, hygiene) that install into your project, plus `scaffold-doctor` to check they are actually armed and not just present. Run via `npx ai-coding-rules-scaffold`. AI agents: run the installer, never hand-copy files.",
   "bin": {
     "ai-coding-rules-scaffold": "bin/cli.js"


### PR DESCRIPTION
Release prep per RELEASING.md step 1. Promotes `[Unreleased]` to `[v0.16.0] - 2026-09-03`, bumps the README clone pin and `package.json`.

## Back-filled entries

Four cloud-session PRs merged with no changelog entry (#161, #164, #165, #166). The cloud session had told its agents not to touch `CHANGELOG.md` to avoid six-way collisions and never wrote the entries itself; confirmed with that session, forgotten not decided. Entries were written from the PR bodies:

- **Added:** security rules in every per-language denylist, measured against third-party corpora; `uninstall.sh --drop-lang`; shipped-rule drift in the doctor; the `.gitignore` linter kill-switch guard.
- **Changed:** the rules-file prune (measured on the shipped file: 536 lines at v0.15.0, 373 on main) and the `--no-verify` contradiction resolved to one statement.
- **Fixed:** #159, untracking a pattern file no longer disables its rules silently.
- **Tests:** the runner counts skips and floors count attempted assertions.

The prune entry tells consumers that both rules files are installed with the preserve-if-present policy (`cp_safe`, `install.sh` lines 202-203), so an existing install receives the prune only via `--force`. Without that line the notes would promise a change most installs never see.

## Verification

- `bash tests/run.sh`: 553 passed, 0 failed.
- Secrets self-lint dry run (RELEASING.md 1.3): exit 0.
- Prettier clean on all three files.
- Release-notes extraction (the `release.yml` awk) yields a non-empty section for `v0.16.0`.
- No em dashes in the added text; the heading uses the same `- DATE` form as v0.15.0.

Two commits rather than one: the agent write-guard refused `--amend` for the date correction, and a second commit was the non-bypass path.

Merge with `--merge` (not squash, not auto) per RELEASING.md, then tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
