### PR TITLE
feat(doctor): measure required status checks; ship the ruleset template (#172)

### DIFF
--- a/.github/rulesets/main-protection.json.template
+++ b/.github/rulesets/main-protection.json.template
@@ -1,0 +1,35 @@
+{
+  "name": "main-protection",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["~DEFAULT_BRANCH"],
+      "exclude": []
+    }
+  },
+  "bypass_actors": [],
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": true,
+        "allowed_merge_methods": ["merge", "squash", "rebase"]
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [{ "context": "guardrails" }]
+      }
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 versioning follows [SemVer](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- **Required status checks are shipped, measured and enforced (#172).** A
+  merge gate that requires zero checks is convention, not enforcement: this
+  repository's own main had exactly that, and three release PRs merged on an
+  agent's reading of the check list. Now shipped: an importable ruleset
+  template (`.github/rulesets/main-protection.json.template`, COMPONENTS.md
+  entry 20) that blocks deletion and force-push, requires a pull request with
+  resolved threads, and requires the `guardrails` check on an up-to-date
+  branch; a doctor section that reads the live setting through the `gh` CLI
+  and reports a default branch with no required checks as a gap, and says
+  what it could not check (no GitHub remote, no gh, not logged in) rather
+  than staying silent; and a RELEASING.md note that `--merge` is safe because
+  the button is the gate. This repository's main now requires all six CI
+  contexts, strict and admin-enforced.
+
 ## [v0.17.0] - 2026-09-03
 
 ### Added

--- a/COMPONENTS.md
+++ b/COMPONENTS.md
@@ -658,6 +658,47 @@ test -s .claude/skills/coding-rules/SKILL.md && echo "verified: coding-rules ski
 rm -rf .claude/skills/coding-rules
 ```
 
+## 20. Required status checks on the default branch
+
+Every CI gate above only blocks a merge if the branch requires it. Measured
+on this scaffold's own repository (issue #172): a protection object existed
+and required zero checks, so pull requests merged on an operator's reading of
+the check list rather than on the repository's say-so. `scaffold-doctor.sh`
+reports this as a gap when it can measure it (needs the `gh` CLI, logged in).
+
+The template is an importable GitHub ruleset: blocks deletion and force-push
+of the default branch, requires a pull request with every review thread
+resolved (zero approvals, so a solo maintainer is not locked out; raise it
+for a team), and requires the `guardrails` check from `lint.yml` to pass on
+an up-to-date branch. Add the other contexts you adopted (`pytest` or
+`vitest` from `tests.yml`, `gitleaks`, `dependency-review`, `test-guard`) to
+`required_status_checks`; a context named here that never reports blocks the
+merge forever, so name only jobs that run on every pull request.
+
+**Blast radius:** every merge into the default branch, from the moment the
+ruleset is active. Import it as `"evaluate"` first on a busy repo.
+
+**Prerequisites:** entry 3 (the `guardrails` job), a GitHub repository.
+
+```sh adopt=branch-protection
+mkdir -p .github/rulesets
+cp "$SCAFFOLD/.github/rulesets/main-protection.json.template" .github/rulesets/main-protection.json
+echo "import it: Settings > Rules > Rulesets > New ruleset > Import a ruleset, or:"
+echo "  gh api -X POST repos/OWNER/REPO/rulesets --input .github/rulesets/main-protection.json"
+```
+
+```sh verify=branch-protection
+set -e
+python3 -c 'import json,sys; d=json.load(open(".github/rulesets/main-protection.json")); assert any(r["type"]=="required_status_checks" for r in d["rules"]); assert d["bypass_actors"]==[]' \
+  || jq -e '.rules[] | select(.type=="required_status_checks")' .github/rulesets/main-protection.json >/dev/null
+echo "verified: ruleset file is valid, requires status checks, and has no bypass actors (import it to arm it; scaffold-doctor.sh measures the live setting)"
+```
+
+```sh remove=branch-protection
+rm -f .github/rulesets/main-protection.json
+# then delete the ruleset in Settings > Rules > Rulesets
+```
+
 ---
 
 ## After adopting: check what is armed

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -37,7 +37,7 @@ The version lives in these places — all must agree on `vX.Y.Z`:
    - Commit these changes with message `chore(release): vX.Y.Z` (the commit-msg
      hook requires conventional commit types; bare "release:" type is rejected).
    - Open the PR, wait for CI green on **both** runners, merge (`--merge`, never
-     `--auto` — this repo has no branch protection).
+     `--auto`). `--merge` is safe because main requires the six CI contexts, strict and admin-enforced (issue #172); the merge button, not the operator's read of the check list, is the gate.
 
 ## 2. Push the tag — CI publishes (npm + GitHub release)
 

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     ".coveragerc.template",
     ".scaffold.toml.template",
     ".github/dependabot.yml.template",
+    ".github/rulesets/main-protection.json.template",
     ".github/workflows/lint.yml.template",
     ".github/workflows/tests.yml.template",
     ".github/workflows/coverage.yml.template",

--- a/scaffold-doctor-gates.sh
+++ b/scaffold-doctor-gates.sh
@@ -378,3 +378,38 @@ _pne() { note "$1"; PNE_ANY=1; }
 [ -f .npmrc ]                                   || _pne "npm install-layer cooldown (.npmrc min-release-age, delays freshly published versions): not installed. Enable with install.sh --npm-cooldown"
 [ -f .claude/skills/coding-rules/SKILL.md ]     || _pne "Claude Code Skill (on-demand rules loading): not installed. Enable with install.sh --claude-skill"
 [ "$PNE_ANY" -eq 1 ] || ok "every opt-in protection is enabled in this project"
+
+# --- 13. required status checks on the default branch -----------------------
+# Every check above is enforced locally by the hook and server-side by CI, but
+# CI only gates a merge if the branch requires it. Measured on this scaffold's
+# own repo (issue #172): a protection object existed and required zero checks,
+# so three release PRs merged on an agent's read of the check list, not on the
+# repo's say-so. This needs the network and the gh CLI, so it is a gap only
+# when it can be measured and is absent; everything else is a note that says
+# what was NOT checked, never silence.
+section "required status checks on the default branch"
+_rsc_remote=$(git config --get remote.origin.url 2>/dev/null || true)
+_rsc_repo=""
+case "$_rsc_remote" in
+  *github.com[:/]*) _rsc_repo=$(printf '%s' "$_rsc_remote" | sed -E 's#.*github\.com[:/]##; s#\.git$##') ;;
+esac
+if [ -z "$_rsc_repo" ]; then
+  note "required status checks: not checked (remote.origin is not a github.com URL)"
+elif ! command -v gh >/dev/null 2>&1; then
+  note "required status checks: not checked (gh CLI not installed; install it and re-run, or verify in Settings > Branches)"
+elif ! gh auth status >/dev/null 2>&1; then
+  note "required status checks: not checked (gh is not logged in: run 'gh auth login' and re-run)"
+else
+  _rsc_default=$(gh api "repos/$_rsc_repo" --jq .default_branch 2>/dev/null || true)
+  _rsc_ctx=$(gh api "repos/$_rsc_repo/branches/${_rsc_default:-main}/protection" --jq '.required_status_checks.contexts | length' 2>/dev/null || echo "")
+  _rsc_rules=$(gh api "repos/$_rsc_repo/rules/branches/${_rsc_default:-main}" --jq '[.[] | select(.type=="required_status_checks")] | length' 2>/dev/null || echo "0")
+  if [ -z "$_rsc_default" ]; then
+    note "required status checks: not checked (gh could not read $_rsc_repo; permissions or network)"
+  elif [ "${_rsc_ctx:-0}" -gt 0 ] 2>/dev/null || [ "${_rsc_rules:-0}" -gt 0 ] 2>/dev/null; then
+    ok "$_rsc_default requires status checks before merge (${_rsc_ctx:-0} via branch protection, ${_rsc_rules:-0} ruleset rule(s))"
+  else
+    gap "$_rsc_repo: '$_rsc_default' requires NO status checks, so a red or unfinished CI run does not block a merge; every gate above is advisory at merge time" \
+        "import .github/rulesets/main-protection.json (COMPONENTS.md entry 20), or Settings > Branches > require the guardrails check"
+  fi
+fi
+unset _rsc_remote _rsc_repo _rsc_default _rsc_ctx _rsc_rules

--- a/tests/cases/40-doctor-required-checks.sh
+++ b/tests/cases/40-doctor-required-checks.sh
@@ -17,7 +17,7 @@ echo "cases/40: scaffold-doctor reports what it could not measure about required
 _rc_fixture() {
   local t; t=$(mktemp -d)
   ( cd "$t" && git init -q && git config user.email t@test.local && git config user.name "Scaffold Test" \
-      && "$SCAFFOLD_DIR/install.sh" --shell --no-verify "$@" ) >/dev/null 2>&1
+      && "$SCAFFOLD_DIR/install.sh" --shell --no-verify ) >/dev/null 2>&1
   printf '%s' "$t"
 }
 
@@ -50,7 +50,11 @@ else
 fi
 
 # 3. gh present but not logged in: a stub gh whose `auth status` fails.
-printf '#!/bin/sh\n[ "$1" = auth ] && exit 1\nexit 1\n' > "$_rc_nogh/gh"; chmod +x "$_rc_nogh/gh"
+cat > "$_rc_nogh/gh" <<'GH'
+#!/bin/sh
+exit 1
+GH
+chmod +x "$_rc_nogh/gh"
 ( cd "$_rc_repo" && PATH="$_rc_nogh" "$SCAFFOLD_DIR/scaffold-doctor.sh" ) >"$HOOK_OUT" 2>&1 || true
 if grep -q 'required status checks: not checked (gh is not logged in' "$HOOK_OUT"; then
   echo "  ✓ gh present, not logged in: reported as not checked, says how to fix"
@@ -74,7 +78,10 @@ fi
 # (exit 1); six is an ok. The stub answers the three gh api calls the section
 # makes, keyed on the endpoint, and nothing else.
 _rc_stub() {
-  printf '#!/bin/sh\ncase "$*" in *"auth status"*) exit 0 ;; *"/protection"*) echo %s ;; *"/rules/branches/"*) echo %s ;; *"repos/"*) echo main ;; esac\n' "$1" "$2" > "$_rc_nogh/gh"
+  {
+    echo '#!/bin/sh'
+    echo "case \"\$*\" in *\"auth status\"*) exit 0 ;; *\"/protection\"*) echo $1 ;; *\"/rules/branches/\"*) echo $2 ;; *\"repos/\"*) echo main ;; esac"
+  } > "$_rc_nogh/gh"
   chmod +x "$_rc_nogh/gh"
 }
 _rc_stub 0 0

--- a/tests/cases/40-doctor-required-checks.sh
+++ b/tests/cases/40-doctor-required-checks.sh
@@ -1,0 +1,101 @@
+# shellcheck shell=bash
+# cases/40-doctor-required-checks.sh: scaffold-doctor's required-status-checks
+# section (issue #172) says what it could NOT measure instead of staying
+# silent, and never turns a missing tool into a false "armed". Sourced into
+# the driver's shell, so PASS/FAIL/SKIP/SCAFFOLD_DIR/HOOK_OUT are in scope.
+#
+# The live measurement needs the network and a logged-in gh, which a test
+# must not depend on. What CAN be asserted offline are the three fallbacks,
+# each of which is the honest shape for a check that cannot run: no GitHub
+# remote, gh absent, gh present but not logged in. A fourth assertion pins
+# that none of them counts as a gap or an ok: a fallback that exited 1 would
+# make every offline doctor run red; one that printed ✓ would report a gate
+# that was never measured.
+
+echo "cases/40: scaffold-doctor reports what it could not measure about required status checks"
+
+_rc_fixture() {
+  local t; t=$(mktemp -d)
+  ( cd "$t" && git init -q && git config user.email t@test.local && git config user.name "Scaffold Test" \
+      && "$SCAFFOLD_DIR/install.sh" --shell --no-verify "$@" ) >/dev/null 2>&1
+  printf '%s' "$t"
+}
+
+# 1. No GitHub remote: a local-only repo, the common case in this suite.
+_rc_repo=$(_rc_fixture)
+( cd "$_rc_repo" && "$SCAFFOLD_DIR/scaffold-doctor.sh" ) >"$HOOK_OUT" 2>&1 || true
+if grep -q 'required status checks: not checked (remote.origin is not a github.com URL)' "$HOOK_OUT"; then
+  echo "  ✓ no GitHub remote: reported as not checked, with the reason"
+  PASS=$((PASS + 1))
+else
+  echo "  ✗ expected the no-remote note"; grep -i 'status checks' "$HOOK_OUT" | sed 's/^/      /'
+  FAIL=$((FAIL + 1))
+fi
+
+# 2. GitHub remote but no gh on PATH: a PATH with only the directories the
+# doctor's other checks need, minus wherever gh lives.
+( cd "$_rc_repo" && git remote add origin git@github.com:example/project.git )
+_rc_nogh=$(mktemp -d)
+for _rc_tool in bash git grep sed awk sort uniq cut tr wc head tail mktemp basename dirname cat cmp find xargs jq python3 ls test; do
+  _rc_path=$(command -v "$_rc_tool" 2>/dev/null || true)
+  [ -n "$_rc_path" ] && ln -s "$_rc_path" "$_rc_nogh/$_rc_tool" 2>/dev/null
+done
+( cd "$_rc_repo" && PATH="$_rc_nogh" "$SCAFFOLD_DIR/scaffold-doctor.sh" ) >"$HOOK_OUT" 2>&1 || true
+if grep -q 'required status checks: not checked (gh CLI not installed' "$HOOK_OUT"; then
+  echo "  ✓ GitHub remote, no gh: reported as not checked, names the missing tool"
+  PASS=$((PASS + 1))
+else
+  echo "  ✗ expected the gh-not-installed note"; grep -i 'status checks' "$HOOK_OUT" | sed 's/^/      /'
+  FAIL=$((FAIL + 1))
+fi
+
+# 3. gh present but not logged in: a stub gh whose `auth status` fails.
+printf '#!/bin/sh\n[ "$1" = auth ] && exit 1\nexit 1\n' > "$_rc_nogh/gh"; chmod +x "$_rc_nogh/gh"
+( cd "$_rc_repo" && PATH="$_rc_nogh" "$SCAFFOLD_DIR/scaffold-doctor.sh" ) >"$HOOK_OUT" 2>&1 || true
+if grep -q 'required status checks: not checked (gh is not logged in' "$HOOK_OUT"; then
+  echo "  ✓ gh present, not logged in: reported as not checked, says how to fix"
+  PASS=$((PASS + 1))
+else
+  echo "  ✗ expected the gh-not-logged-in note"; grep -i 'status checks' "$HOOK_OUT" | sed 's/^/      /'
+  FAIL=$((FAIL + 1))
+fi
+
+# 4. None of the three fallbacks is a gap or an ok for this section.
+if ! grep -qE '^\s+[✓✗] .*required status checks' "$HOOK_OUT" && ! grep -qE '✗ .*requires NO status checks' "$HOOK_OUT"; then
+  echo "  ✓ an unmeasurable check is a note, never a ✓ or a gap"
+  PASS=$((PASS + 1))
+else
+  echo "  ✗ the fallback produced a ✓ or ✗ line for a check that did not run"
+  grep -E 'status checks' "$HOOK_OUT" | sed 's/^/      /'
+  FAIL=$((FAIL + 1))
+fi
+
+# 5 and 6. The live path, with gh stubbed: zero required checks is a gap
+# (exit 1); six is an ok. The stub answers the three gh api calls the section
+# makes, keyed on the endpoint, and nothing else.
+_rc_stub() {
+  printf '#!/bin/sh\ncase "$*" in *"auth status"*) exit 0 ;; *"/protection"*) echo %s ;; *"/rules/branches/"*) echo %s ;; *"repos/"*) echo main ;; esac\n' "$1" "$2" > "$_rc_nogh/gh"
+  chmod +x "$_rc_nogh/gh"
+}
+_rc_stub 0 0
+_rc_rc=0; ( cd "$_rc_repo" && PATH="$_rc_nogh" "$SCAFFOLD_DIR/scaffold-doctor.sh" ) >"$HOOK_OUT" 2>&1 || _rc_rc=$?
+if [ "$_rc_rc" -eq 1 ] && grep -q "requires NO status checks" "$HOOK_OUT" && grep -q 'fix: import .github/rulesets/main-protection.json' "$HOOK_OUT"; then
+  echo "  ✓ measured zero required checks: a gap with the fix named, exit 1"
+  PASS=$((PASS + 1))
+else
+  echo "  ✗ expected a gap and exit 1 for zero required checks (got exit $_rc_rc)"; grep -i 'status checks' "$HOOK_OUT" | sed 's/^/      /'
+  FAIL=$((FAIL + 1))
+fi
+_rc_stub 6 0
+( cd "$_rc_repo" && PATH="$_rc_nogh" "$SCAFFOLD_DIR/scaffold-doctor.sh" ) >"$HOOK_OUT" 2>&1 || true
+if grep -q '✓ main requires status checks before merge (6 via branch protection, 0 ruleset rule(s))' "$HOOK_OUT"; then
+  echo "  ✓ measured six required checks: reported armed with the counts"
+  PASS=$((PASS + 1))
+else
+  echo "  ✗ expected the armed line with counts"; grep -i 'status checks' "$HOOK_OUT" | sed 's/^/      /'
+  FAIL=$((FAIL + 1))
+fi
+
+rm -rf "$_rc_repo" "$_rc_nogh"
+unset _rc_repo _rc_nogh _rc_tool _rc_path _rc_rc
+unset -f _rc_fixture _rc_stub

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -111,6 +111,7 @@ CASE_FLOORS=(
   "37-doctor-content-drift.sh:4"
   "38-components-catalog.sh:20"
   "39-scaffold-assess.sh:9"
+  "40-doctor-required-checks.sh:6"
 )
 
 # A case file that exists but is NOT in the list above contributes nothing and


### PR DESCRIPTION
Closes #172.

## Applied on this repo (API, outside the diff)

`main` now requires `test (ubuntu-latest)`, `test (macos-latest)`, `guardrails`, `shellcheck`, `gitleaks`, `dependency-review`; strict (branch must be current); enforced for admins. Force-push and deletion stay blocked. Measured after applying:

```json
{"admins":true,"contexts":[6 listed],"del":false,"force":false,"strict":true}
```

This PR is the first one that merges under that rule.

## Shipped

- `.github/rulesets/main-protection.json.template`: importable ruleset. Deletion and non-fast-forward blocked, PR required with resolved threads and zero approvals (solo-maintainer safe, raise for a team), `guardrails` required on an up-to-date branch. Consumers add the contexts they adopted; the catalog entry warns that a named context that never reports blocks forever.
- Doctor section 13: reads the live setting via `gh`. Zero required checks is a **gap** with the fix named; no GitHub remote / no gh / not logged in are **notes** that say what was not checked. Verified ✓ on this repo after the API change.
- COMPONENTS.md entry 20 (adopt/verify/remove, exercised by case 38, now 20 entries).
- RELEASING.md: `--merge` is safe because the button is the gate, not because the operator looked.

## Tests

Case 40, floor 6: three offline fallbacks; none is a ✓ or a gap; live path with `gh` stubbed: zero checks → gap + exit 1 with the fix line, six → armed line with counts. Suite: 590 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
