### PR TITLE
fix(ci): gate release tags on the PR test workflow, not a bare private copy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,16 +18,17 @@ permissions:
   contents: read
 
 jobs:
-  # Gate: never publish a tag whose tests don't pass. The cross-platform matrix
-  # runs on every PR; here a single fast ubuntu run guards a tag pushed directly.
+  # Gate: never publish a tag whose tests don't pass. This calls the SAME
+  # workflow every PR runs (tool installs, zizmor, pin-drift check, both
+  # runners) rather than a private copy of it. The private copy ran the suite
+  # bare, with no ruff, actionlint or pytest; it passed only while the runner
+  # counted passes alone, and the v0.16.0 tag failed on it the first time the
+  # floors counted attempted assertions (#161). Two definitions of "green"
+  # drift; one cannot.
   test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-        with:
-          persist-credentials: false
-      - run: chmod +x tests/run.sh install.sh githooks/pre-commit.template
-      - run: ./tests/run.sh
+    uses: ./.github/workflows/test.yml
+    permissions:
+      contents: read
 
   publish-npm:
     needs: test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,12 @@ on:
   pull_request:
   push:
     branches: [main]
+  # release.yml gates a version tag on this exact job. It used to carry its own
+  # bare `./tests/run.sh` with none of the tool installs below, which passed by
+  # luck until the runner started counting attempted assertions (#161): the
+  # v0.16.0 tag then failed on actionlint being absent while every PR was green.
+  # One definition of "the suite passes", called from both places.
+  workflow_call:
 
 permissions:
   contents: read

--- a/tests/cases/35-workflow-template-validity.sh
+++ b/tests/cases/35-workflow-template-validity.sh
@@ -109,3 +109,17 @@ else
   SKIP=$((SKIP + _wt_total))
 fi
 unset _wt_templates _wt_own _wt_total _wt_tpl _wt_name _wt_dir
+
+# The release gate must be the PR gate, not a copy of it. release.yml once
+# carried its own bare `./tests/run.sh` with none of test.yml's tool installs;
+# it passed while the runner counted only passes and went red on the v0.16.0
+# tag the first time floors counted attempted assertions (#161). Runs without
+# actionlint: it is a structural check on the file, not a lint.
+if grep -Eq '^\s+uses: \./\.github/workflows/test\.yml\s*$' "$SCAFFOLD_DIR/.github/workflows/release.yml" \
+   && grep -Eq '^\s+workflow_call:\s*$' "$SCAFFOLD_DIR/.github/workflows/test.yml"; then
+  echo "  ✓ release.yml gates the tag on the same test.yml job every PR runs (workflow_call)"
+  PASS=$((PASS + 1))
+else
+  echo "  ✗ release.yml does not call test.yml: the release gate is a private copy of the suite run and will drift from the PR gate again"
+  FAIL=$((FAIL + 1))
+fi

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -49,7 +49,7 @@ HERE="$(cd "$(dirname "$0")" && pwd)"
 # number for every case that does not touch SKIP, so the floors in the list
 # below are unchanged by this. It matters for a case whose whole body sits
 # behind an optional tool AND which says how many assertions that costs —
-# cases/35 (14 workflows, actionlint) and cases/36 (3 verdicts, pytest).
+# cases/35 (14 workflows, actionlint; plus 1 ungated structural check) and cases/36 (3 verdicts, pytest).
 # Counting only passes would force those floors to 0, the bare machine's
 # number, and a 0 floor guards nothing: the file could be emptied and the run
 # would still be green.
@@ -106,7 +106,7 @@ CASE_FLOORS=(
   "32-uninstall-report.sh:6"
   "33-harness-self-checks.sh:12"
   "34-shipped-pattern-files.sh:11"
-  "35-workflow-template-validity.sh:14"
+  "35-workflow-template-validity.sh:15"
   "36-red-green-verdict.sh:3"
   "37-doctor-content-drift.sh:4"
 )


### PR DESCRIPTION
## What broke

The v0.16.0 tag push ran `release.yml`, whose `test` job ran `./tests/run.sh` bare, with none of the tool installs `test.yml` does (ruff, actionlint, pytest). [Run 33754904906](https://github.com/Sting25/ai-coding-rules-scaffold/actions/runs/33754904906) failed on the runner's own floor guard:

```
cases/02-scaffold-allow-ruff-edge.sh: ran 14 assertions, floor is 15
cases/35-workflow-template-validity.sh: ran 0 assertions, floor is 14
Result: 528 passed, 1 failed, 3 skipped
```

Every PR run was green at the same commit. The private copy had passed by luck until #161 made floors count attempted assertions and made case 35 go red in CI without actionlint. v0.15.0 released fine only because case 35 did not exist yet.

## Fix

- `test.yml` also answers `workflow_call`.
- `release.yml`'s `test` job is now `uses: ./.github/workflows/test.yml`. The tag gate is exactly the PR gate: tool installs, zizmor, pin-drift check, both runners. One definition of green.
- Case 35 gains an ungated structural assertion that `release.yml` calls `test.yml`. Verified red with the old `release.yml` and green with the new one. Floor 14 to 15.

## Verification

- `actionlint` on both workflows: clean.
- `bash tests/run.sh`: 554 passed, 0 failed.
- Red-green on the new assertion, shown above.

The tag itself still points at the pre-fix commit and needs a decision (recreate v0.16.0 on the fixed main, or cut v0.16.1); that is being asked of the owner separately, not decided here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
