### PR TITLE
feat(hook): each scanner is its own component; the hook and CI run what is present

### DIFF
--- a/.github/workflows/lint.yml.template
+++ b/.github/workflows/lint.yml.template
@@ -409,14 +409,20 @@ jobs:
           # is no diff base (so a brand-new repo still gets fully scanned).
           .githooks/lib/ci-changed-files >"$CHANGED_LIST"
           FAILED=0
-          # Whole-tree security boundary (not overridable by .scaffold.toml):
-          .githooks/lib/check-secrets   --ci <"$ALL_LIST"     || FAILED=1
-          .githooks/lib/check-filenames --ci <"$ALL_LIST"     || FAILED=1
-          # Changed-files-only quality gates:
-          .githooks/lib/check-size        --ci <"$CHANGED_LIST" || FAILED=1
-          .githooks/lib/check-large-files --ci <"$CHANGED_LIST" || FAILED=1
-          .githooks/lib/check-patterns    --ci <"$CHANGED_LIST" || FAILED=1
-          .githooks/lib/check-hygiene      --ci <"$CHANGED_LIST" || FAILED=1
+          # Every scanner PRESENT in lib/, mirroring the hook's own discovery
+          # loop, so a project that adopted a subset gets that subset here too.
+          # Secrets and filenames are the whole-tree security boundary (not
+          # overridable by .scaffold.toml); every other scanner is a
+          # changed-files quality gate. gitleaks, red-green and mutation-diff
+          # have their own workflows and are skipped here.
+          for check in .githooks/lib/check-*; do
+            [ -x "$check" ] || continue
+            case "${check##*/}" in
+              check-secrets|check-filenames) "$check" --ci <"$ALL_LIST" || FAILED=1 ;;
+              check-gitleaks|check-red-green|check-mutation-diff) ;;
+              *) "$check" --ci <"$CHANGED_LIST" || FAILED=1 ;;
+            esac
+          done
           # Project-local checks — the supported extension point (issue #72).
           # Every executable in .githooks/local.d/ runs with the same contract as
           # the shipped checks: --ci, the NUL-delimited list on stdin, non-zero

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **Each of the six core scanners is its own component; the hook and the CI
+  mirror run whatever is present.** `pre-commit` and `lint.yml` used to name
+  all six scanners and fail loudly on a missing one, so a project could not
+  take only `check-secrets`. Both now run every executable `lib/check-*`
+  through one discovery loop (Python tools driven by test-guard.yml are
+  excluded; gitleaks keeps its present-iff-adopted rule). COMPONENTS.md entry
+  1 is now the hook alone plus entries 1a to 1f, one per scanner, each with
+  its own adopt and verify block; case 38 also adopts each scanner alone with
+  only the hook and proves its verify, on top of the cumulative pass. The
+  hole this opens, a deleted scanner going quiet, is closed by the doctor:
+  a shipped scanner that the install manifest recorded and that is now
+  missing is a gap; one that was never adopted is a note. The doctor's
+  call-site checks recognize the discovery loop, and its server-side check
+  accepts either the loop or the older named lines. Installer behavior and
+  a fresh install's file set are unchanged.
+- **README leads with clone-and-copy.** The `npx` path is documented as one
+  installer alternative rather than the first thing a reader sees.
+
 ### Added
 
 - **Required status checks are shipped, measured and enforced (#172).** A

--- a/COMPONENTS.md
+++ b/COMPONENTS.md
@@ -32,8 +32,9 @@ export SCAFFOLD="$PWD/package"
 ```
 
 The catalog is tested: `tests/cases/38-components-catalog.sh` extracts the
-fenced `adopt` and `verify` blocks below, runs them in a throwaway repository,
-and fails the suite if any verify step does not prove its guard. If a command
+fenced `adopt` and `verify` blocks below, runs them in a throwaway repository
+(cumulatively, and each scanner alone with only the hook), and fails the suite
+if any verify step does not prove its guard. If a command
 here is wrong, CI is red.
 
 Hand-copied files are yours. The installer's upgrade logic keys off a manifest
@@ -50,37 +51,28 @@ installed, and writes nothing. Its output names the entry numbers below.
 
 ---
 
-## 1. Commit guard core
+## 1. Commit guard: the hook and its scanners
 
-Six scanners plus the hook that runs them, the shared config reader, and the
-two pattern files every project wants. They are one component because the
-hook calls all six and fails loudly on a missing one, and because all six are
-cheap and staged-only.
+The pre-commit hook runs every scanner present in `.githooks/lib/`, and
+nothing else. Each scanner below is its own component: copy the hook once
+(1), then any scanner you want (1a to 1f), in any combination. A scanner you
+did not copy is simply not run. `scaffold-doctor.sh` tells "not adopted"
+from "removed after install" using the installer's manifest, so a hand-picked
+subset is never reported as broken.
 
-| Scanner           | Blocks                                                                                 |
-| ----------------- | -------------------------------------------------------------------------------------- |
-| check-secrets     | credential-shaped strings: 42 rules covering AWS, GitHub, Slack, private keys and more |
-| check-filenames   | committing `.env`, `id_rsa`, `*.pem`, keystores, by name                               |
-| check-patterns    | forbidden source patterns from `.forbidden-patterns/*.txt`, per language (see entry 2) |
-| check-hygiene     | invisible unicode, bidi controls, merge-conflict markers, other smuggling              |
-| check-large-files | files over 512,000 bytes (override in `.scaffold.toml`)                                |
-| check-size        | files over 500 lines (override in `.scaffold.toml`)                                    |
-
-**Blast radius:** staged files only. Safe on any existing codebase. Existing
-committed secrets are not touched; see README "Already have commit history?"
-for a one-time scan.
+All six scanners read the files staged in the commit being made and nothing
+else, so every one of them is safe on an existing codebase. They share one
+contract: NUL-separated staged paths on stdin, non-zero exit blocks the
+commit. `scaffold-config` is an optional sibling that reads `.scaffold.toml`
+overrides (entry 13); without it every rule runs at its default.
 
 **Prerequisites:** bash, git. No other tool.
 
-```sh adopt=core
-mkdir -p .githooks/lib .forbidden-patterns
+```sh adopt=hook
+mkdir -p .githooks/lib
 cp "$SCAFFOLD/githooks/pre-commit.template" .githooks/pre-commit
-for c in check-size check-large-files check-patterns check-filenames check-secrets check-hygiene scaffold-config; do
-  cp "$SCAFFOLD/githooks/lib/$c.template" ".githooks/lib/$c"
-done
-chmod +x .githooks/pre-commit .githooks/lib/*
-cp "$SCAFFOLD/forbidden-patterns/secrets.txt.template" .forbidden-patterns/secrets.txt
-cp "$SCAFFOLD/forbidden-patterns/shell.txt.template"   .forbidden-patterns/shell.txt
+cp "$SCAFFOLD/githooks/lib/scaffold-config.template" .githooks/lib/scaffold-config
+chmod +x .githooks/pre-commit .githooks/lib/scaffold-config
 git config core.hooksPath .githooks
 ```
 
@@ -89,26 +81,187 @@ lefthook, a company hook set), do not overwrite it: chain `.githooks/pre-commit`
 from your existing pre-commit instead. README "Pairing with Husky / lefthook"
 shows both.
 
-The verify step stages a file named `.env` and an oversize file, and asserts
-the commit is refused. It leaves your index as it found it.
-
-```sh verify=core
+```sh verify=hook
 set -e
-git stash list >/dev/null
-printf 'x=1\n' > .env.scaffold-verify && mv .env.scaffold-verify .env
-head -c 600000 /dev/zero > scaffold-verify.bin
-git add -f .env scaffold-verify.bin
-if git -c commit.gpgsign=false commit -q -m "scaffold verify" >/dev/null 2>&1; then
-  git reset -q --soft HEAD~1; git reset -q .env scaffold-verify.bin; rm -f .env scaffold-verify.bin
-  echo "NOT ARMED: the commit with .env and a 600 KB file went through"; exit 1
-fi
-git reset -q .env scaffold-verify.bin; rm -f .env scaffold-verify.bin
-echo "verified: commit guard core refused .env and a 600 KB file"
+[ "$(git config --get core.hooksPath)" = ".githooks" ] || { echo "NOT WIRED: core.hooksPath is not .githooks"; exit 1; }
+test -x .githooks/pre-commit
+printf 'ok\n' > scaffold-verify.txt && git add scaffold-verify.txt
+git -c commit.gpgsign=false commit -q -m "scaffold verify: hook runs" >/dev/null
+git reset -q --soft HEAD~1 && git reset -q scaffold-verify.txt && rm -f scaffold-verify.txt
+echo "verified: the hook is wired and runs on commit (no scanners adopted yet, so it blocks nothing)"
 ```
 
-```sh remove=core
+```sh remove=hook
 git config --unset core.hooksPath
-rm -rf .githooks .forbidden-patterns
+rm -rf .githooks
+```
+
+### 1a. check-secrets
+
+Blocks credential-shaped strings in staged content: 42 rules covering AWS,
+GitHub, Slack, Stripe, private keys, URL-embedded passwords and more. Reads
+its rules from `.forbidden-patterns/secrets.txt`, which ships with it and is
+scanned itself, so a secret parked in the pattern file is caught too.
+
+```sh adopt=scanner-secrets
+mkdir -p .githooks/lib .forbidden-patterns
+cp "$SCAFFOLD/githooks/lib/check-secrets.template" .githooks/lib/check-secrets
+cp "$SCAFFOLD/forbidden-patterns/secrets.txt.template" .forbidden-patterns/secrets.txt
+chmod +x .githooks/lib/check-secrets
+```
+
+The verify step assembles an AWS-shaped key at run time so that this
+document does not itself contain one.
+
+```sh verify=scanner-secrets
+set -e
+printf 'key = "AKIA%s"\n' 'IOSFODNN7EXAMPLE' > scaffold_verify.cfg && git add scaffold_verify.cfg
+if git -c commit.gpgsign=false commit -q -m "scaffold verify" >/dev/null 2>&1; then
+  git reset -q --soft HEAD~1; git reset -q scaffold_verify.cfg; rm -f scaffold_verify.cfg
+  echo "NOT ARMED: an AWS-shaped key was committed"; exit 1
+fi
+git reset -q scaffold_verify.cfg; rm -f scaffold_verify.cfg
+echo "verified: check-secrets refused an AWS-shaped key"
+```
+
+```sh remove=scanner-secrets
+rm -f .githooks/lib/check-secrets .forbidden-patterns/secrets.txt
+```
+
+### 1b. check-filenames
+
+Blocks files by name: `.env` and variants, `id_rsa` and other SSH private
+keys, `*.pem`, `*.key`, `.p12`, `.pfx`, `.jks`, `.ppk`. `.env.example` and
+`.env.template` are allowed.
+
+```sh adopt=scanner-filenames
+mkdir -p .githooks/lib
+cp "$SCAFFOLD/githooks/lib/check-filenames.template" .githooks/lib/check-filenames
+chmod +x .githooks/lib/check-filenames
+```
+
+```sh verify=scanner-filenames
+set -e
+printf 'x=1\n' > .env.scaffold-verify && mv .env.scaffold-verify .env && git add -f .env
+if git -c commit.gpgsign=false commit -q -m "scaffold verify" >/dev/null 2>&1; then
+  git reset -q --soft HEAD~1; git reset -q .env; rm -f .env
+  echo "NOT ARMED: a .env file was committed"; exit 1
+fi
+git reset -q .env; rm -f .env
+echo "verified: check-filenames refused .env"
+```
+
+```sh remove=scanner-filenames
+rm -f .githooks/lib/check-filenames
+```
+
+### 1c. check-patterns
+
+Blocks forbidden source patterns per language, read from
+`.forbidden-patterns/<lang>.txt` (entry 2 lists them). With no pattern files
+present it scans nothing; adopt at least one. The adopt block below takes
+`backend.txt` (Python); swap in the languages you write.
+
+```sh adopt=scanner-patterns
+mkdir -p .githooks/lib .forbidden-patterns
+cp "$SCAFFOLD/githooks/lib/check-patterns.template" .githooks/lib/check-patterns
+chmod +x .githooks/lib/check-patterns
+cp "$SCAFFOLD/forbidden-patterns/backend.txt.template" .forbidden-patterns/backend.txt
+```
+
+```sh verify=scanner-patterns
+set -e
+printf 'import os\nbreakpoint()\n' > scaffold_verify.py && git add scaffold_verify.py
+if git -c commit.gpgsign=false commit -q -m "scaffold verify" >/dev/null 2>&1; then
+  git reset -q --soft HEAD~1; git reset -q scaffold_verify.py; rm -f scaffold_verify.py
+  echo "NOT ARMED: a breakpoint() in a .py file was committed"; exit 1
+fi
+git reset -q scaffold_verify.py; rm -f scaffold_verify.py
+echo "verified: check-patterns refused breakpoint() in a staged .py file"
+```
+
+```sh remove=scanner-patterns
+rm -f .githooks/lib/check-patterns .forbidden-patterns/backend.txt
+```
+
+### 1d. check-hygiene
+
+Blocks invisible and direction-changing Unicode (Trojan Source), leftover
+merge-conflict markers, and case-only filename collisions.
+
+```sh adopt=scanner-hygiene
+mkdir -p .githooks/lib
+cp "$SCAFFOLD/githooks/lib/check-hygiene.template" .githooks/lib/check-hygiene
+chmod +x .githooks/lib/check-hygiene
+```
+
+The verify step writes a right-to-left override byte sequence at run time.
+
+```sh verify=scanner-hygiene
+set -e
+printf 'total = 1 \342\200\256// reversed\n' > scaffold_verify.txt && git add scaffold_verify.txt
+if git -c commit.gpgsign=false commit -q -m "scaffold verify" >/dev/null 2>&1; then
+  git reset -q --soft HEAD~1; git reset -q scaffold_verify.txt; rm -f scaffold_verify.txt
+  echo "NOT ARMED: a bidi override character was committed"; exit 1
+fi
+git reset -q scaffold_verify.txt; rm -f scaffold_verify.txt
+echo "verified: check-hygiene refused a bidi override character"
+```
+
+```sh remove=scanner-hygiene
+rm -f .githooks/lib/check-hygiene
+```
+
+### 1e. check-large-files
+
+Blocks any staged file over 512,000 bytes (raise or lower it per path in
+`.scaffold.toml`, entry 13). Large binaries bloat history permanently.
+
+```sh adopt=scanner-large-files
+mkdir -p .githooks/lib
+cp "$SCAFFOLD/githooks/lib/check-large-files.template" .githooks/lib/check-large-files
+chmod +x .githooks/lib/check-large-files
+```
+
+```sh verify=scanner-large-files
+set -e
+head -c 600000 /dev/zero > scaffold-verify.bin && git add scaffold-verify.bin
+if git -c commit.gpgsign=false commit -q -m "scaffold verify" >/dev/null 2>&1; then
+  git reset -q --soft HEAD~1; git reset -q scaffold-verify.bin; rm -f scaffold-verify.bin
+  echo "NOT ARMED: a 600 KB file was committed"; exit 1
+fi
+git reset -q scaffold-verify.bin; rm -f scaffold-verify.bin
+echo "verified: check-large-files refused a 600 KB file"
+```
+
+```sh remove=scanner-large-files
+rm -f .githooks/lib/check-large-files
+```
+
+### 1f. check-size
+
+Blocks any staged source file over 500 lines, the cap that keeps a file
+inside an agent's context window (override per path in `.scaffold.toml`).
+
+```sh adopt=scanner-size
+mkdir -p .githooks/lib
+cp "$SCAFFOLD/githooks/lib/check-size.template" .githooks/lib/check-size
+chmod +x .githooks/lib/check-size
+```
+
+```sh verify=scanner-size
+set -e
+awk 'BEGIN { for (i = 0; i < 501; i++) print "x = " i }' > scaffold_verify.py && git add scaffold_verify.py
+if git -c commit.gpgsign=false commit -q -m "scaffold verify" >/dev/null 2>&1; then
+  git reset -q --soft HEAD~1; git reset -q scaffold_verify.py; rm -f scaffold_verify.py
+  echo "NOT ARMED: a 501-line file was committed"; exit 1
+fi
+git reset -q scaffold_verify.py; rm -f scaffold_verify.py
+echo "verified: check-size refused a 501-line file"
+```
+
+```sh remove=scanner-size
+rm -f .githooks/lib/check-size
 ```
 
 ## 2. Language pattern files
@@ -138,7 +291,7 @@ fires only when you next touch that file. To see how often that would be,
 run the assess script, or disable a single rule in `.scaffold.toml` (entry 13)
 rather than deleting the file.
 
-**Prerequisites:** entry 1.
+**Prerequisites:** entry 1c (check-patterns).
 
 ```sh adopt=patterns
 cp "$SCAFFOLD/forbidden-patterns/backend.txt.template"  .forbidden-patterns/backend.txt
@@ -164,9 +317,9 @@ rm -f .forbidden-patterns/backend.txt .forbidden-patterns/frontend.txt
 
 ## 3. CI mirror of the commit guard
 
-`lint.yml` runs the same six scanners server-side on every pull request and
-push, using the same scripts in `.githooks/lib/`, so the hook and CI cannot
-drift. Secrets and filenames are scanned whole-tree; the quality gates run on
+`lint.yml` runs every scanner present in `.githooks/lib/` server-side on
+every pull request and push, the same discovery loop the hook runs, so the
+hook and CI cannot drift and a hand-picked subset is mirrored as-is. Secrets and filenames are scanned whole-tree; the quality gates run on
 changed files only. It also runs ruff, eslint, prettier, tsc and phpcs when
 their configs are present (entries 6 to 12 decide that).
 
@@ -174,7 +327,7 @@ their configs are present (entries 6 to 12 decide that).
 and filename scans (a leaked credential anywhere fails the job, which is the
 point). The linters follow their own configs' scope.
 
-**Prerequisites:** entry 1, GitHub Actions.
+**Prerequisites:** entry 1 plus at least one scanner, GitHub Actions.
 
 ```sh adopt=ci-lint
 mkdir -p .github/workflows
@@ -189,11 +342,9 @@ the hook calls, so hook and CI agree before the first push.
 
 ```sh verify=ci-lint
 set -e
-for c in check-size check-large-files check-patterns check-filenames check-secrets check-hygiene; do
-  grep -q "lib/$c" .github/workflows/lint.yml || { echo "NOT MIRRORED: lint.yml does not call $c"; exit 1; }
-done
+grep -q 'for check in .githooks/lib/check-\*' .github/workflows/lint.yml || { echo "NOT MIRRORED: lint.yml does not run the scanners present in lib/"; exit 1; }
 if command -v actionlint >/dev/null 2>&1; then actionlint -shellcheck= -pyflakes= .github/workflows/lint.yml; fi
-echo "verified: lint.yml calls all six scanners the hook calls"
+echo "verified: lint.yml runs every scanner present in .githooks/lib/, the same loop the hook runs"
 ```
 
 ```sh remove=ci-lint
@@ -521,8 +672,9 @@ credential file into context. `.claude/settings.json` wires it for Claude Code;
 **Blast radius:** the agent's tool calls in this repo. No effect on commits or
 files.
 
-**Prerequisites:** entry 1's `secrets.txt` and `shell.txt` (the hook reads
-them), `jq` on PATH (fails open without it, and says so).
+**Prerequisites:** `.forbidden-patterns/secrets.txt` (entry 1a) and
+`shell.txt` (copy it from `$SCAFFOLD/forbidden-patterns/shell.txt.template`),
+`jq` on PATH (fails open without it, and says so).
 
 ```sh adopt=agent-guard
 cp "$SCAFFOLD/githooks/lib/agent-precheck.template" .githooks/lib/agent-precheck

--- a/README.md
+++ b/README.md
@@ -52,7 +52,21 @@ What the scaffold doesn't try to solve: parallel-session collisions, context-win
 
 > **AI agents, and anyone adopting this on an existing codebase:** you do not need the installer. [COMPONENTS.md](COMPONENTS.md) lists every component with what it blocks, its blast radius (staged files only, or project-wide), the exact copy commands, a verify command that proves the guard is armed, and how to remove it. Start with `npx ai-coding-rules-scaffold assess`, which measures what each component would flag in this repo and writes nothing. Then pick what you want, run the adopt block, run the verify block, then `scaffold-doctor.sh`. The project-wide entries (tsconfig, ruff, eslint) carry a measurement command to run first with nothing copied; that is how you avoid thousands of findings on day one. The installer below performs the same copies for you in one go. If it errors or is blocked, stop and show your user the error instead of working around it.
 
-**Quickest — `npx`, no clone.** From your project root:
+**Recommended: clone it, then take what you want.** No package manager, no
+installer. Clone a pinned tag, read [COMPONENTS.md](COMPONENTS.md), and copy
+the components you want with the commands in each entry; every entry has a
+verify step, and `scaffold-assess.sh` measures what each would flag first.
+
+```sh
+git clone --branch v0.17.0 https://github.com/Sting25/ai-coding-rules-scaffold ~/src/ai-coding-rules-scaffold
+export SCAFFOLD=~/src/ai-coding-rules-scaffold
+bash "$SCAFFOLD/scaffold-assess.sh"        # from your project root: what would each component flag?
+```
+
+The rest of this section is the installer, which does the same copies in one
+go. It is a convenience and the paths below are alternatives to each other.
+
+**`npx`, no clone.** From your project root:
 
 ```sh
 npx ai-coding-rules-scaffold                  # auto-detects Python / JS

--- a/githooks/pre-commit.template
+++ b/githooks/pre-commit.template
@@ -173,18 +173,20 @@ cleanup() {
 trap cleanup EXIT
 
 FAILED=0
-"$LIB/check-size"        <"$STAGED_LIST" || FAILED=1
-"$LIB/check-large-files" <"$STAGED_LIST" || FAILED=1
-"$LIB/check-patterns"    <"$STAGED_LIST" || FAILED=1
-"$LIB/check-filenames"   <"$STAGED_LIST" || FAILED=1
-"$LIB/check-secrets"     <"$STAGED_LIST" || FAILED=1
-"$LIB/check-hygiene"     <"$STAGED_LIST" || FAILED=1
-# Opt-in only: present iff installed with `install.sh --gitleaks-hook`. The
-# existence guard is the opt-in switch — a project that didn't opt in has no
-# such file and skips it entirely.
-if [ -x "$LIB/check-gitleaks" ]; then
-  "$LIB/check-gitleaks" <"$STAGED_LIST" || FAILED=1
-fi
+# Run every scanner that is PRESENT in lib/, not a fixed list. Each scanner is
+# a separate component (COMPONENTS.md entries 1a to 1f): a project that copied
+# only check-secrets gets exactly that check, and a missing scanner is "not
+# adopted", not an error. The trade-off is that a DELETED scanner also goes
+# quiet here; scaffold-doctor.sh closes that hole, reporting a scanner the
+# install manifest recorded but that is no longer on disk as a gap. The
+# gitleaks pass rides the same rule (present iff `--gitleaks-hook` or entry
+# 16 copied it). check-red-green and check-mutation-diff are Python tools
+# driven by test-guard.yml with their own arguments, never from here.
+for check in "$LIB"/check-*; do
+  [ -x "$check" ] || continue
+  case "${check##*/}" in check-red-green|check-mutation-diff) continue ;; esac
+  "$check" <"$STAGED_LIST" || FAILED=1
+done
 
 # Project-local checks — the supported extension point (issue #72). Every
 # executable in .githooks/local.d/ runs here under the SAME contract as the

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "scaffold-doctor.sh",
     "scaffold-assess.sh",
     "scaffold-doctor-gates.sh",
