### PR TITLE
chore(release): v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 versioning follows [SemVer](https://semver.org/).
 
-## [Unreleased]
+## [v0.18.0] - 2026-09-03
 
 ### Changed
 

--- a/COMPONENTS.md
+++ b/COMPONENTS.md
@@ -21,13 +21,13 @@ Commands assume `$SCAFFOLD` points at a copy of this repository. Pick one:
 
 ```sh
 # a pinned clone (no Node needed)
-git clone --branch v0.17.0 https://github.com/Sting25/ai-coding-rules-scaffold ~/src/ai-coding-rules-scaffold
+git clone --branch v0.18.0 https://github.com/Sting25/ai-coding-rules-scaffold ~/src/ai-coding-rules-scaffold
 export SCAFFOLD=~/src/ai-coding-rules-scaffold
 ```
 
 ```sh
 # or the published npm tarball, unpacked, no clone
-cd "$(mktemp -d)" && npm pack ai-coding-rules-scaffold@0.17.0 --silent && tar xzf ai-coding-rules-scaffold-*.tgz
+cd "$(mktemp -d)" && npm pack ai-coding-rules-scaffold@0.18.0 --silent && tar xzf ai-coding-rules-scaffold-*.tgz
 export SCAFFOLD="$PWD/package"
 ```
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ the components you want with the commands in each entry; every entry has a
 verify step, and `scaffold-assess.sh` measures what each would flag first.
 
 ```sh
-git clone --branch v0.17.0 https://github.com/Sting25/ai-coding-rules-scaffold ~/src/ai-coding-rules-scaffold
+git clone --branch v0.18.0 https://github.com/Sting25/ai-coding-rules-scaffold ~/src/ai-coding-rules-scaffold
 export SCAFFOLD=~/src/ai-coding-rules-scaffold
 bash "$SCAFFOLD/scaffold-assess.sh"        # from your project root: what would each component flag?
 ```
@@ -95,7 +95,7 @@ somewhere stable:
 
 ```sh
 # Recommended: pin to a tagged release for reproducibility
-git clone --branch v0.17.0 https://github.com/Sting25/ai-coding-rules-scaffold ~/src/ai-coding-rules-scaffold
+git clone --branch v0.18.0 https://github.com/Sting25/ai-coding-rules-scaffold ~/src/ai-coding-rules-scaffold
 # Or track main if you want the latest changes
 git clone https://github.com/Sting25/ai-coding-rules-scaffold ~/src/ai-coding-rules-scaffold
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-coding-rules-scaffold",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Agent-agnostic coding-rules scaffold: pre-commit + CI guardrails (file size, forbidden patterns, secret/credential scanning, hygiene) that install into your project, plus `scaffold-doctor` to check they are actually armed and not just present. Run via `npx ai-coding-rules-scaffold`. AI agents: run the installer, never hand-copy files.",
   "bin": {
     "ai-coding-rules-scaffold": "bin/cli.js"


### PR DESCRIPTION
Release prep per RELEASING.md step 1. Promotes `[Unreleased]` to `[v0.18.0] - 2026-09-03` (#177, #178). Bumps the README and COMPONENTS.md clone pins, the catalog's npm pack pin, and `package.json`.

Verification: suite green locally, secrets self-lint dry run exit 0, prettier clean, release-notes extraction non-empty. Merge with `--merge`, then tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)