### PR TITLE
chore(release): v0.16.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,16 +18,17 @@ permissions:
   contents: read
 
 jobs:
-  # Gate: never publish a tag whose tests don't pass. The cross-platform matrix
-  # runs on every PR; here a single fast ubuntu run guards a tag pushed directly.
+  # Gate: never publish a tag whose tests don't pass. This calls the SAME
+  # workflow every PR runs (tool installs, zizmor, pin-drift check, both
+  # runners) rather than a private copy of it. The private copy ran the suite
+  # bare, with no ruff, actionlint or pytest; it passed only while the runner
+  # counted passes alone, and the v0.16.0 tag failed on it the first time the
+  # floors counted attempted assertions (#161). Two definitions of "green"
+  # drift; one cannot.
   test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-        with:
-          persist-credentials: false
-      - run: chmod +x tests/run.sh install.sh githooks/pre-commit.template
-      - run: ./tests/run.sh
+    uses: ./.github/workflows/test.yml
+    permissions:
+      contents: read
 
   publish-npm:
     needs: test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,12 @@ on:
   pull_request:
   push:
     branches: [main]
+  # release.yml gates a version tag on this exact job. It used to carry its own
+  # bare `./tests/run.sh` with none of the tool installs below, which passed by
+  # luck until the runner started counting attempted assertions (#161): the
+  # v0.16.0 tag then failed on actionlint being absent while every PR was green.
+  # One definition of "the suite passes", called from both places.
+  workflow_call:
 
 permissions:
   contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,30 @@ All notable changes to this project are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 versioning follows [SemVer](https://semver.org/).
 
+## [v0.16.1] - 2026-09-03
+
+### Fixed
+
+- **The release workflow gates a tag on the same test job every PR
+  runs.** `release.yml` carried its own bare `./tests/run.sh` with none
+  of `test.yml`'s tool installs (ruff, actionlint, pytest). That copy
+  passed while the test runner counted only passes; once floors counted
+  attempted assertions (v0.16.0, #161) and the workflow-validity case
+  went red in CI without actionlint, the v0.16.0 tag failed its own gate
+  (case 35 ran 0 of 14, case 02 ran 14 of 15) while every PR run at the
+  same commit was green. `test.yml` now also answers `workflow_call` and
+  the release job calls it, so there is one definition of "the suite
+  passes": tool installs, zizmor, the pin-drift check, both runners. A
+  structural assertion in case 35 keeps the release gate pointed at the
+  PR gate.
+
 ## [v0.16.0] - 2026-09-03
+
+**This tag was never published.** Its release workflow failed on the
+gate bug fixed in v0.16.1, so there is no GitHub Release, npm version or
+Homebrew bottle for it. v0.16.1 is the first published build of the 0.16
+line and contains everything below.
+
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,6 @@ gate bug fixed in v0.16.1, so there is no GitHub Release, npm version or
 Homebrew bottle for it. v0.16.1 is the first published build of the 0.16
 line and contains everything below.
 
-
 ### Added
 
 - **Install manifest: upgrades now deliver what an untouched file is

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ somewhere stable:
 
 ```sh
 # Recommended: pin to a tagged release for reproducibility
-git clone --branch v0.16.0 https://github.com/Sting25/ai-coding-rules-scaffold ~/src/ai-coding-rules-scaffold
+git clone --branch v0.16.1 https://github.com/Sting25/ai-coding-rules-scaffold ~/src/ai-coding-rules-scaffold
 # Or track main if you want the latest changes
 git clone https://github.com/Sting25/ai-coding-rules-scaffold ~/src/ai-coding-rules-scaffold
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-coding-rules-scaffold",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Agent-agnostic coding-rules scaffold: pre-commit + CI guardrails (file size, forbidden patterns, secret/credential scanning, hygiene) that install into your project, plus `scaffold-doctor` to check they are actually armed and not just present. Run via `npx ai-coding-rules-scaffold`. AI agents: run the installer, never hand-copy files.",
   "bin": {
     "ai-coding-rules-scaffold": "bin/cli.js"

--- a/tests/cases/35-workflow-template-validity.sh
+++ b/tests/cases/35-workflow-template-validity.sh
@@ -109,3 +109,17 @@ else
   SKIP=$((SKIP + _wt_total))
 fi
 unset _wt_templates _wt_own _wt_total _wt_tpl _wt_name _wt_dir
+
+# The release gate must be the PR gate, not a copy of it. release.yml once
+# carried its own bare `./tests/run.sh` with none of test.yml's tool installs;
+# it passed while the runner counted only passes and went red on the v0.16.0
+# tag the first time floors counted attempted assertions (#161). Runs without
+# actionlint: it is a structural check on the file, not a lint.
+if grep -Eq '^\s+uses: \./\.github/workflows/test\.yml\s*$' "$SCAFFOLD_DIR/.github/workflows/release.yml" \
+   && grep -Eq '^\s+workflow_call:\s*$' "$SCAFFOLD_DIR/.github/workflows/test.yml"; then
+  echo "  ✓ release.yml gates the tag on the same test.yml job every PR runs (workflow_call)"
+  PASS=$((PASS + 1))
+else
+  echo "  ✗ release.yml does not call test.yml: the release gate is a private copy of the suite run and will drift from the PR gate again"
+  FAIL=$((FAIL + 1))
+fi

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -49,7 +49,7 @@ HERE="$(cd "$(dirname "$0")" && pwd)"
 # number for every case that does not touch SKIP, so the floors in the list
 # below are unchanged by this. It matters for a case whose whole body sits
 # behind an optional tool AND which says how many assertions that costs —
-# cases/35 (14 workflows, actionlint) and cases/36 (3 verdicts, pytest).
+# cases/35 (14 workflows, actionlint; plus 1 ungated structural check) and cases/36 (3 verdicts, pytest).
 # Counting only passes would force those floors to 0, the bare machine's
 # number, and a 0 floor guards nothing: the file could be emptied and the run
 # would still be green.
@@ -106,7 +106,7 @@ CASE_FLOORS=(
   "32-uninstall-report.sh:6"
   "33-harness-self-checks.sh:12"
   "34-shipped-pattern-files.sh:11"
-  "35-workflow-template-validity.sh:14"
+  "35-workflow-template-validity.sh:15"
   "36-red-green-verdict.sh:3"
   "37-doctor-content-drift.sh:4"
 )


### PR DESCRIPTION
Release prep per RELEASING.md step 1, stacked on #169 (merge that first; this PR then reduces to the three release files).

v0.16.0 was tagged but never published: `release.yml`'s private copy of the suite run failed its own floor guard ([run 33754904906](https://github.com/Sting25/ai-coding-rules-scaffold/actions/runs/33754904906)). Owner decision: leave that tag in place and cut v0.16.1 as the first published build of the 0.16 line rather than rewrite a pushed tag.

- `CHANGELOG.md`: new `[v0.16.1]` section with the gate fix; the `[v0.16.0]` section is marked as never published and its content carries forward.
- `README.md`: clone pin to v0.16.1.
- `package.json`: 0.16.1.

Verification: prettier clean on all three, secrets self-lint dry run exit 0, release-notes extraction for v0.16.1 yields a 17-line section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
