### PR TITLE
feat(assess): scaffold-assess.sh measures what the scaffold would flag, read-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,24 @@ versioning follows [SemVer](https://semver.org/).
   (both checked red-green). The README's note telling agents never to
   hand-copy files is replaced by this path; `install.sh` stays as the
   convenience that performs the same copies.
+- **`scaffold-assess.sh` and `npx ai-coding-rules-scaffold assess`: measure
+  what the scaffold would flag before adopting anything.** Read-only. Renders
+  the shipped scanners and pattern files into a temp directory and runs them
+  from the target's git root over its tracked files, the same list CI scans.
+  Reports per component: the five core scanners with counts and samples; each
+  language pattern file separately, as "not applicable" when no tracked file
+  has its extensions (zero findings on zero files is not clean); the
+  project-wide configs measured with the real tool and the shipped config
+  when the tool resolves (ruff findings, tsc errors, with the monorepo case
+  from #163 named instead of measured); and which tools this machine has.
+  Untracked files are counted as not scanned rather than left silent, since
+  the scanners read the index. Two scanners gained `SCAFFOLD_PATTERNS_DIR`
+  (default `.forbidden-patterns`) so the assessment can point them at the
+  shipped rules; the hook and CI never set it. Regression test: case 39,
+  which also runs under `LC_ALL=C` because the first draft counted findings
+  with a bracket expression around a multibyte glyph and reported every
+  scanner clean on a tree with a tracked `.env`, a 600 KB blob and a
+  `breakpoint()`.
 
 ## [v0.16.1] - 2026-09-03
 

--- a/COMPONENTS.md
+++ b/COMPONENTS.md
@@ -42,11 +42,11 @@ hand-edited and preserves them. To upgrade a hand-copied component, re-run its
 adopt block against a newer `$SCAFFOLD`.
 
 **Before adopting anything on an existing codebase**, measure what it would
-flag: `bash "$SCAFFOLD/scaffold-assess.sh"` runs every scanner read-only
-against your tracked files and reports findings per component, and says
-"not applicable" for a language you have no files in. (Ships in v0.17; until
-then, adopt the core and run `git ls-files -z | .githooks/lib/check-secrets --ci`
-for the same measurement on secrets.)
+flag. `bash "$SCAFFOLD/scaffold-assess.sh"` (or `npx ai-coding-rules-scaffold
+assess`, no clone) runs every scanner read-only against your tracked files and
+reports findings per component, says "not applicable" for a language you have
+no files in, measures the project-wide configs with the tool itself when it is
+installed, and writes nothing. Its output names the entry numbers below.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ What the scaffold doesn't try to solve: parallel-session collisions, context-win
 
 ## Install
 
-> **AI agents, and anyone adopting this on an existing codebase:** you do not need the installer. [COMPONENTS.md](COMPONENTS.md) lists every component with what it blocks, its blast radius (staged files only, or project-wide), the exact copy commands, a verify command that proves the guard is armed, and how to remove it. Pick what you want, run the adopt block, run the verify block, then `scaffold-doctor.sh`. The project-wide entries (tsconfig, ruff, eslint) carry a measurement command to run first with nothing copied; that is how you avoid thousands of findings on day one. The installer below performs the same copies for you in one go. If it errors or is blocked, stop and show your user the error instead of working around it.
+> **AI agents, and anyone adopting this on an existing codebase:** you do not need the installer. [COMPONENTS.md](COMPONENTS.md) lists every component with what it blocks, its blast radius (staged files only, or project-wide), the exact copy commands, a verify command that proves the guard is armed, and how to remove it. Start with `npx ai-coding-rules-scaffold assess`, which measures what each component would flag in this repo and writes nothing. Then pick what you want, run the adopt block, run the verify block, then `scaffold-doctor.sh`. The project-wide entries (tsconfig, ruff, eslint) carry a measurement command to run first with nothing copied; that is how you avoid thousands of findings on day one. The installer below performs the same copies for you in one go. If it errors or is blocked, stop and show your user the error instead of working around it.
 
 **Quickest — `npx`, no clone.** From your project root:
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -25,9 +25,13 @@ const pkgRoot = path.resolve(__dirname, '..');
 // install.sh is already pinned at its 500-line module cap (issue #84), so a
 // second script gets a second entry point instead of a bigger install.sh.
 const args = process.argv.slice(2);
-const isDoctor = args[0] === 'doctor';
-const script = isDoctor ? 'scaffold-doctor.sh' : 'install.sh';
-const scriptArgs = isDoctor ? args.slice(1) : args;
+// `assess` is the read-only measurement (scaffold-assess.sh): what each
+// component would flag in this repo, with nothing copied. Same shape as
+// `doctor`: dispatch on the first word, pass the rest through.
+const SUBCOMMANDS = { doctor: 'scaffold-doctor.sh', assess: 'scaffold-assess.sh' };
+const isSub = Object.prototype.hasOwnProperty.call(SUBCOMMANDS, args[0]);
+const script = isSub ? SUBCOMMANDS[args[0]] : 'install.sh';
+const scriptArgs = isSub ? args.slice(1) : args;
 const target = path.join(pkgRoot, script);
 
 if (!fs.existsSync(target)) {

--- a/githooks/lib/check-patterns.template
+++ b/githooks/lib/check-patterns.template
@@ -327,7 +327,11 @@ INCLUDED=0
 # Auto-discover every pattern file. secrets.txt is check-secrets' domain (it
 # scans all files, not by extension), so skip it here. Then apply the optional
 # INCLUDE/EXCLUDE basename filter documented in the header.
-for cfg in .forbidden-patterns/*.txt; do
+# SCAFFOLD_PATTERNS_DIR (default .forbidden-patterns) lets scaffold-assess.sh
+# run this scanner against a tree that has not adopted the scaffold, reading
+# the shipped pattern files from wherever it rendered them. The hook and CI
+# never set it, so their behavior is unchanged.
+for cfg in "${SCAFFOLD_PATTERNS_DIR:-.forbidden-patterns}"/*.txt; do
   # `-e` alone is not enough: a DANGLING symlink is not -e, so a config swapped
   # for one would be skipped here and never reach the config_usable() guard.
   # Both false still means "no glob match → literal string", which is skipped.

--- a/githooks/lib/check-secrets.template
+++ b/githooks/lib/check-secrets.template
@@ -66,7 +66,9 @@ case "$MAX_LINE_LENGTH" in
 esac
 [ "$MAX_LINE_LENGTH" -gt 0 ] || { echo "error: MAX_LINE_LENGTH must be > 0" >&2; exit 2; }
 
-CONFIG=".forbidden-patterns/secrets.txt"
+# SCAFFOLD_PATTERNS_DIR: same override scaffold-assess.sh uses for
+# check-patterns; unset in the hook and CI, so the default path is unchanged.
+CONFIG="${SCAFFOLD_PATTERNS_DIR:-.forbidden-patterns}/secrets.txt"
 
 # A config path that EXISTS but is not a readable REGULAR file is a disarm, not
 # a fresh checkout, so it fails CLOSED at BOTH gates, no local leniency.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "uninstall.sh",
     "uninstall-drop-lang.sh",
     "scaffold-doctor.sh",
+    "scaffold-assess.sh",
     "scaffold-doctor-gates.sh",
     "bin/",
     "githooks/",

--- a/scaffold-assess.sh
+++ b/scaffold-assess.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# scaffold-assess.sh — measure what the scaffold would flag in THIS project,
+# before adopting anything. Read-only: writes nothing into the target tree.
+#
+# usage: scaffold-assess.sh [--samples N]   (run from anywhere inside the repo)
+#   --samples N   show up to N example findings per scanner (default 3)
+#
+# Exit status: 0 assessment printed, 2 usage error / not a git repository.
+# Findings never change the exit status: this is a measurement, not a gate.
+#
+# WHY. Every guard the scaffold ships is cheap on a fresh repository and
+# expensive to discover on an existing one: the first commit after adoption
+# is where a project learns that a pattern rule fires on 200 legacy files, or
+# that a root tsconfig.json makes the hook type-check the whole tree (#163:
+# 12,235 errors). COMPONENTS.md lets a reader pick components; this script
+# tells them what each would cost, per component, with nothing copied.
+#
+# HOW. The shipped scanners are rendered from their *.template sources into a
+# temp directory and run from the target's git root over `git ls-files`, the
+# same whole-tree list lint.yml scans in CI. check-patterns and check-secrets
+# read their pattern files from $SCAFFOLD_PATTERNS_DIR, pointed at the shipped
+# templates, so a tree with no .forbidden-patterns/ still gets the real rules.
+# The target's own .scaffold.toml overrides, if any, are honored, because they
+# would be honored by the hook too.
+#
+# WHAT IT CANNOT SEE. The scanners read the git INDEX (`git show :0:path`),
+# which is what the hook and CI read, so untracked files are not scanned; the
+# count of untracked files is printed rather than left silent. A component
+# whose language has no tracked files is reported as "not applicable", never
+# as "clean": zero findings on zero files proves nothing.
+set -euo pipefail
+
+SAMPLES=3
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --samples) shift; SAMPLES=${1:-}; case "$SAMPLES" in ''|*[!0-9]*) echo "scaffold-assess: --samples needs a number" >&2; exit 2 ;; esac ;;
+    -h|--help) sed -n '2,10p' "$0"; exit 0 ;;
+    *) echo "scaffold-assess: unknown argument '$1'" >&2; exit 2 ;;
+  esac
+  shift
+done
+
+SCAFFOLD_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if ! ROOT=$(git rev-parse --show-toplevel 2>/dev/null); then
+  echo "scaffold-assess: not inside a git repository. The scanners read the git index, so there is nothing to measure here." >&2
+  exit 2
+fi
+cd "$ROOT"
+if [ "$(pwd -P)" = "$SCAFFOLD_DIR" ]; then
+  echo "scaffold-assess: run this from the project you want to assess, not from the scaffold checkout." >&2
+  exit 2
+fi
+
+# Render the scanners and pattern files somewhere the target tree never sees.
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+mkdir -p "$WORK/lib" "$WORK/patterns"
+for t in "$SCAFFOLD_DIR"/githooks/lib/check-*.template "$SCAFFOLD_DIR"/githooks/lib/scaffold-config.template; do
+  n=$(basename "$t" .template)
+  cp "$t" "$WORK/lib/$n" && chmod +x "$WORK/lib/$n"
+done
+for t in "$SCAFFOLD_DIR"/forbidden-patterns/*.txt.template; do
+  cp "$t" "$WORK/patterns/$(basename "$t" .template)"
+done
+export SCAFFOLD_PATTERNS_DIR="$WORK/patterns"
+
+ALL="$WORK/all.z"
+git -c core.quotepath=off ls-files -z >"$ALL"
+TRACKED=$(tr -cd '\0' <"$ALL" | wc -c | tr -d ' ')
+UNTRACKED=$(git ls-files --others --exclude-standard | wc -l | tr -d ' ')
+
+echo "scaffold-assess: $ROOT"
+echo "  tracked files scanned: $TRACKED   untracked (not scanned, not in the index): $UNTRACKED"
+[ -f .scaffold.toml ] && echo "  note: this repo has a .scaffold.toml; its overrides are applied below, as the hook would apply them."
+echo
+
+# run_scanner NAME LISTFILE: run one rendered scanner over a NUL list, capture
+# its plain (non --ci) output, and print a one-line verdict plus samples.
+# Findings are the "✗ file: desc" and "! file: desc" lines the scanners emit
+# per (file, rule); the indented match excerpts under them are not counted.
+# Alternation, not a bracket expression: under a C locale `[✗!]` is a byte
+# class and never matches the three-byte glyph, which reported every scanner
+# clean on a tree with findings (caught by the smoke, then by case 39).
+run_scanner() {
+  local name=$1 list=$2 out="$WORK/$1.out" n
+  "$WORK/lib/$name" <"$list" >"$out" 2>&1 || true
+  n=$(grep -cE '^(✗|!) ' "$out" || true)
+  if [ "$n" -eq 0 ]; then
+    echo "  ✓ $name: clean"
+  else
+    echo "  ✗ $name: $n finding(s)"
+    grep -E '^(✗|!) ' "$out" | head -n "$SAMPLES" | sed 's/^/      /'
+    [ "$n" -gt "$SAMPLES" ] && echo "      ... and $((n - SAMPLES)) more"
+  fi
+  return 0
+}
+
+echo "Commit guard core (COMPONENTS.md entry 1), whole tree:"
+for s in check-secrets check-filenames check-hygiene check-large-files check-size; do
+  run_scanner "$s" "$ALL"
+done
+echo
+
+# Per-language pattern files: attribute findings to one file at a time via
+# CHECK_PATTERNS_INCLUDE, and count the tracked files its header extensions
+# match so "no files" is reported as not applicable rather than clean.
+echo "Language pattern files (entry 2), one line per file:"
+for cfg in "$WORK"/patterns/*.txt; do
+  base=$(basename "$cfg")
+  case "$base" in secrets.txt) continue ;; esac
+  exts=$(grep -m1 -E '^#[[:space:]]*scaffold-extensions:' "$cfg" | sed -E 's/^#[[:space:]]*scaffold-extensions:[[:space:]]*//; s/[[:space:]]+$//')
+  if [ -z "$exts" ]; then
+    echo "  ! $base: no scaffold-extensions header, skipped"
+    continue
+  fi
+  re='\.('; for e in $exts; do re="$re$e|"; done; re="${re%|})\$"
+  matched=$(tr '\0' '\n' <"$ALL" | grep -ciE "$re" || true)
+  if [ "$matched" -eq 0 ]; then
+    echo "  - $base: not applicable (no tracked files with extension: $exts)"
+    continue
+  fi
+  out="$WORK/$base.out"
+  CHECK_PATTERNS_INCLUDE="$base" "$WORK/lib/check-patterns" <"$ALL" >"$out" 2>&1 || true
+  n=$(grep -cE '^(✗|!) ' "$out" || true)
+  if [ "$n" -eq 0 ]; then
+    echo "  ✓ $base: clean across $matched file(s)"
+  else
+    echo "  ✗ $base: $n finding(s) across $matched file(s) ($(grep -E '^(✗|!) ' "$out" | cut -d: -f1 | sort -u | wc -l | tr -d ' ') files)"
+    grep -E '^(✗|!) ' "$out" | head -n "$SAMPLES" | sed 's/^/      /'
+    [ "$n" -gt "$SAMPLES" ] && echo "      ... and $((n - SAMPLES)) more"
+  fi
+done
+echo
+
+# Project-wide tool configs (entries 6 to 10): these govern the whole tree, so
+# the honest measurement is the tool itself, run with the shipped config and
+# nothing copied. Only run when the tool resolves; say so when it does not.
+echo "Project-wide configs (entries 6 to 10), measured with the shipped config:"
+py_files=$(tr '\0' '\n' <"$ALL" | grep -c '\.py$' || true)
+if [ "$py_files" -eq 0 ]; then
+  echo "  - ruff.toml: not applicable (no tracked .py files)"
+elif command -v ruff >/dev/null 2>&1 || python3 -m ruff --version >/dev/null 2>&1; then
+  if command -v ruff >/dev/null 2>&1; then RUFF=ruff; else RUFF="python3 -m ruff"; fi
+  n=$($RUFF check --no-cache --config "$SCAFFOLD_DIR/ruff.toml.template" --quiet --exit-zero --output-format concise . 2>/dev/null | grep -c . || true)
+  echo "  $([ "$n" -eq 0 ] && echo ✓ || echo ✗) ruff.toml: $n finding(s) across $py_files .py file(s); the hook lints only staged files, so this is the debt, not a blocker"
+else
+  echo "  ! ruff.toml: $py_files .py file(s), ruff not installed here, not measured"
+fi
+js_files=$(tr '\0' '\n' <"$ALL" | grep -ciE '\.(js|jsx|ts|tsx|mjs|cjs)$' || true)
+if [ "$js_files" -eq 0 ]; then
+  echo "  - tsconfig.json: not applicable (no tracked JS/TS files)"
+elif [ -f tsconfig.json ]; then
+  echo "  - tsconfig.json: this repo already has one; the scaffold's would not be copied over it"
+elif grep -q '"workspaces"' package.json 2>/dev/null || [ -f pnpm-workspace.yaml ]; then
+  echo "  ! tsconfig.json: workspaces monorepo, do not add a root tsconfig.json (#163); per-package configs already type-check"
+elif command -v node >/dev/null 2>&1 && node -e "require.resolve('typescript/package.json')" >/dev/null 2>&1; then
+  n=$(npx --no-install tsc --noEmit -p "$SCAFFOLD_DIR/tsconfig.json.template" 2>&1 | grep -c 'error TS' || true)
+  echo "  $([ "$n" -eq 0 ] && echo ✓ || echo ✗) tsconfig.json: $n type error(s) across $js_files JS/TS file(s); the hook runs tsc PROJECT-WIDE on every JS/TS commit, so this is a blocker until zero"
+else
+  echo "  ! tsconfig.json: $js_files JS/TS file(s), typescript not resolvable here, not measured. It is project-wide: measure before adopting."
+fi
+if [ "$js_files" -gt 0 ]; then
+  if command -v node >/dev/null 2>&1 && node -e "require.resolve('eslint/package.json')" >/dev/null 2>&1; then
+    echo "  ! eslint.config.js: eslint is installed; measure with: npx eslint -c \"$SCAFFOLD_DIR/eslint.config.js.template\" . (needs typescript-eslint and eslint-plugin-security)"
+  else
+    echo "  ! eslint.config.js: $js_files JS/TS file(s), eslint not resolvable here, not measured"
+  fi
+fi
+echo
+
+echo "Tools on this machine (what the hook and CI can run):"
+tool() { if eval "$2" >/dev/null 2>&1; then echo "  ✓ $1"; else echo "  - $1: absent ($3)"; fi; }
+tool "ruff (Python lint)"          "command -v ruff || python3 -m ruff --version" "entry 6 does nothing without it"
+tool "pytest"                      "command -v pytest || python3 -m pytest --version" "entries 4 and 18 need it"
+tool "node"                        "command -v node" "every JS/TS tool below needs it"
+tool "eslint (project-local)"      "node -e \"require.resolve('eslint/package.json')\"" "entry 9 skips with a note"
+tool "typescript (project-local)"  "node -e \"require.resolve('typescript/package.json')\"" "entry 10 skips with a note"
+tool "prettier (project-local)"    "node -e \"require.resolve('prettier/package.json')\"" "entry 11 skips with a note"
+tool "shellcheck"                  "command -v shellcheck" "shell.txt rules still run; shellcheck lint does not"
+tool "gitleaks"                    "command -v gitleaks" "entry 16's local pass skips, CI gate still runs"
+tool "jq"                          "command -v jq" "entry 15's agent guard fails open"
+tool "actionlint"                  "command -v actionlint" "workflow validation in COMPONENTS.md verify steps is skipped"
+echo
+echo "Next: read COMPONENTS.md, adopt the entries you want, run each verify block, then scaffold-doctor.sh."
+echo "Nothing was written to $ROOT."

--- a/tests/cases/39-scaffold-assess.sh
+++ b/tests/cases/39-scaffold-assess.sh
@@ -1,0 +1,146 @@
+# shellcheck shell=bash
+# cases/39-scaffold-assess.sh: scaffold-assess.sh measures a tree that has NOT
+# adopted the scaffold, per component, without writing to it. Sourced into the
+# driver's shell, so PASS/FAIL/SKIP/SCAFFOLD_DIR/HOOK_OUT are already in scope.
+#
+# WHY. The assessment is the "measure before you adopt" step COMPONENTS.md
+# leads with. Its whole value is that a finding it reports is one the hook
+# would block, and that a component with no matching files is reported as not
+# applicable rather than clean. The first smoke of the script reported every
+# scanner clean on a tree with a tracked .env, a 600 KB blob and a
+# breakpoint(): the finding count used a bracket expression with a multibyte
+# glyph, which is a byte class under a C locale. So this case runs under LC_ALL=C
+# as well as the inherited locale, and asserts the counts, not the exit code.
+#
+# The fixture is one repository with: a tracked .env (check-filenames), a
+# 600 KB file (check-large-files), a .py with breakpoint() and print()
+# (backend.txt), a .js with console.log (frontend.txt), and no Go files
+# (go.txt must read "not applicable"). One untracked file checks the
+# not-scanned count. Assertions read the report's own lines.
+
+echo "cases/39: scaffold-assess.sh reports per component, counts findings, writes nothing"
+
+_sa_fixture() {
+  local t; t=$(mktemp -d)
+  ( cd "$t" && git init -q && git config user.email t@test.local && git config user.name "Scaffold Test" \
+      && mkdir -p src && printf 'import os\nbreakpoint()\nprint("x")\n' > src/app.py \
+      && printf 'console.log(1)\n' > src/a.js && printf 'x=1\n' > .env \
+      && head -c 600000 /dev/zero > big.bin && git add -f src .env big.bin && git commit -q -m init \
+      && printf 'loose\n' > loose.txt )
+  printf '%s' "$t"
+}
+
+_sa_repo=$(_sa_fixture)
+_sa_before=$(cd "$_sa_repo" && git status --porcelain && ls -A)
+
+for _sa_locale in inherit C; do
+  if [ "$_sa_locale" = C ]; then
+    ( cd "$_sa_repo" && LC_ALL=C LANG=C bash "$SCAFFOLD_DIR/scaffold-assess.sh" ) >"$HOOK_OUT" 2>&1
+  else
+    ( cd "$_sa_repo" && bash "$SCAFFOLD_DIR/scaffold-assess.sh" ) >"$HOOK_OUT" 2>&1
+  fi
+  _sa_rc=$?
+  if [ "$_sa_rc" -eq 0 ] \
+     && grep -q '✗ check-filenames: 1 finding' "$HOOK_OUT" \
+     && grep -q '✗ check-large-files: 1 finding' "$HOOK_OUT" \
+     && grep -q '✗ backend.txt: 2 finding(s) across 1 file' "$HOOK_OUT" \
+     && grep -q '✗ frontend.txt: 1 finding(s) across 1 file' "$HOOK_OUT"; then
+    echo "  ✓ [$_sa_locale locale] counts: .env, 600 KB blob, 2 backend and 1 frontend findings, exit 0"
+    PASS=$((PASS + 1))
+  else
+    echo "  ✗ [$_sa_locale locale] expected the four finding lines and exit 0 (got exit $_sa_rc)"
+    sed 's/^/      /' "$HOOK_OUT" | head -30
+    FAIL=$((FAIL + 1))
+  fi
+done
+
+# The inherited-locale report is still in HOOK_OUT for the structural checks.
+( cd "$_sa_repo" && bash "$SCAFFOLD_DIR/scaffold-assess.sh" ) >"$HOOK_OUT" 2>&1 || true
+if grep -q -- '- go.txt: not applicable (no tracked files with extension: go)' "$HOOK_OUT" \
+   && ! grep -q '✓ go.txt' "$HOOK_OUT"; then
+  echo "  ✓ a language with no tracked files reads 'not applicable', never 'clean'"
+  PASS=$((PASS + 1))
+else
+  echo "  ✗ go.txt should be reported as not applicable"
+  FAIL=$((FAIL + 1))
+fi
+if grep -q 'tracked files scanned: 4   untracked (not scanned, not in the index): 1' "$HOOK_OUT"; then
+  echo "  ✓ the untracked file is counted as not scanned rather than left silent"
+  PASS=$((PASS + 1))
+else
+  echo "  ✗ expected 'tracked files scanned: 4   untracked ...: 1'"
+  grep 'tracked files' "$HOOK_OUT" | sed 's/^/      /'
+  FAIL=$((FAIL + 1))
+fi
+if grep -q '^      ✗ src/app.py: Remove breakpoint() before committing' "$HOOK_OUT"; then
+  echo "  ✓ samples name the file and the rule the hook would cite"
+  PASS=$((PASS + 1))
+else
+  echo "  ✗ expected an indented sample line for src/app.py breakpoint()"
+  FAIL=$((FAIL + 1))
+fi
+_sa_after=$(cd "$_sa_repo" && git status --porcelain && ls -A)
+if [ "$_sa_before" = "$_sa_after" ] && [ ! -e "$_sa_repo/.forbidden-patterns" ] && [ ! -e "$_sa_repo/.ruff_cache" ]; then
+  echo "  ✓ nothing was written to the target (status and listing identical; no .forbidden-patterns, no .ruff_cache)"
+  PASS=$((PASS + 1))
+else
+  echo "  ✗ the target tree changed:"
+  diff <(echo "$_sa_before") <(echo "$_sa_after") | sed 's/^/      /'
+  FAIL=$((FAIL + 1))
+fi
+
+# Not a git repository: the scanners read the index, so refuse with exit 2.
+_sa_plain=$(mktemp -d)
+if ( cd "$_sa_plain" && bash "$SCAFFOLD_DIR/scaffold-assess.sh" ) >"$HOOK_OUT" 2>&1; then
+  echo "  ✗ outside a git repository the script should exit 2"
+  FAIL=$((FAIL + 1))
+else
+  if [ $? -eq 2 ] 2>/dev/null || grep -q 'not inside a git repository' "$HOOK_OUT"; then
+    echo "  ✓ outside a git repository: refuses with the reason (the scanners read the index)"
+    PASS=$((PASS + 1))
+  else
+    echo "  ✗ wrong failure outside a git repository"; sed 's/^/      /' "$HOOK_OUT"
+    FAIL=$((FAIL + 1))
+  fi
+fi
+rm -rf "$_sa_plain"
+
+# The npm entry point routes `assess` to the script, like `doctor`.
+if command -v node >/dev/null 2>&1; then
+  if ( cd "$_sa_repo" && node "$SCAFFOLD_DIR/bin/cli.js" assess ) >"$HOOK_OUT" 2>&1 && grep -q '✗ check-filenames: 1 finding' "$HOOK_OUT"; then
+    echo "  ✓ 'npx ai-coding-rules-scaffold assess' routes to scaffold-assess.sh"
+    PASS=$((PASS + 1))
+  else
+    echo "  ✗ bin/cli.js assess did not produce the assessment"; sed 's/^/      /' "$HOOK_OUT" | head -5
+    FAIL=$((FAIL + 1))
+  fi
+else
+  echo "  - SKIP: node not installed, the cli.js assess route was not exercised"
+  SKIP=$((SKIP + 1))
+fi
+
+# SCAFFOLD_PATTERNS_DIR: the override the script relies on. A pattern dir
+# holding one custom rule flags a tracked file only when the variable points
+# at it; unset, the scanners read .forbidden-patterns/ (absent here), so the
+# same file passes. Positive on both sides, not "no output".
+_sa_alt=$(mktemp -d)
+printf 'SCAFFOLDTESTTOKEN\ttest rule from an alternate pattern dir\n' > "$_sa_alt/secrets.txt"
+printf '# scaffold-extensions: py\nSCAFFOLDTESTTOKEN\ttest rule from an alternate pattern dir\n' > "$_sa_alt/backend.txt"
+( cd "$_sa_repo" && printf 'SCAFFOLDTESTTOKEN = 1\n' > src/alt.py && git add src/alt.py )
+_sa_with=$(cd "$_sa_repo" && printf 'src/alt.py\0' | SCAFFOLD_PATTERNS_DIR="$_sa_alt" bash "$SCAFFOLD_DIR/githooks/lib/check-secrets.template" 2>&1 || true)
+_sa_without=$(cd "$_sa_repo" && printf 'src/alt.py\0' | bash "$SCAFFOLD_DIR/githooks/lib/check-secrets.template" 2>&1 || true)
+_sa_pwith=$(cd "$_sa_repo" && printf 'src/alt.py\0' | SCAFFOLD_PATTERNS_DIR="$_sa_alt" bash "$SCAFFOLD_DIR/githooks/lib/check-patterns.template" 2>&1 || true)
+_sa_pwithout=$(cd "$_sa_repo" && printf 'src/alt.py\0' | bash "$SCAFFOLD_DIR/githooks/lib/check-patterns.template" 2>&1 || true)
+if grep -q 'alternate pattern dir' <<<"$_sa_with" && ! grep -q 'alternate pattern dir' <<<"$_sa_without" \
+   && grep -q 'alternate pattern dir' <<<"$_sa_pwith" && ! grep -q 'alternate pattern dir' <<<"$_sa_pwithout"; then
+  echo "  ✓ SCAFFOLD_PATTERNS_DIR redirects check-secrets and check-patterns; unset, both read the default path"
+  PASS=$((PASS + 1))
+else
+  echo "  ✗ SCAFFOLD_PATTERNS_DIR override not honored by both scanners"
+  printf '%s\n' "$_sa_with" "$_sa_without" "$_sa_pwith" "$_sa_pwithout" | sed 's/^/      /' | head -8
+  FAIL=$((FAIL + 1))
+fi
+( cd "$_sa_repo" && git reset -q src/alt.py && rm -f src/alt.py )
+rm -rf "$_sa_alt" "$_sa_repo"
+unset _sa_repo _sa_before _sa_after _sa_locale _sa_rc _sa_plain _sa_alt _sa_with _sa_without _sa_pwith _sa_pwithout
+unset -f _sa_fixture

--- a/tests/cases/39-scaffold-assess.sh
+++ b/tests/cases/39-scaffold-assess.sh
@@ -127,10 +127,19 @@ _sa_alt=$(mktemp -d)
 printf 'SCAFFOLDTESTTOKEN\ttest rule from an alternate pattern dir\n' > "$_sa_alt/secrets.txt"
 printf '# scaffold-extensions: py\nSCAFFOLDTESTTOKEN\ttest rule from an alternate pattern dir\n' > "$_sa_alt/backend.txt"
 ( cd "$_sa_repo" && printf 'SCAFFOLDTESTTOKEN = 1\n' > src/alt.py && git add src/alt.py )
-_sa_with=$(cd "$_sa_repo" && printf 'src/alt.py\0' | SCAFFOLD_PATTERNS_DIR="$_sa_alt" bash "$SCAFFOLD_DIR/githooks/lib/check-secrets.template" 2>&1 || true)
-_sa_without=$(cd "$_sa_repo" && printf 'src/alt.py\0' | bash "$SCAFFOLD_DIR/githooks/lib/check-secrets.template" 2>&1 || true)
-_sa_pwith=$(cd "$_sa_repo" && printf 'src/alt.py\0' | SCAFFOLD_PATTERNS_DIR="$_sa_alt" bash "$SCAFFOLD_DIR/githooks/lib/check-patterns.template" 2>&1 || true)
-_sa_pwithout=$(cd "$_sa_repo" && printf 'src/alt.py\0' | bash "$SCAFFOLD_DIR/githooks/lib/check-patterns.template" 2>&1 || true)
+# _sa_scan DIR SCANNER: run one scanner over src/alt.py from the fixture with
+# SCAFFOLD_PATTERNS_DIR set to DIR (unset when DIR is empty). Output only;
+# the scanner's exit status is the finding, not an error.
+_sa_scan() {
+  local dir=$1; shift
+  ( cd "$_sa_repo" || exit 1
+    if [ -n "$dir" ]; then export SCAFFOLD_PATTERNS_DIR="$dir"; fi
+    printf 'src/alt.py\0' | bash "$@" ) 2>&1 || true
+}
+_sa_with=$(_sa_scan "$_sa_alt" "$SCAFFOLD_DIR/githooks/lib/check-secrets.template")
+_sa_without=$(_sa_scan "" "$SCAFFOLD_DIR/githooks/lib/check-secrets.template")
+_sa_pwith=$(_sa_scan "$_sa_alt" "$SCAFFOLD_DIR/githooks/lib/check-patterns.template")
+_sa_pwithout=$(_sa_scan "" "$SCAFFOLD_DIR/githooks/lib/check-patterns.template")
 if grep -q 'alternate pattern dir' <<<"$_sa_with" && ! grep -q 'alternate pattern dir' <<<"$_sa_without" \
    && grep -q 'alternate pattern dir' <<<"$_sa_pwith" && ! grep -q 'alternate pattern dir' <<<"$_sa_pwithout"; then
   echo "  ✓ SCAFFOLD_PATTERNS_DIR redirects check-secrets and check-patterns; unset, both read the default path"
@@ -143,4 +152,4 @@ fi
 ( cd "$_sa_repo" && git reset -q src/alt.py && rm -f src/alt.py )
 rm -rf "$_sa_alt" "$_sa_repo"
 unset _sa_repo _sa_before _sa_after _sa_locale _sa_rc _sa_plain _sa_alt _sa_with _sa_without _sa_pwith _sa_pwithout
-unset -f _sa_fixture
+unset -f _sa_fixture _sa_scan

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -110,6 +110,7 @@ CASE_FLOORS=(
   "36-red-green-verdict.sh:3"
   "37-doctor-content-drift.sh:4"
   "38-components-catalog.sh:20"
+  "39-scaffold-assess.sh:9"
 )
 
 # A case file that exists but is NOT in the list above contributes nothing and


### PR DESCRIPTION
Stacked on #173 (base is that branch; merge #173 first, then retarget or merge this).

## What

`scaffold-assess.sh`, also `npx ai-coding-rules-scaffold assess`. Read-only measurement of what each component in COMPONENTS.md would flag in the current repo, with nothing copied and nothing written.

- Renders the shipped scanners + pattern files into a temp dir; runs them from the target's git root over `git ls-files` (what CI scans).
- Core scanners: count + up to N samples each.
- Language pattern files: one line each, **not applicable** when no tracked file has the header's extensions. Zero findings on zero files is never reported as clean.
- Project-wide configs: measured with the real tool and the shipped config when the tool resolves (`ruff --no-cache`, `tsc --noEmit -p <template>`); a workspaces monorepo gets the #163 warning instead of a measurement.
- Tools present on this machine, with what each absence costs.
- Untracked files counted as "not scanned" (the scanners read the index).
- Exit 0 always on a completed assessment; 2 outside a git repo or from the scaffold checkout.

Two scanners gain `SCAFFOLD_PATTERNS_DIR` (default unchanged). `bin/cli.js` routes `assess` the way it routes `doctor`.

## Defect found and fixed before commit

First smoke: every core scanner reported **clean** on a fixture with a tracked `.env`, a 600 KB blob and a `breakpoint()`. The scanners were right (verified by hand); the count `grep -cE '^[✗!] '` is a byte class under a C locale and never matches the three-byte glyph. Fixed with alternation. Case 39 runs the assessment under the inherited locale and under `LC_ALL=C`, asserting the four counts. With the bracket form restored, the C-locale assertion goes red (verified). The ruff measurement also left `.ruff_cache` in the target; `--no-cache` now, and case 39 asserts the target's status and listing are byte-identical before and after.

## Measured

- Suite: 583 passed, 0 failed. Case 39 floor 9.
- shellcheck clean; 186 lines, under the repo's 500-line cap.
- Sample run on the fixture, both locales:
  ```
  ✗ check-filenames: 1 finding(s)
  ✗ check-large-files: 1 finding(s)
  ✗ backend.txt: 2 finding(s) across 1 file(s) (1 files)
  - go.txt: not applicable (no tracked files with extension: go)
  ✗ ruff.toml: 2 finding(s) across 1 .py file(s); the hook lints only staged files, so this is the debt, not a blocker
  ! tsconfig.json: workspaces monorepo, do not add a root tsconfig.json (#163)
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
