### PR TITLE
docs(templates): headers describe the installed file instead of instructing to copy it (#163)

### DIFF
--- a/.coveragerc.template
+++ b/.coveragerc.template
@@ -1,4 +1,4 @@
-# Copy to project root as `.coveragerc` (install.sh does this for Python
+# Project-root `.coveragerc` (install.sh installs it for Python
 # stacks). Configures coverage.py for the patch-coverage gate; pair with
 # `pytest --cov --cov-report=xml` (the coverage.yml CI job runs exactly that).
 [run]

--- a/.github/dependabot.yml.template
+++ b/.github/dependabot.yml.template
@@ -1,4 +1,4 @@
-# Copy to your project as `.github/dependabot.yml`. Keeps the SHA-pinned GitHub
+# `.github/dependabot.yml`, installed by the scaffold. Keeps the SHA-pinned GitHub
 # Actions in your workflows (lint.yml, gitleaks.yml) fresh — SHA pins are a
 # supply-chain best practice but don't auto-update, so without this they rot.
 # Dependabot reads a `uses: owner/action@<sha>  # vX.Y.Z` pin natively and bumps

--- a/.github/workflows/coverage.yml.template
+++ b/.github/workflows/coverage.yml.template
@@ -1,8 +1,8 @@
 name: coverage
 
 # OPT-IN patch-coverage gate: the strictness layer on top of the default-on
-# `tests.yml` (#97). Copy to your project as `.github/workflows/coverage.yml`
-# (or `install.sh --coverage-gate`, which installs this INSTEAD OF tests.yml:
+# `tests.yml` (#97). Installed as `.github/workflows/coverage.yml` by hand
+# (or by `install.sh --coverage-gate`, which installs this INSTEAD OF tests.yml:
 # this workflow already runs the tests, so installing both would run them
 # twice for the same push/PR).
 #

--- a/.github/workflows/gitleaks.yml.template
+++ b/.github/workflows/gitleaks.yml.template
@@ -1,7 +1,7 @@
 name: gitleaks
 
-# OPT-IN secret-scanning backstop. Copy to your project as
-# `.github/workflows/gitleaks.yml`, or install it with
+# OPT-IN secret-scanning backstop, installed as
+# `.github/workflows/gitleaks.yml` by hand (COMPONENTS.md) or with
 # `install.sh --gitleaks-ci`. Not installed by default: it adds a third-party
 # action dependency, so opt in deliberately.
 #

--- a/.github/workflows/lint.yml.template
+++ b/.github/workflows/lint.yml.template
@@ -1,6 +1,6 @@
 name: lint
 
-# Copy to your project as `.github/workflows/lint.yml`.
+# Installed as `.github/workflows/lint.yml`.
 # Mirrors the pre-commit hook server-side via the same lib/check-* scripts —
 # the hook and CI can never drift because they share one implementation.
 # Adjust Python / Node versions per project.

--- a/.github/workflows/test-guard.yml.template
+++ b/.github/workflows/test-guard.yml.template
@@ -1,6 +1,6 @@
 name: test-guard
 
-# Copy to your project as `.github/workflows/test-guard.yml`.
+# Installed as `.github/workflows/test-guard.yml`.
 # Installed by the scaffold's opt-in `--test-guard` flag.
 #
 # The anti-gaming layer. Every other gate in this scaffold assumes the test

--- a/.github/workflows/tests.yml.template
+++ b/.github/workflows/tests.yml.template
@@ -1,7 +1,7 @@
 name: tests
 
-# DEFAULT-ON test execution. Copy to your project as
-# `.github/workflows/tests.yml` (install.sh installs it automatically; opt out
+# DEFAULT-ON test execution, installed as
+# `.github/workflows/tests.yml` (install.sh does it automatically; opt out
 # with `--no-test-workflow`, or install `--coverage-gate` instead (see below).
 #
 # WHY THIS EXISTS (#97). A default install used to produce lint-only CI: green

--- a/.npmrc.template
+++ b/.npmrc.template
@@ -1,4 +1,4 @@
-# Copy to your project as `.npmrc` (install.sh --npm-cooldown, issue #117).
+# Project-root `.npmrc`, installed by `install.sh --npm-cooldown` (issue #117).
 #
 # min-release-age delays how soon a freshly published package version becomes
 # installable, counted in DAYS from its publish time: npm resolves to an

--- a/.prettierignore.template
+++ b/.prettierignore.template
@@ -1,4 +1,4 @@
-# Copy to project root as `.prettierignore`. Prettier formats code only;
+# Project-root `.prettierignore`. Prettier formats code only;
 # eslint owns correctness (the two don't overlap — strictTypeChecked ships no
 # stylistic rules, so there is intentionally NO eslint-config-prettier).
 # Keep generated / vendored / lockfile content out of formatting.

--- a/AGENTS.md.template
+++ b/AGENTS.md.template
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-Instructions for AI coding agents working in this repo. `AGENTS.md` is an open cross-tool standard (see [agents.md](https://agents.md)) read natively by Cursor, Aider, Codex, and others; the standard specifies nested `AGENTS.md` files with closest-file-wins precedence. For Claude Code, a thin `CLAUDE.md` pointer is installed alongside this file. Copy to your project root as `AGENTS.md` and edit the **Project** section.
+Instructions for AI coding agents working in this repo. `AGENTS.md` is an open cross-tool standard (see [agents.md](https://agents.md)) read natively by Cursor, Aider, Codex, and others; the standard specifies nested `AGENTS.md` files with closest-file-wins precedence. For Claude Code, a thin `CLAUDE.md` pointer is installed alongside this file. This file lives at the project root as `AGENTS.md`; edit the **Project** section.
 
 ## Coding rules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 versioning follows [SemVer](https://semver.org/).
 
+## [Unreleased]
+
+### Changed
+
+- **Template headers describe the installed file instead of instructing the
+  installer (#163, second half).** Every shipped template opened with "Copy
+  to your project as ..." and the installed copy kept that line, so a target
+  repo ended up with files whose first line addressed the person installing
+  them. The 27 headers now say where the file lives and what puts it there
+  ("Installed as `.github/workflows/lint.yml`", "Project-root `ruff.toml`").
+  Wording only: no rule, option or path changed, and installed copies stay
+  byte-identical to their templates, which `cp_safe --force` and the doctor's
+  drift check rely on.
+
 ## [v0.18.0] - 2026-09-03
 
 ### Changed

--- a/claude-settings.json.template
+++ b/claude-settings.json.template
@@ -1,5 +1,5 @@
 {
-  "//": "ai-coding-rules-scaffold — OPT-IN agent-runtime guardrails for Claude Code (the scaffold's deferred 'layer three'). Copy to your project as .claude/settings.json, or merge these keys into an existing one. Two parts: a permissions deny-list (the agent can't read credential files or run a few catastrophic commands) and a PreToolUse hook that scans content the agent is about to write against .forbidden-patterns/secrets.txt — the same patterns the commit-time scanner uses. Trim the deny-list to taste; paths use gitignore-style matching.",
+  "//": "ai-coding-rules-scaffold — OPT-IN agent-runtime guardrails for Claude Code (the scaffold's deferred 'layer three'). Installed as .claude/settings.json, or merge these keys into an existing one. Two parts: a permissions deny-list (the agent can't read credential files or run a few catastrophic commands) and a PreToolUse hook that scans content the agent is about to write against .forbidden-patterns/secrets.txt — the same patterns the commit-time scanner uses. Trim the deny-list to taste; paths use gitignore-style matching.",
 
   "permissions": {
     "deny": [

--- a/eslint.config.js.template
+++ b/eslint.config.js.template
@@ -1,4 +1,4 @@
-// Copy to project root as `eslint.config.js` (flat config, ESLint 9+).
+// Project-root `eslint.config.js` (flat config, ESLint 9+).
 //
 // Install peers:
 //   npm i -D eslint @eslint/js @eslint/compat typescript-eslint \

--- a/forbidden-patterns/backend.txt.template
+++ b/forbidden-patterns/backend.txt.template
@@ -6,7 +6,7 @@
 # The `scaffold-extensions:` header above tells check-patterns which file
 # extensions these rules scan — drop a new <lang>.txt with its own header to
 # add a language; see forbidden-patterns/README.md.
-# Copy to your project as `.forbidden-patterns/backend.txt`.
+# Installed as `.forbidden-patterns/backend.txt`.
 
 (^|[^A-Za-z_])print[[:space:]]*\(	Use structlog (or the project's logger), not print()
 os\.path\.join	Use pathlib.Path(), not os.path.join

--- a/forbidden-patterns/frontend.txt.template
+++ b/forbidden-patterns/frontend.txt.template
@@ -2,8 +2,8 @@
 # scaffold-extensions: ts tsx js jsx mjs cjs mts cts vue svelte
 # Format: <regex><TAB><description>   (one per line; # comments ignored)
 # Separator is TAB — patterns can contain literal `|` for ERE alternation.
-# Patterns are case-SENSITIVE, scanned against the staged blob. Copy to your
-# project as `.forbidden-patterns/frontend.txt`.
+# Patterns are case-SENSITIVE, scanned against the staged blob. Installed as
+# `.forbidden-patterns/frontend.txt`.
 
 # --- Debug leaks ---
 (^|[^A-Za-z_])console\.log[[:space:]]*\(	Use the project logger, not console.log

--- a/forbidden-patterns/go.txt.template
+++ b/forbidden-patterns/go.txt.template
@@ -2,7 +2,7 @@
 # scaffold-extensions: go
 # Format: <regex><TAB><description>   (one per line; # comments ignored)
 # Separator is TAB - patterns can contain literal `|` for ERE alternation.
-# Case-sensitive ERE (grep -anE). Copy to your project as `.forbidden-patterns/go.txt`.
+# Case-sensitive ERE (grep -anE). Installed as `.forbidden-patterns/go.txt`.
 # Active rules flag leftover debug output plus one security sink (TLS bypass);
 # panic/log.Fatal live in optional below.
 

--- a/forbidden-patterns/java.txt.template
+++ b/forbidden-patterns/java.txt.template
@@ -6,7 +6,7 @@
 # Bans console debug output (keeps logger.info/warn/error intact) plus two
 # narrow command-execution / TLS sinks below.
 # printStackTrace ban is no-arg only; printStackTrace(writer) is allowed (logging idiom).
-# Copy to your project as `.forbidden-patterns/java.txt`.
+# Installed as `.forbidden-patterns/java.txt`.
 
 (^|[^A-Za-z_])System\.out\.print(ln)?[[:space:]]*\(	Use a logger (slf4j/Log4j), not System.out.print/println
 (^|[^A-Za-z_])System\.err\.print(ln|f)?[[:space:]]*\(	Use logger.error(), not System.err.print/println/printf

--- a/forbidden-patterns/kotlin.txt.template
+++ b/forbidden-patterns/kotlin.txt.template
@@ -2,7 +2,7 @@
 # scaffold-extensions: kt kts
 # Format: <regex><TAB><description>   (one per line; # comments ignored)
 # Separator is TAB - patterns can contain literal `|` for ERE alternation; no literal TAB.
-# Copy to your project as `.forbidden-patterns/kotlin.txt`.
+# Installed as `.forbidden-patterns/kotlin.txt`.
 # Note: *.kts are Gradle/script files where println() is idiomatic; flagging it there
 # still catches stray debug output, but expect to scaffold-allow legitimate cases.
 # print/println/TODO anchors exclude a preceding `.` so member calls like writer.println(),

--- a/forbidden-patterns/php.txt.template
+++ b/forbidden-patterns/php.txt.template
@@ -2,8 +2,8 @@
 # scaffold-extensions: php phtml php3 php4 php5 php7 php8
 # Format: <regex><TAB><description>   (one per line; # comments ignored)
 # Separator is TAB; patterns can contain literal | for ERE alternation.
-# Patterns are case-SENSITIVE, scanned against the staged blob. Copy to
-# your project as `.forbidden-patterns/php.txt`.
+# Patterns are case-SENSITIVE, scanned against the staged blob. Installed
+# as `.forbidden-patterns/php.txt`.
 # error_log() is intentionally NOT banned - it is legitimate logging.
 # die()/exit() are common control flow and live in optionalPatterns.
 

--- a/forbidden-patterns/ruby.txt.template
+++ b/forbidden-patterns/ruby.txt.template
@@ -2,8 +2,8 @@
 # scaffold-extensions: rb rake
 # Format: <regex><TAB><description>   (one per line; # comments ignored)
 # Separator is TAB - patterns can contain literal `|` for ERE alternation.
-# Patterns are case-SENSITIVE, scanned against the staged blob. Copy to your
-# project as `.forbidden-patterns/ruby.txt`.
+# Patterns are case-SENSITIVE, scanned against the staged blob. Installed as
+# `.forbidden-patterns/ruby.txt`.
 # Debug rules target breakpoints (binding.pry/irb, byebug, debugger) and pp; a
 # second block below targets code-execution and TLS-downgrade sinks. Command
 # injection is NOT covered - see the NOT COVERED note in that block.

--- a/forbidden-patterns/rust.txt.template
+++ b/forbidden-patterns/rust.txt.template
@@ -2,8 +2,8 @@
 # scaffold-extensions: rs
 # Format: <regex><TAB><description>   (one per line; # comments ignored)
 # Separator is TAB - patterns can contain literal `|` for ERE alternation.
-# Patterns are case-SENSITIVE, scanned against the staged blob. Copy to your
-# project as `.forbidden-patterns/rust.txt`.
+# Patterns are case-SENSITIVE, scanned against the staged blob. Installed as
+# `.forbidden-patterns/rust.txt`.
 # Each macro pattern requires an opening delimiter ( [ { after the `!` so it
 # only fires on a real invocation, not an identifier or a comment mention, and
 # to stay portable across GNU grep and ugrep.

--- a/forbidden-patterns/secrets.txt.template
+++ b/forbidden-patterns/secrets.txt.template
@@ -1,7 +1,7 @@
 # Forbidden patterns for secret / credential leakage.
 # Applied to all tracked text files (no extension filter).
 # Format: [(?-i)]<regex><TAB><description>   (one per line; # comments ignored)
-# Copy to your project as `.forbidden-patterns/secrets.txt`.
+# Installed as `.forbidden-patterns/secrets.txt`.
 #
 # All patterns are ERE-compatible (no PCRE lookaheads).
 # Separator is TAB — patterns can contain literal `|` for ERE alternation.

--- a/forbidden-patterns/shell.txt.template
+++ b/forbidden-patterns/shell.txt.template
@@ -4,7 +4,7 @@
 # The second header claims files with no .sh extension: the same RUN/recipe
 # lines (curl|bash, rm -rf /, chmod 777) live in Dockerfiles and Makefiles,
 # where an extension match never looks.
-# Copy to your project as `.forbidden-patterns/shell.txt`.
+# Installed as `.forbidden-patterns/shell.txt`.
 
 (^|[^A-Za-z_])(curl|wget)([[:space:]]+[^|]*)?\|[[:space:]]*(sudo[[:space:]]+)?(bash|sh|zsh)([[:space:]]|$)	Piping remote download to a shell — review the script and run it as a separate step
 (^|[^A-Za-z_])rm[[:space:]]+((-[a-zA-Z]+|--[a-z]+)[[:space:]]+)+["']?(/|/\*|~|~/\*|\$\{?HOME\}?(/\*)?)["']?([[:space:]]|[;&]|$)	`rm -rf /` (or /*, ~, $HOME) detected — refuse to ship; scope to a specific path

--- a/githooks/lib/credential-read-patterns.txt.template
+++ b/githooks/lib/credential-read-patterns.txt.template
@@ -12,8 +12,8 @@
 # Format: <glob><TAB><description>   (one per line; # comments ignored). A
 # glob matches a read path exactly, or as a path suffix ("*/<glob>") — so
 # ".ssh/*" matches both a relative ".ssh/config" and "/home/x/.ssh/config".
-# Copy to your project as `.githooks/lib/credential-read-patterns.txt`, or
-# let `install.sh --cursor` do it (cp_pattern: re-running install notifies on
+# Installed as `.githooks/lib/credential-read-patterns.txt`, by hand or
+# by `install.sh --cursor` (cp_pattern: re-running install notifies on
 # drift rather than overwriting your edits).
 
 .env	environment file (secrets)

--- a/pytest.ini.template
+++ b/pytest.ini.template
@@ -1,4 +1,4 @@
-# Copy to project root as `pytest.ini` (install.sh does this for Python stacks
+# Project-root `pytest.ini` (install.sh installs it for Python stacks
 # when no pytest config already exists in pyproject.toml/pytest.ini/tox.ini —
 # including one in a subdirectory, see below).
 # Minimal, standalone — like ruff.toml, it does not edit your pyproject.toml.

--- a/ruff.toml.template
+++ b/ruff.toml.template
@@ -1,4 +1,4 @@
-# Copy to project root as `ruff.toml`.
+# Project-root `ruff.toml`.
 # Python lint config enforcing the coding-rules scaffold.
 # Adjust target-version and line-length per project if needed.
 

--- a/tsconfig.json.template
+++ b/tsconfig.json.template
@@ -1,5 +1,5 @@
 {
-  // Copy to project root as `tsconfig.json` (install.sh does this for frontend
+  // Project-root `tsconfig.json` (install.sh installs it for frontend
   // stacks). This is the type-checker config that `eslint.config.js`'s
   // type-aware rules (`strictTypeChecked`) AND the `tsc --noEmit` step in the
   // pre-commit hook + CI both rely on — without it, the highest-value async-

--- a/vitest.config.ts.template
+++ b/vitest.config.ts.template
@@ -1,4 +1,4 @@
-// Copy to project root as `vitest.config.ts` (install.sh does this for frontend
+// Project-root `vitest.config.ts` (install.sh installs it for frontend
 // stacks unless the project already uses Jest). Vitest is the default runner:
 // Vite-native, ESM-first, near-zero config. Swap for Jest if your stack already
 // standardized on it — the scaffold won't fight an existing choice.


### PR DESCRIPTION
Second half of #163, split out from #181 as its own change.

## What changed

Every shipped template opened with `# Copy to your project as ...` (or `Copy to project root as ...`), and since installed copies are byte-identical to their templates, a target repo ended up with files whose first line addressed the person installing them. The issue's example was `.github/dependabot.yml`.

The 27 headers now describe the file rather than instruct the reader:

| Before | After |
|---|---|
| `# Copy to your project as .github/workflows/lint.yml.` | `# Installed as .github/workflows/lint.yml.` |
| `# Copy to project root as ruff.toml.` | `# Project-root ruff.toml.` |
| `# Copy to project root as pytest.ini (install.sh does this for Python stacks ...` | `# Project-root pytest.ini (install.sh installs it for Python stacks ...` |
| `... Copy to your project as .githooks/lib/credential-read-patterns.txt, or let install.sh --cursor do it` | `... Installed as .githooks/lib/credential-read-patterns.txt, by hand or by install.sh --cursor` |

Wording only. No rule row, option, path, or default changed; the rest of each header (why the file exists, what it pairs with) is untouched.

## Why reword rather than strip on copy

The issue suggested stripping the header block at copy time. Two things compare an installed file to its template byte for byte and would break: `cp_safe`'s `--force` path uses `cmp -s` to decide whether to back up and rewrite, and the doctor's shipped-rule drift check diffs pattern files against their templates. Rewording keeps copies identical and fixes the text at the source.

## Checks

- Every replacement was applied by an exact-match script that reports the match count per file: 27 files, each matched exactly once, and `grep 'Copy to'` over all templates now returns nothing.
- `bash tests/run.sh`: 603 passed, 0 failed (the main baseline).
- prettier 3.9.6 with the shipped config, run the way self-lint.yml does: AGENTS.md.template and CHANGELOG.md clean.
- No test or doc referenced the old wording (grepped before changing it).

## Merge note

This branch is off main and adds its own `## [Unreleased]` section to CHANGELOG.md; #181 adds one too. Whichever merges second needs a one-hunk rebase of the changelog. I will rebase this one if #181 goes first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
