### PR TITLE
chore(homebrew): sync canonical formula to v0.18.0

### DIFF
--- a/packaging/homebrew/ai-coding-rules-scaffold.rb
+++ b/packaging/homebrew/ai-coding-rules-scaffold.rb
@@ -9,8 +9,8 @@
 class AiCodingRulesScaffold < Formula
   desc "Pre-commit and CI guardrails: size, pattern, secret, and hygiene checks"
   homepage "https://github.com/Sting25/ai-coding-rules-scaffold"
-  url "https://github.com/Sting25/ai-coding-rules-scaffold/archive/refs/tags/v0.17.0.tar.gz"
-  sha256 "3dd3f855260eef7803f9771008063bdf67d1ce880289377c8c7451c8a6ac5a10"
+  url "https://github.com/Sting25/ai-coding-rules-scaffold/archive/refs/tags/v0.18.0.tar.gz"
+  sha256 "c8cbe976b90a2189dc966478287a08d9e160541a1ef9a5f73ebb39d42cb01fad"
   license "MIT"
 
   def install


### PR DESCRIPTION
Points the canonical formula at the v0.18.0 tag with the tarball sha256 computed from GitHub's archive, per RELEASING.md step 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)