+    "scaffold-doctor-checks.sh",
     "bin/",
     "githooks/",
     "forbidden-patterns/",

--- a/scaffold-doctor-checks.sh
+++ b/scaffold-doctor-checks.sh
@@ -1,0 +1,93 @@
+# shellcheck shell=bash
+# scaffold-doctor-checks.sh — section 3 of scaffold-doctor.sh: the shipped
+# checks (present, executable, and CALLED), and the opt-in checks' call
+# sites. SOURCED by scaffold-doctor.sh at the point section 3 used to be
+# inline, so it runs with the doctor's counters, helpers and `set -euo
+# pipefail`; extracted for the same reason scaffold-doctor-gates.sh was, the
+# doctor's own 500-line cap, when the discovery-loop and manifest-aware
+# absence logic (COMPONENTS.md entries 1a to 1f) pushed it over. Not a
+# standalone script: it has no shebang on purpose.
+
+# --- 3. the shipped checks --------------------------------------------------
+# The orchestrator calls these six unguarded, so a missing or non-executable
+# one makes the hook error out and BLOCK the commit — noisy, not silent, but
+# still broken, and worth naming precisely rather than leaving to a stack trace.
+#
+# Present and executable is still not the same as RUNNING, which is the whole
+# premise of this script and was the one thing this section did not test. Issue
+# #72 is exactly that shape: an upgrade preserved a customized
+# .github/workflows/lint.yml whose check-large-files call site was never there,
+# the script stayed on disk, and this report said "lib/check-large-files armed
+# ... 0 gaps" while an 800 KB file committed clean. So each check is now matched
+# against its CALLERS too.
+#
+# check_called_in NAME FILE... (is NAME invoked in any of those files?)
+# Comment lines are stripped first: every one of these files discusses the
+# checks by name in its own header, and a header is not a call site. The name
+# must match as a whole word so one check's name cannot satisfy another's.
+check_called_in() {
+  local name=$1
+  shift
+  local re="(^|[^A-Za-z0-9_.-])${name}([^A-Za-z0-9_.-]|\$)" f body
+  for f in "$@"; do
+    [ -f "$f" ] || continue
+    body=$(grep -vE '^[[:space:]]*#' "$f" 2>/dev/null || true)
+    if grep -qE "$re" <<<"$body"; then
+      return 0
+    fi
+    # The hook and lint.yml run every present lib/check-* through a discovery
+    # loop rather than naming each scanner (COMPONENTS.md entries 1a to 1f),
+    # so a `check-*` glob over lib/ is a call site for every check-* name.
+    case "$name" in check-*)
+      if grep -q -e "\$LIB\"/check-\*" -e "\$LIB/check-\*" -e ".githooks/lib/check-\*" <<<"$body"; then
+        return 0
+      fi ;;
+    esac
+  done
+  return 1
+}
+section "shipped checks"
+for chk in check-size check-large-files check-patterns check-filenames check-secrets check-hygiene; do
+  if [ ! -f ".githooks/lib/$chk" ]; then
+    # Absent is two different things. The hook runs whatever is present, so a
+    # scanner that was never adopted is a note (COMPONENTS.md lets a project
+    # take a subset). One the installer RECORDED in its manifest and that is
+    # now gone was removed, and the hook went quiet about it: that is a gap.
+    if [ -f .githooks/.scaffold-manifest ] && grep -qE "[[:space:]]\.githooks/lib/$chk\$" .githooks/.scaffold-manifest; then
+      gap "lib/$chk was installed (recorded in .githooks/.scaffold-manifest) and is now missing — the hook silently skips it" \
+          "re-run install.sh to restore it, or remove its manifest line if dropping it was deliberate"
+    else
+      note "lib/$chk not adopted (COMPONENTS.md entry 1) — the hook runs only the scanners present"
+    fi
+  elif [ ! -x ".githooks/lib/$chk" ]; then
+    gap "lib/$chk is not executable — every commit will error on it" "chmod +x .githooks/lib/$chk"
+  elif ! check_called_in "$chk" .githooks/pre-commit .githooks/commit-msg \
+                         .githooks/local.d/* .github/workflows/*.yml; then
+    gap "lib/$chk is installed and executable but nothing calls it: no invocation in .githooks/pre-commit or .github/workflows/, so it is decoration and the commits it should block are not blocked (issue #72)" \
+        "re-run install.sh to restore the call sites, then re-apply any customization you had made to the hook or workflow"
+  elif [ -f .github/workflows/lint.yml ] && ! check_called_in "$chk" .github/workflows/*.yml; then
+    # Half-wired, not inert: the hook still runs it locally, so this is a note
+    # rather than a gap. But --no-verify, a push from a machine without the
+    # hooks wired, and a web-UI edit all reach main with nobody having run it,
+    # which is what makes it worth saying out loud even under --quiet.
+    note_always "lib/$chk runs in the pre-commit hook but NO CI call site invokes it: a --no-verify commit or a push from an unwired clone reaches main unchecked (issue #72)"
+  else
+    ok "lib/$chk armed"
+  fi
+done
+# The opt-in checks arrive only with their flag, so absence is not a gap. Once
+# one IS on disk the same rule applies: a check nothing calls is decoration,
+# whichever flag installed it.
+for chk_path in .githooks/lib/check-*; do
+  [ -f "$chk_path" ] || continue
+  chk=$(basename "$chk_path")
+  case "$chk" in
+    check-size|check-large-files|check-patterns|check-filenames|check-secrets|check-hygiene) continue ;;
+  esac
+  if ! check_called_in "$chk" .githooks/pre-commit .githooks/commit-msg \
+                       .githooks/local.d/* .github/workflows/*.yml; then
+    gap "lib/$chk is installed but nothing calls it: no invocation in .githooks/ or .github/workflows/, so it never runs" \
+        "re-run install.sh with the flag that installed it, to restore its call site"
+  fi
+done
+

--- a/scaffold-doctor-gates.sh
+++ b/scaffold-doctor-gates.sh
@@ -55,8 +55,11 @@ elif [ ! -f .github/workflows/lint.yml ]; then
 # Anchored past any leading '#': lint.yml is YAML, and a job hollowed out to a
 # comment that still NAMES the scripts it no longer runs would otherwise read
 # as armed — the exact "present but not running" shape this script exists for.
-elif grep -qE '^[[:space:]]*[^#[:space:]].*check-secrets' .github/workflows/lint.yml &&
-     grep -qE '^[[:space:]]*[^#[:space:]].*check-patterns' .github/workflows/lint.yml; then
+elif { grep -qE '^[[:space:]]*[^#[:space:]].*check-secrets' .github/workflows/lint.yml &&
+       grep -qE '^[[:space:]]*[^#[:space:]].*check-patterns' .github/workflows/lint.yml; } ||
+     grep -qE '^[[:space:]]*[^#[:space:]].*\.githooks/lib/check-\*' .github/workflows/lint.yml; then
+  # Either the older lint.yml that names the scanners, or the discovery loop
+  # over lib/check-* that runs whatever a project adopted (same loop as the hook).
   ok "lint.yml re-runs the guardrail checks server-side"
 else
   gap ".github/workflows/lint.yml exists but its guardrails job no longer invokes lib/check-secrets and lib/check-patterns — CI is not mirroring the hook" \

--- a/scaffold-doctor.sh
+++ b/scaffold-doctor.sh
@@ -72,7 +72,7 @@ SCAFFOLD_DIR="$(cd "$(dirname "$0")" && pwd)"
 # linked onto PATH), computed here: a relative $0 is relative to the caller's cwd.
 DOCTOR_DIR="$SCAFFOLD_DIR"; _d0=$0
 [ ! -L "$_d0" ] || { _t=$(readlink "$_d0"); case $_t in /*) _d0=$_t ;; *) _d0=${_d0%/*}/$_t ;; esac; }
-[ -f "$DOCTOR_DIR/scaffold-doctor-gates.sh" ] || [ "${_d0%/*}" = "$_d0" ] ||
+{ [ -f "$DOCTOR_DIR/scaffold-doctor-gates.sh" ] && [ -f "$DOCTOR_DIR/scaffold-doctor-checks.sh" ]; } || [ "${_d0%/*}" = "$_d0" ] ||
   DOCTOR_DIR="$(cd "${_d0%/*}" 2>/dev/null && pwd)" || DOCTOR_DIR="$SCAFFOLD_DIR"
 
 # The shipped checks read their config by BARE RELATIVE PATH
@@ -167,71 +167,15 @@ if [ -f .githooks/commit-msg ] && [ ! -x .githooks/commit-msg ]; then
 fi
 
 # --- 3. the shipped checks --------------------------------------------------
-# The orchestrator calls these six unguarded, so a missing or non-executable
-# one makes the hook error out and BLOCK the commit — noisy, not silent, but
-# still broken, and worth naming precisely rather than leaving to a stack trace.
-#
-# Present and executable is still not the same as RUNNING, which is the whole
-# premise of this script and was the one thing this section did not test. Issue
-# #72 is exactly that shape: an upgrade preserved a customized
-# .github/workflows/lint.yml whose check-large-files call site was never there,
-# the script stayed on disk, and this report said "lib/check-large-files armed
-# ... 0 gaps" while an 800 KB file committed clean. So each check is now matched
-# against its CALLERS too.
-#
-# check_called_in NAME FILE... (is NAME invoked in any of those files?)
-# Comment lines are stripped first: every one of these files discusses the
-# checks by name in its own header, and a header is not a call site. The name
-# must match as a whole word so one check's name cannot satisfy another's.
-check_called_in() {
-  local name=$1
-  shift
-  local re="(^|[^A-Za-z0-9_.-])${name}([^A-Za-z0-9_.-]|\$)" f body
-  for f in "$@"; do
-    [ -f "$f" ] || continue
-    body=$(grep -vE '^[[:space:]]*#' "$f" 2>/dev/null || true)
-    if grep -qE "$re" <<<"$body"; then
-      return 0
-    fi
-  done
-  return 1
-}
-section "shipped checks"
-for chk in check-size check-large-files check-patterns check-filenames check-secrets check-hygiene; do
-  if [ ! -f ".githooks/lib/$chk" ]; then
-    gap "lib/$chk is missing — the hook calls it unguarded and every commit will error" \
-        "re-run install.sh to restore it"
-  elif [ ! -x ".githooks/lib/$chk" ]; then
-    gap "lib/$chk is not executable — every commit will error on it" "chmod +x .githooks/lib/$chk"
-  elif ! check_called_in "$chk" .githooks/pre-commit .githooks/commit-msg \
-                         .githooks/local.d/* .github/workflows/*.yml; then
-    gap "lib/$chk is installed and executable but nothing calls it: no invocation in .githooks/pre-commit or .github/workflows/, so it is decoration and the commits it should block are not blocked (issue #72)" \
-        "re-run install.sh to restore the call sites, then re-apply any customization you had made to the hook or workflow"
-  elif [ -f .github/workflows/lint.yml ] && ! check_called_in "$chk" .github/workflows/*.yml; then
-    # Half-wired, not inert: the hook still runs it locally, so this is a note
-    # rather than a gap. But --no-verify, a push from a machine without the
-    # hooks wired, and a web-UI edit all reach main with nobody having run it,
-    # which is what makes it worth saying out loud even under --quiet.
-    note_always "lib/$chk runs in the pre-commit hook but NO CI call site invokes it: a --no-verify commit or a push from an unwired clone reaches main unchecked (issue #72)"
-  else
-    ok "lib/$chk armed"
-  fi
-done
-# The opt-in checks arrive only with their flag, so absence is not a gap. Once
-# one IS on disk the same rule applies: a check nothing calls is decoration,
-# whichever flag installed it.
-for chk_path in .githooks/lib/check-*; do
-  [ -f "$chk_path" ] || continue
-  chk=$(basename "$chk_path")
-  case "$chk" in
-    check-size|check-large-files|check-patterns|check-filenames|check-secrets|check-hygiene) continue ;;
-  esac
-  if ! check_called_in "$chk" .githooks/pre-commit .githooks/commit-msg \
-                       .githooks/local.d/* .github/workflows/*.yml; then
-    gap "lib/$chk is installed but nothing calls it: no invocation in .githooks/ or .github/workflows/, so it never runs" \
-        "re-run install.sh with the flag that installed it, to restore its call site"
-  fi
-done
+# Lives in scaffold-doctor-checks.sh (its header says why), SOURCED here so it
+# runs in this shell, in this position, with these counters. Missing, it is a
+# note rather than a hard error, for the same reason the gates module is.
+if [ -f "$DOCTOR_DIR/scaffold-doctor-checks.sh" ]; then
+  # shellcheck source=scaffold-doctor-checks.sh
+  . "$DOCTOR_DIR/scaffold-doctor-checks.sh"
+else
+  note "scaffold-doctor-checks.sh not found next to scaffold-doctor.sh ($DOCTOR_DIR): the shipped-checks section (present, executable, called) is skipped; re-fetch the full scaffold bundle, not just this one file"
+fi
 
 # --- 4. pattern data --------------------------------------------------------
 # check-patterns auto-discovers .forbidden-patterns/*.txt. If the directory is

--- a/tests/cases/18-doctor.sh
+++ b/tests/cases/18-doctor.sh
@@ -251,20 +251,27 @@ doc_case "an executable local.d check is reported armed" 0 \
 
 # (G) The shipped checks are called unguarded by the orchestrator, so a missing
 # one breaks every commit. Loud, not silent — but still worth naming precisely.
-doc_case "a missing shipped check is reported" 1 \
-  "lib/check-hygiene is missing" rm -f .githooks/lib/check-hygiene
+doc_case "a shipped check the manifest recorded but that is now missing is a gap" 1 \
+  "lib/check-hygiene was installed (recorded in .githooks/.scaffold-manifest) and is now missing" rm -f .githooks/lib/check-hygiene
+# Absent AND not in the manifest is a project that adopted a subset by hand
+# (COMPONENTS.md): the hook runs what is present, so this is a note, exit 0.
+doc_case "a shipped check that was never adopted is a note, not a gap" 0 \
+  "lib/check-hygiene not adopted" \
+  bash -c 'rm -f .githooks/lib/check-hygiene && grep -v "lib/check-hygiene\$" .githooks/.scaffold-manifest >m.tmp && mv m.tmp .githooks/.scaffold-manifest'
 
 # ...but on-disk-and-executable was the ONLY thing this section tested, which is
 # issue #72 restated: an upgrade preserved a customized lint.yml with no
 # check-large-files call site, the script sat on disk, and the report said
 # "lib/check-large-files armed ... 0 gaps" while an oversized file committed
 # clean. A check nothing calls is decoration, and the doctor has to say so.
+# The hook and lint.yml call every present scanner through one discovery
+# loop over lib/check-*, so "no call site" means that loop line is gone.
 doc_drop_ci_callsite() {
-  grep -v 'check-large-files' .github/workflows/lint.yml >lint.tmp && mv lint.tmp .github/workflows/lint.yml
+  grep -v 'lib/check-\*' .github/workflows/lint.yml >lint.tmp && mv lint.tmp .github/workflows/lint.yml
 }
 doc_drop_all_callsites() {
   doc_drop_ci_callsite
-  grep -v 'check-large-files' .githooks/pre-commit >pc.tmp && mv pc.tmp .githooks/pre-commit
+  grep -v -F "\"\$LIB\"/check-*" .githooks/pre-commit >pc.tmp && mv pc.tmp .githooks/pre-commit
   chmod +x .githooks/pre-commit
 }
 
@@ -293,13 +300,17 @@ DOCT=$(doc_project)
 ( cd "$DOCT" && doc_drop_ci_callsite ) >/dev/null 2>&1
 doc_rc=0
 ( cd "$DOCT" && "$SCAFFOLD_DIR/scaffold-doctor.sh" --quiet ) >"$HOOK_OUT" 2>&1 || doc_rc=$?
-if [ "$doc_rc" -eq 0 ] && grep -qF "0 gaps" "$HOOK_OUT" \
-   && grep -qF "lib/check-large-files runs in the pre-commit hook but NO CI call site" "$HOOK_OUT"; then
-  echo "  ✓ a check with no CI call site is a --quiet-visible note, not a gap"
+# With one discovery loop there is no per-scanner CI call site to lose: losing
+# the loop loses the whole server-side mirror, which is a gap (a --no-verify
+# commit reaches main unchecked), and --quiet must still show it with its
+# section name so a one-line report is not a green one.
+if [ "$doc_rc" -eq 1 ] \
+   && grep -qF "[server-side backstop] .github/workflows/lint.yml exists but its guardrails job no longer invokes" "$HOOK_OUT"; then
+  echo "  ✓ a lint.yml that lost the scanner loop is a --quiet-visible gap, exit 1"
   PASS=$((PASS + 1))
 else
-  echo "  ✗ missing CI call site misreported under --quiet (exit $doc_rc)"
-  sed 's/^/      /' "$HOOK_OUT"
+  echo "  ✗ missing CI scanner loop misreported under --quiet (exit $doc_rc)"
+  sed 's/^/      /' "$HOOK_OUT" | head -6
   FAIL=$((FAIL + 1))
 fi
 rm -rf "$DOCT"

--- a/tests/cases/38-components-catalog.sh
+++ b/tests/cases/38-components-catalog.sh
@@ -77,7 +77,7 @@ else
   done
   # The catalog's own count must match what this case exercised, so a new
   # entry without adopt/verify fences cannot hide behind the ones that have them.
-  _cc_headings=$(grep -cE '^## [0-9]+\. ' "$_cc_doc")
+  _cc_headings=$(grep -cE '^##+ [0-9]+[a-z]?\. ' "$_cc_doc")
   if [ "$_cc_headings" -eq "${#_cc_names[@]}" ]; then
     echo "  ✓ every numbered entry ($_cc_headings) has an adopt block"
     PASS=$((PASS + 1))
@@ -86,6 +86,28 @@ else
     FAIL=$((FAIL + 1))
   fi
   rm -rf "$_cc_repo"
+  # Each scanner alone: a fresh repo, the hook (entry 1) plus ONE scanner
+  # (1a to 1f), then that scanner's verify. This is the promise that a
+  # project may take a subset; the cumulative pass above cannot prove it,
+  # because there every earlier scanner is already present.
+  for _cc_name in "${_cc_names[@]}"; do
+    case "$_cc_name" in scanner-*) ;; *) continue ;; esac
+    _cc_repo=$(mktemp -d)
+    ( cd "$_cc_repo" && git init -q && git config user.email t@test.local && git config user.name "Scaffold Test" \
+        && git config commit.gpgsign false && printf '# solo fixture\n' > README.md && git add README.md && git commit -q -m "init" )
+    if ( cd "$_cc_repo" && SCAFFOLD="$SCAFFOLD_DIR" bash -e -c "$(_cc_block adopt hook)" && SCAFFOLD="$SCAFFOLD_DIR" bash -e -c "$(_cc_block adopt "$_cc_name")" ) >"$HOOK_OUT" 2>&1 \
+       && ( cd "$_cc_repo" && SCAFFOLD="$SCAFFOLD_DIR" bash -c "$(_cc_block verify "$_cc_name")" ) >"$HOOK_OUT" 2>&1 \
+       && grep -q '^verified:' "$HOOK_OUT" \
+       && [ "$(find "$_cc_repo/.githooks/lib" -name 'check-*' | wc -l | tr -d ' ')" -eq 1 ]; then
+      echo "  ✓ $_cc_name alone (hook + one scanner): $(grep -m1 '^verified:' "$HOOK_OUT" | cut -c11-)"
+      PASS=$((PASS + 1))
+    else
+      echo "  ✗ $_cc_name alone: adopt or verify failed with only the hook and this scanner present"
+      sed 's/^/      /' "$HOOK_OUT" | head -8
+      FAIL=$((FAIL + 1))
+    fi
+    rm -rf "$_cc_repo"
+  done
 fi
 unset _cc_doc _cc_names _cc_name _cc_adopt _cc_verify _cc_nv _cc_repo _cc_headings
 unset -f _cc_block

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -89,7 +89,7 @@ CASE_FLOORS=(
   "15-local-checks.sh:7"
   "16-coverage-gate.sh:6"
   "17-whole-tree-configs.sh:10"
-  "18-doctor.sh:30"
+  "18-doctor.sh:31"
   "19-test-workflow.sh:17"
   "20-paired-artifacts.sh:19"
   "21-ci-workflow-drift.sh:25"
@@ -109,7 +109,7 @@ CASE_FLOORS=(
   "35-workflow-template-validity.sh:15"
   "36-red-green-verdict.sh:3"
   "37-doctor-content-drift.sh:4"
-  "38-components-catalog.sh:20"
+  "38-components-catalog.sh:33"
   "39-scaffold-assess.sh:9"
   "40-doctor-required-checks.sh:6"
 )


### PR DESCRIPTION
## Why

Owner direction: the six core scanners must work individually, with a reader taking only what they want from the catalog. The hook and `lint.yml` named all six and errored on a missing one, so that was not possible.

## What

- **Discovery loop** in `pre-commit.template` and `lint.yml.template`: every executable `lib/check-*` runs; in CI, secrets and filenames whole-tree, the rest changed-files. `check-red-green` and `check-mutation-diff` (Python, driven by test-guard.yml) are excluded; gitleaks keeps present-iff-adopted.
- **COMPONENTS.md**: entry 1 is the hook alone; 1a to 1f are the six scanners, each with adopt/verify/remove. 26 numbered entries. The secrets verify assembles an AWS-shaped key at run time so the document itself contains none; the hygiene verify writes a bidi override byte sequence.
- **Case 38** also adopts each scanner alone (hook + one scanner, asserts exactly one `check-*` on disk) and proves its verify. Red with the loop removed from the hook template, verified.
- **Doctor**: a deleted scanner going quiet is the hole a discovery loop opens; closed: a shipped scanner the install manifest recorded but now missing is a **gap**, never adopted is a **note**. `check_called_in` treats the `lib/check-*` glob as a call site; the server-side check accepts the loop or the older named lines. Section 3 extracted to `scaffold-doctor-checks.sh` (the doctor hit its own 500-line cap at 510; sourced in place like the gates module, missing-module note, added to the npm files list). Case 18: the per-scanner "CI call site dropped" scenario no longer exists; that assertion now checks that losing the loop is a `--quiet`-visible gap.
- **README** leads with clone-and-copy plus `scaffold-assess.sh`; `npx` is one installer alternative.

## Measured

- Suite: 603 passed, 0 failed (was 590). Floors: 18 → 31, 38 → 33.
- Doctor on a fresh `--shell` install: 0 gaps. Line counts: doctor 436, checks module 93, gates 415.
- Catalog self-scan with check-secrets and check-hygiene: exit 0. shellcheck clean.

Installer behavior and a fresh install's file set are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
