### PR TITLE
chore(homebrew): sync canonical formula to v0.16.1

### DIFF
--- a/packaging/homebrew/ai-coding-rules-scaffold.rb
+++ b/packaging/homebrew/ai-coding-rules-scaffold.rb
@@ -9,8 +9,8 @@
 class AiCodingRulesScaffold < Formula
   desc "Pre-commit and CI guardrails: size, pattern, secret, and hygiene checks"
   homepage "https://github.com/Sting25/ai-coding-rules-scaffold"
-  url "https://github.com/Sting25/ai-coding-rules-scaffold/archive/refs/tags/v0.15.0.tar.gz"
-  sha256 "975e5159790eb5cd237545ecb61a1331d7737cd7b43e791c4884526418588d91"
+  url "https://github.com/Sting25/ai-coding-rules-scaffold/archive/refs/tags/v0.16.1.tar.gz"
+  sha256 "ef10f86bad27098623cb7bffcd2dd712bda974634e269c6eedd98c5ee92898ea"
   license "MIT"
 
   def install


### PR DESCRIPTION
Points the canonical formula at the v0.16.1 tag with the tarball sha256 computed from GitHub's archive, per RELEASING.md step 3. Replaces #168, which targeted the never-published v0.16.0 tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)