### PR TITLE
fix(install): skip the root tsconfig.json in monorepos, place it by policy (#163)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 versioning follows [SemVer](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- **install.sh no longer drops a root `tsconfig.json` into a monorepo
+  (#163).** The root file is the switch that makes the pre-commit hook and
+  lint.yml run `tsc --noEmit` over the whole tree, so in a workspaces repo it
+  type-checked every workspace with options written for none of them and
+  blocked every JS/TS commit (12,235 errors measured). The frontend install
+  now places the file by policy, the same logic as COMPONENTS.md entry 10's
+  adopt block: skipped, with the reason named, when `package.json` has a
+  `workspaces` key or `pnpm-workspace.yaml` exists, or when per-directory
+  `tsconfig.json` files already exist (node_modules, vendor and build output
+  are not counted); an existing root file is left alone as before; a plain
+  frontend repo still receives it, now followed by a note saying the hook will
+  type-check the tree and how to undo that, so the placement is never silent.
+  The catalog's adopt block gained the same per-directory check. Case 41
+  covers all six paths and was red before the fix.
+
 ## [v0.18.0] - 2026-09-03
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,17 @@ versioning follows [SemVer](https://semver.org/).
   are not counted); an existing root file is left alone as before; a plain
   frontend repo still receives it, now followed by a note saying the hook will
   type-check the tree and how to undo that, so the placement is never silent.
-  The catalog's adopt block gained the same per-directory check. Case 41
-  covers all six paths and was red before the fix.
+  The catalog's adopt block gained the same per-directory check, and
+  `scaffold-assess.sh` reports the per-directory case by name instead of
+  measuring the template project-wide. Case 41 covers all six installer paths
+  and was red before the fix; case 39 covers the assess line.
+- **The pytest-config probe's node_modules prune was inert.** `find -mindepth
+  2` never evaluates the prune on a depth-1 directory, so a vendored
+  `pyproject.toml` under `node_modules/` counted as the repo's pytest config
+  and suppressed the root `pytest.ini` with a "pytest config in
+  node_modules/x" skip. Found while writing the same probe for
+  `tsconfig.json`; the tsconfig probe was written without it. Case 17 gained
+  the assertion, red before the fix.
 
 ## [v0.18.0] - 2026-09-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,9 @@ versioning follows [SemVer](https://semver.org/).
   `scaffold-assess.sh` reports the per-directory case by name instead of
   measuring the template project-wide. Case 41 covers all six installer paths
   and was red before the fix; case 39 covers the assess line.
-- **The pytest-config probe's node_modules prune was inert.** `find -mindepth
-  2` never evaluates the prune on a depth-1 directory, so a vendored
-  `pyproject.toml` under `node_modules/` counted as the repo's pytest config
+- **The pytest-config probe's node_modules prune was inert.** With
+  `-mindepth 2`, find never evaluates the prune on a depth-1 directory, so a
+  vendored `pyproject.toml` under `node_modules/` counted as the pytest config
   and suppressed the root `pytest.ini` with a "pytest config in
   node_modules/x" skip. Found while writing the same probe for
   `tsconfig.json`; the tsconfig probe was written without it. Case 17 gained

--- a/COMPONENTS.md
+++ b/COMPONENTS.md
@@ -544,6 +544,7 @@ Measure first, nothing copied:
 ```sh adopt=tsconfig
 if [ -f tsconfig.json ]; then echo "tsconfig.json exists, leave it";
 elif grep -q '"workspaces"' package.json 2>/dev/null || [ -f pnpm-workspace.yaml ]; then echo "workspaces monorepo: do not add a root tsconfig.json";
+elif [ -n "$(find . -maxdepth 3 \( -name .git -o -name node_modules -o -name vendor -o -name dist -o -name build \) -prune -o -type f -name tsconfig.json -print 2>/dev/null)" ]; then echo "per-directory tsconfig.json files exist: do not add a root one, it would type-check the whole tree";
 else cp "$SCAFFOLD/tsconfig.json.template" tsconfig.json; fi
 ```
 

--- a/install-lib.sh
+++ b/install-lib.sh
@@ -391,6 +391,45 @@ cp_scaffold_preserve() {
 # flip the mode of a skipped, user-owned file.
 mkx() { if [ -f "$1" ]; then chmod +x "$1"; fi; }
 
+# --- tsconfig.json placement (#163) -----------------------------------------
+# A root tsconfig.json is not just a config file: the pre-commit hook and
+# lint.yml run `tsc --noEmit` over the WHOLE tree whenever one exists. In a
+# workspaces monorepo that checks every workspace with compiler options written
+# for none of them and blocks every JS/TS commit (12,235 errors measured in
+# #163, and the natural reaction, --no-verify, switches off every other
+# guardrail too). So the file is placed by policy, mirroring COMPONENTS.md's
+# adopt=tsconfig block: an existing root file goes through cp_safe unchanged;
+# a workspaces repo or one with per-directory tsconfig files gets a skip that
+# names the reason; a plain repo gets the file plus a note saying what the hook
+# will now do and how to undo it, so the placement is never silent.
+cp_tsconfig_root() {
+  local src=$1 nested
+  if [ -e tsconfig.json ] || [ -L tsconfig.json ]; then
+    cp_safe "$src" "tsconfig.json"
+    return
+  fi
+  if grep -qs '"workspaces"' package.json || [ -f pnpm-workspace.yaml ]; then
+    echo "skip (workspaces monorepo): tsconfig.json  (not writing a root tsconfig.json: with one present the pre-commit hook and lint.yml run 'tsc --noEmit' over the whole tree with its options and ignore each workspace's own config (#163). Type-check per workspace; to layer the strictness on, merge tsconfig.json.template's compilerOptions into each workspace's tsconfig.)"
+    return
+  fi
+  # No -mindepth: with it, find never evaluates the expression for depth-1
+  # entries, so the prune would not fire on ./node_modules and a dependency's
+  # tsconfig.json would count as the repo's. The root file cannot match here:
+  # its existence was handled above.
+  nested=$(find . -maxdepth 3 \
+      \( -name .git -o -name node_modules -o -name .venv -o -name venv -o -name vendor \
+         -o -name dist -o -name build -o -name .claude \) -prune -o \
+      -type f -name tsconfig.json -print 2>/dev/null \
+    | sed -e 's#^\./##' -e 's#/tsconfig\.json$##' | sort | tr '\n' ' ' || true)
+  nested=${nested% }
+  if [ -n "$nested" ]; then
+    echo "skip (tsconfig.json in $nested): tsconfig.json  (not writing a root tsconfig.json: this repo type-checks per directory, and a root file would make the pre-commit hook and lint.yml run 'tsc --noEmit' over the whole tree instead, #163. Merge tsconfig.json.template's compilerOptions into those configs if you want the strictness.)"
+    return
+  fi
+  cp_safe "$src" "tsconfig.json"
+  echo "note:         tsconfig.json installed at the repo root. The pre-commit hook and lint.yml now run 'tsc --noEmit' over every tracked .ts/.tsx on JS/TS commits, with the strict options in that file. If that is not what this repo wants, delete tsconfig.json (or merge its compilerOptions into your own build config) and the type-check step goes back to skipping."
+}
+
 # install_opt_in_* flag bodies (zizmor CI, Socket CI, npm cooldown #117,
 # Claude Skill #118, test-guard #140) and install_test_workflow_ci (#97) live
 # in install-optin.sh, sourced by install.sh alongside this file: first

--- a/install.sh
+++ b/install.sh
@@ -306,7 +306,9 @@ if [ "$MODE" = "frontend" ] || [ "$MODE" = "both" ]; then
   cp_pattern "$SCAFFOLD_DIR/forbidden-patterns/frontend.txt.template" ".forbidden-patterns/frontend.txt"
   # TypeScript config the eslint type-aware rules + the tsc --noEmit hook/CI
   # step already assume (closes the gap where they silently degrade if absent).
-  cp_safe "$SCAFFOLD_DIR/tsconfig.json.template" "tsconfig.json"
+  # The root file is also the switch that turns on whole-tree type-checking,
+  # so it is placed by policy (skipped in monorepos, #163), not copied blindly.
+  cp_tsconfig_root "$SCAFFOLD_DIR/tsconfig.json.template"
   # Formatting: Prettier runs SEPARATELY from eslint by design (strictTypeChecked
   # ships no stylistic rules, so there is no eslint-config-prettier — see the
   # header of eslint.config.js).

--- a/install.sh
+++ b/install.sh
@@ -261,7 +261,11 @@ if [ "$MODE" = "python" ] || [ "$MODE" = "both" ]; then
   # So look one level down as well, bounded: -maxdepth 2 covers backend/ and
   # services/x/ without walking a vendored tree, and prunes the usual suspects.
   # A `find` result is only used as a yes/no signal, so a weird filename cannot
-  # do anything but flip a boolean.
+  # do anything but flip a boolean. No -mindepth on the find: with one, find
+  # never evaluates the prune on a depth-1 directory, so ./node_modules was
+  # walked and a vendored pyproject.toml suppressed the root pytest.ini. A root
+  # config with a pytest section is caught by the grep above, and one without
+  # is filtered by the grep in the loop, so depth 1 adds no false match.
   PYTEST_CFG=""
   if grep -qs -e '\[tool.pytest.ini_options\]' -e '\[pytest\]' pyproject.toml tox.ini setup.cfg 2>/dev/null; then
     PYTEST_CFG="."
@@ -273,7 +277,7 @@ if [ "$MODE" = "python" ] || [ "$MODE" = "both" ]; then
         break
       fi
     done <<EOF_PYCFG
-$(find . -mindepth 2 -maxdepth 3 \
+$(find . -maxdepth 3 \
        \( -name .git -o -name node_modules -o -name .venv -o -name venv \
           -o -name .tox -o -name .claude -o -name vendor \) -prune -o \
        -type f \( -name pyproject.toml -o -name tox.ini -o -name setup.cfg -o -name pytest.ini \) \

--- a/scaffold-assess.sh
+++ b/scaffold-assess.sh
@@ -154,6 +154,8 @@ elif [ -f tsconfig.json ]; then
   echo "  - tsconfig.json: this repo already has one; the scaffold's would not be copied over it"
 elif grep -q '"workspaces"' package.json 2>/dev/null || [ -f pnpm-workspace.yaml ]; then
   echo "  ! tsconfig.json: workspaces monorepo, do not add a root tsconfig.json (#163); per-package configs already type-check"
+elif nested=$(find . -maxdepth 3 \( -name .git -o -name node_modules -o -name vendor -o -name dist -o -name build \) -prune -o -type f -name tsconfig.json -print 2>/dev/null | sed -e 's#^\./##' -e 's#/tsconfig\.json$##' | sort | tr '\n' ' ') && [ -n "$nested" ]; then
+  echo "  ! tsconfig.json: per-directory tsconfig.json in ${nested% }; install.sh will not add a root one (#163), which would type-check the whole tree with these options instead"
 elif command -v node >/dev/null 2>&1 && node -e "require.resolve('typescript/package.json')" >/dev/null 2>&1; then
   n=$(npx --no-install tsc --noEmit -p "$SCAFFOLD_DIR/tsconfig.json.template" 2>&1 | grep -c 'error TS' || true)
   echo "  $([ "$n" -eq 0 ] && echo ✓ || echo ✗) tsconfig.json: $n type error(s) across $js_files JS/TS file(s); the hook runs tsc PROJECT-WIDE on every JS/TS commit, so this is a blocker until zero"

--- a/tests/cases/17-whole-tree-configs.sh
+++ b/tests/cases/17-whole-tree-configs.sh
@@ -38,6 +38,25 @@ else
 fi
 rm -rf "$MONO"
 
+# (T) A pytest config under node_modules is a dependency's, not the repo's, so
+#     it must NOT count as a subdirectory config. The probe prunes node_modules,
+#     but `find -mindepth 2` never evaluates the prune on a depth-1 directory,
+#     so the prune was inert and a vendored pyproject.toml suppressed the root
+#     pytest.ini with a "pytest config in node_modules/x" skip (found while
+#     fixing the same construct for tsconfig.json, #163).
+VEND=$(mktemp -d)
+mkdir -p "$VEND/node_modules/x"
+( cd "$VEND" && git init --quiet && git config user.email test@test.local && git config user.name "Scaffold Test" && git config core.hooksPath .nohooks \
+  && printf '[project]\nname = "x"\n' >pyproject.toml \
+  && printf '[tool.pytest.ini_options]\n' >node_modules/x/pyproject.toml \
+  && "$SCAFFOLD_DIR/install.sh" --python ) >"$HOOK_OUT" 2>&1
+if [ -f "$VEND/pytest.ini" ] && ! grep -q "pytest config in node_modules" "$HOOK_OUT"; then
+  echo "  ✓ a pytest config under node_modules is pruned; the root pytest.ini is still installed"; PASS=$((PASS + 1))
+else
+  echo "  ✗ a vendored pyproject.toml under node_modules must not suppress the root pytest.ini"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$VEND"
+
 # (T) With no pytest config anywhere, the file still installs — the detection
 #     must not be so eager that the feature stops working. Without this, deleting
 #     the install line entirely would pass the assertion above.

--- a/tests/cases/39-scaffold-assess.sh
+++ b/tests/cases/39-scaffold-assess.sh
@@ -153,3 +153,24 @@ fi
 rm -rf "$_sa_alt" "$_sa_repo"
 unset _sa_repo _sa_before _sa_after _sa_locale _sa_rc _sa_plain _sa_alt _sa_with _sa_without _sa_pwith _sa_pwithout
 unset -f _sa_fixture _sa_scan
+
+# (T) Per-directory tsconfig.json files (no workspaces key): the assessment
+#     must say install.sh will not add a root one, naming the directories, and
+#     must NOT measure the template project-wide. A tsconfig.json under
+#     node_modules is a dependency's and must not be named. Mirrors the
+#     installer's cp_tsconfig_root and COMPONENTS.md entry 10 (#163).
+_sa_nested=$(mktemp -d)
+( cd "$_sa_nested" && git init --quiet \
+    && printf '{"name":"fixture","version":"1.0.0","private":true}\n' >package.json \
+    && mkdir -p client server node_modules/dep \
+    && echo '{}' >client/tsconfig.json && echo '{}' >server/tsconfig.json && echo '{}' >node_modules/dep/tsconfig.json \
+    && echo 'export const a = 1;' >client/a.ts \
+    && git add package.json client server \
+    && bash "$SCAFFOLD_DIR/scaffold-assess.sh" ) >"$HOOK_OUT" 2>&1
+if grep -q '! tsconfig.json: per-directory tsconfig.json in client server; install.sh will not add a root one' "$HOOK_OUT" \
+   && ! grep -q 'node_modules' "$HOOK_OUT" && ! grep -q 'tsconfig.json: .* type error' "$HOOK_OUT"; then
+  echo "  ✓ assess names per-directory tsconfig.json files and does not measure the template project-wide"; PASS=$((PASS + 1))
+else
+  echo "  ✗ assess should report per-directory tsconfig.json files by name (#163)"; sed 's/^/      /' "$HOOK_OUT" | grep -i 'tsconfig' | head -4; FAIL=$((FAIL + 1))
+fi
+rm -rf "$_sa_nested"; unset _sa_nested

--- a/tests/cases/41-tsconfig-monorepo.sh
+++ b/tests/cases/41-tsconfig-monorepo.sh
@@ -1,0 +1,111 @@
+# shellcheck shell=bash
+# cases/41-tsconfig-monorepo.sh — where install.sh puts tsconfig.json (#163).
+# Sourced into the driver's shell, so the globals (PASS/FAIL/HOOK_OUT/
+# SCAFFOLD_DIR) are already in scope.
+#
+# The root tsconfig.json is the switch that makes the pre-commit hook and
+# lint.yml run `tsc --noEmit` over the whole tree. In a workspaces monorepo
+# that switch type-checks every workspace with the wrong compiler options and
+# blocks every JS/TS commit (12,235 errors measured in #163). So the installer
+# must NOT write it when the repo is a workspaces monorepo or already carries
+# per-directory tsconfig files, must say so by name, and must still write it,
+# with a note about what the hook will now do, for a plain frontend repo.
+#
+# Helpers are prefixed tsm_ and this file builds its own fixtures rather than
+# borrowing another case's, so it also runs on its own.
+
+echo "cases/41 — root tsconfig.json placement in monorepos (#163)"
+
+# A fresh frontend repo: package.json plus one .ts file. Extra fixture files
+# are created by the caller before install.sh runs.
+_tsm_fixture() {
+  local d
+  d=$(mktemp -d)
+  ( cd "$d" && git init --quiet && git config user.email test@test.local && git config user.name "Scaffold Test" \
+    && printf '{"name":"fixture","version":"1.0.0","private":true}\n' >package.json \
+    && mkdir -p src && echo 'export const x = 1;' >src/index.ts )
+  echo "$d"
+}
+
+_tsm_install() { ( cd "$1" && "$SCAFFOLD_DIR/install.sh" --frontend --no-verify ) >"$HOOK_OUT" 2>&1; }
+
+# (T) npm/yarn workspaces key: no root tsconfig.json, and the skip names the
+#     file and the reason.
+W=$(_tsm_fixture)
+printf '{"name":"fixture","version":"1.0.0","private":true,"workspaces":["client","server"]}\n' >"$W/package.json"
+mkdir -p "$W/client" "$W/server"
+_tsm_install "$W"
+if [ ! -e "$W/tsconfig.json" ] && grep -q "skip (workspaces monorepo): tsconfig.json" "$HOOK_OUT" \
+   && [ -f "$W/eslint.config.js" ]; then
+  echo "  ✓ workspaces key in package.json: no root tsconfig.json, skip printed, the rest of the frontend set still lands"; PASS=$((PASS + 1))
+else
+  echo "  ✗ workspaces monorepo should not receive a root tsconfig.json (and should say so)"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$W"
+
+# (T) pnpm-workspace.yaml is the same signal for pnpm monorepos.
+P=$(_tsm_fixture)
+printf 'packages:\n  - "packages/*"\n' >"$P/pnpm-workspace.yaml"
+_tsm_install "$P"
+if [ ! -e "$P/tsconfig.json" ] && grep -q "skip (workspaces monorepo): tsconfig.json" "$HOOK_OUT"; then
+  echo "  ✓ pnpm-workspace.yaml: no root tsconfig.json, skip printed"; PASS=$((PASS + 1))
+else
+  echo "  ✗ pnpm workspace should not receive a root tsconfig.json"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$P"
+
+# (T) No workspaces key, but nested tsconfig.json files already exist: the
+#     repo type-checks per directory, so a root config would override that
+#     with whole-tree checking. Skip, and name the directories.
+N=$(_tsm_fixture)
+mkdir -p "$N/client" "$N/server"
+echo '{"compilerOptions":{"strict":true}}' >"$N/client/tsconfig.json"
+echo '{"compilerOptions":{"strict":true}}' >"$N/server/tsconfig.json"
+_tsm_install "$N"
+if [ ! -e "$N/tsconfig.json" ] && grep -q "skip (tsconfig.json in client server): tsconfig.json" "$HOOK_OUT"; then
+  echo "  ✓ nested client/ and server/ tsconfig.json: no root file, skip names both directories"; PASS=$((PASS + 1))
+else
+  echo "  ✗ nested tsconfig.json files should suppress the root one and be named"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$N"
+
+# (T) A tsconfig.json under node_modules is a dependency's, not the repo's:
+#     it must not count as nested, so a plain repo with installed deps still
+#     receives the root file.
+D=$(_tsm_fixture)
+mkdir -p "$D/node_modules/somelib"
+echo '{"compilerOptions":{"strict":false}}' >"$D/node_modules/somelib/tsconfig.json"
+_tsm_install "$D"
+if [ -f "$D/tsconfig.json" ] && grep -q "installed:    tsconfig.json" "$HOOK_OUT"; then
+  echo "  ✓ a dependency's tsconfig.json under node_modules is ignored; the root file is installed"; PASS=$((PASS + 1))
+else
+  echo "  ✗ node_modules must be pruned from the nested-tsconfig probe"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$D"
+
+# (T) Plain frontend repo: the file lands, byte-identical to the template, AND
+#     the install output says what the hook will now do and how to undo it.
+#     The note is the fix for "the install output does not call out that a
+#     root tsconfig.json was placed" (#163).
+S=$(_tsm_fixture)
+_tsm_install "$S"
+if [ -f "$S/tsconfig.json" ] && cmp -s "$S/tsconfig.json" "$SCAFFOLD_DIR/tsconfig.json.template" \
+   && grep -q "note:         tsconfig.json installed at the repo root" "$HOOK_OUT" \
+   && grep -q "tsc --noEmit" "$HOOK_OUT"; then
+  echo "  ✓ plain frontend repo still receives tsconfig.json, with a note that the hook now type-checks the tree"; PASS=$((PASS + 1))
+else
+  echo "  ✗ plain frontend repo must receive tsconfig.json and a whole-tree type-check note"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$S"
+
+# (T) An existing root tsconfig.json keeps cp_safe's behaviour: untouched,
+#     with the usual "skip (exists)" line, not a monorepo message.
+E=$(_tsm_fixture)
+echo '{"compilerOptions":{"target":"ES2019"}}' >"$E/tsconfig.json"
+_tsm_install "$E"
+if grep -q '"target":"ES2019"' "$E/tsconfig.json" && grep -q "skip (exists): tsconfig.json" "$HOOK_OUT"; then
+  echo "  ✓ an existing root tsconfig.json is left untouched with the ordinary skip line"; PASS=$((PASS + 1))
+else
+  echo "  ✗ an existing root tsconfig.json must be left alone"; sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$E"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -110,7 +110,7 @@ CASE_FLOORS=(
   "36-red-green-verdict.sh:3"
   "37-doctor-content-drift.sh:4"
   "38-components-catalog.sh:33"
-  "39-scaffold-assess.sh:9"
+  "39-scaffold-assess.sh:10"
   "40-doctor-required-checks.sh:6"
   "41-tsconfig-monorepo.sh:6"
 )

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -112,6 +112,7 @@ CASE_FLOORS=(
   "38-components-catalog.sh:33"
   "39-scaffold-assess.sh:9"
   "40-doctor-required-checks.sh:6"
+  "41-tsconfig-monorepo.sh:6"
 )
 
 # A case file that exists but is NOT in the list above contributes nothing and

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -88,7 +88,7 @@ CASE_FLOORS=(
   "14-shell-install-mode.sh:5"
   "15-local-checks.sh:7"
   "16-coverage-gate.sh:6"
-  "17-whole-tree-configs.sh:10"
+  "17-whole-tree-configs.sh:11"
   "18-doctor.sh:31"
   "19-test-workflow.sh:17"
   "20-paired-artifacts.sh:19"


### PR DESCRIPTION
Closes #163.

## What changed

**install.sh no longer drops a root `tsconfig.json` into a monorepo.** The root file is the switch that makes the pre-commit hook and lint.yml run `tsc --noEmit` over the whole tree, so the fix is in the decision to place it, not in the hook. `cp_tsconfig_root` (in install-lib.sh, because install.sh sits at the 500-line cap) mirrors COMPONENTS.md entry 10's adopt block:

| Repo shape | Before | After |
|---|---|---|
| root `tsconfig.json` exists | `skip (exists)` | unchanged |
| `workspaces` key in package.json, or `pnpm-workspace.yaml` | file written, hook type-checks every workspace | `skip (workspaces monorepo): tsconfig.json`, reason named |
| per-directory `tsconfig.json` files, no workspaces key | file written | `skip (tsconfig.json in client server): tsconfig.json`, directories named |
| `tsconfig.json` only under node_modules / vendor / dist / build | file written | file written (those dirs are pruned) |
| plain frontend repo | file written silently | file written, plus a `note:` line saying the hook now type-checks the tree and how to undo it |

The catalog's adopt block gains the same per-directory check, and `scaffold-assess.sh` reports that case by name instead of measuring the template project-wide, so installer, catalog and assessment agree.

**Second fix, found on the way:** the existing pytest-config probe had an inert node_modules prune. `find -mindepth 2 ... -prune` never evaluates the prune on a depth-1 directory, so a vendored `pyproject.toml` under `node_modules/` counted as the repo's pytest config and suppressed the root `pytest.ini`. Measured on a fixture before the change; the tsconfig probe was written without `-mindepth`. Separate commit so it reverts on its own.

## Tests

- Case 41 (new): six installer paths above. Red before the fix (4 of 6 failed), green after.
- Case 17: node_modules pytest assertion, red before the fix.
- Case 39: assess names per-directory tsconfig files and does not print a project-wide error count.
- Floors: 41 at 6, 17 from 10 to 11, 39 from 9 to 10, measured with `SCAFFOLD_TEST_CASE_COUNTS=1`.
- shellcheck run the way shellcheck.yml does, over every discovered shell file: clean.

## The rest of the issue

- `.npmrc` is already opt-in (`--npm-cooldown`) and announces itself at install time, so it is not placed by default any more.
- `.coveragerc` is still copied in Python mode. coverage.py only reads it from the directory pytest runs in, so with a nested pytest config it is inert, and the nested-config skip line points at it as the settings to merge. Left as is.
- **Template headers on installed copies** (`# Copy to your project as ...`) are not changed here. Stripping at copy time would break two things that compare an installed file to its template byte for byte: `cp_safe`'s `--force` path (`cmp -s`, which decides whether to back up and rewrite) and the doctor's shipped-rule drift check. The cheaper fix is rewording the 23 template headers so the first line describes the file rather than instructing the installer. That is a separate, doc-only change; say the word and it follows as its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
