### PR TITLE
chore(release): v0.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 versioning follows [SemVer](https://semver.org/).
 
-## [Unreleased]
+## [v0.18.1] - 2026-09-04
 
 ### Changed
 

--- a/COMPONENTS.md
+++ b/COMPONENTS.md
@@ -21,13 +21,13 @@ Commands assume `$SCAFFOLD` points at a copy of this repository. Pick one:
 
 ```sh
 # a pinned clone (no Node needed)
-git clone --branch v0.18.0 https://github.com/Sting25/ai-coding-rules-scaffold ~/src/ai-coding-rules-scaffold
+git clone --branch v0.18.1 https://github.com/Sting25/ai-coding-rules-scaffold ~/src/ai-coding-rules-scaffold
 export SCAFFOLD=~/src/ai-coding-rules-scaffold
 ```
 
 ```sh
 # or the published npm tarball, unpacked, no clone
-cd "$(mktemp -d)" && npm pack ai-coding-rules-scaffold@0.18.0 --silent && tar xzf ai-coding-rules-scaffold-*.tgz
+cd "$(mktemp -d)" && npm pack ai-coding-rules-scaffold@0.18.1 --silent && tar xzf ai-coding-rules-scaffold-*.tgz
 export SCAFFOLD="$PWD/package"
 ```
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ the components you want with the commands in each entry; every entry has a
 verify step, and `scaffold-assess.sh` measures what each would flag first.
 
 ```sh
-git clone --branch v0.18.0 https://github.com/Sting25/ai-coding-rules-scaffold ~/src/ai-coding-rules-scaffold
+git clone --branch v0.18.1 https://github.com/Sting25/ai-coding-rules-scaffold ~/src/ai-coding-rules-scaffold
 export SCAFFOLD=~/src/ai-coding-rules-scaffold
 bash "$SCAFFOLD/scaffold-assess.sh"        # from your project root: what would each component flag?
 ```
@@ -95,7 +95,7 @@ somewhere stable:
 
 ```sh
 # Recommended: pin to a tagged release for reproducibility
-git clone --branch v0.18.0 https://github.com/Sting25/ai-coding-rules-scaffold ~/src/ai-coding-rules-scaffold
+git clone --branch v0.18.1 https://github.com/Sting25/ai-coding-rules-scaffold ~/src/ai-coding-rules-scaffold
 # Or track main if you want the latest changes
 git clone https://github.com/Sting25/ai-coding-rules-scaffold ~/src/ai-coding-rules-scaffold
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-coding-rules-scaffold",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "Agent-agnostic coding-rules scaffold: pre-commit + CI guardrails (file size, forbidden patterns, secret/credential scanning, hygiene) that install into your project, plus `scaffold-doctor` to check they are actually armed and not just present. Run via `npx ai-coding-rules-scaffold`. AI agents: run the installer, never hand-copy files.",
   "bin": {
     "ai-coding-rules-scaffold": "bin/cli.js"


### PR DESCRIPTION
Release prep for v0.18.1 per RELEASING.md section 1.

- Promote `[Unreleased]` to `## [v0.18.1] - 2026-09-04` in CHANGELOG.md (the two #163 fixes and the template-header reword, plus the pytest-probe prune fix).
- Bump the clone pins in README.md and COMPONENTS.md, the npm pack pin in COMPONENTS.md, and `version` in package.json.
- Self-lint dry run (`check-secrets --ci`) rc 0. Homebrew formula is synced after the GitHub Release exists, as in v0.18.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)