### PR TITLE
chore(homebrew): sync canonical formula to v0.18.1

### DIFF
--- a/packaging/homebrew/ai-coding-rules-scaffold.rb
+++ b/packaging/homebrew/ai-coding-rules-scaffold.rb
@@ -9,8 +9,8 @@
 class AiCodingRulesScaffold < Formula
   desc "Pre-commit and CI guardrails: size, pattern, secret, and hygiene checks"
   homepage "https://github.com/Sting25/ai-coding-rules-scaffold"
-  url "https://github.com/Sting25/ai-coding-rules-scaffold/archive/refs/tags/v0.18.0.tar.gz"
-  sha256 "c8cbe976b90a2189dc966478287a08d9e160541a1ef9a5f73ebb39d42cb01fad"
+  url "https://github.com/Sting25/ai-coding-rules-scaffold/archive/refs/tags/v0.18.1.tar.gz"
+  sha256 "56f11ff5826132ff8f74c7cf663ded021bcd449857dd9ad360dbe8772f43546f"
   license "MIT"
 
   def install


### PR DESCRIPTION
Sync `packaging/homebrew/ai-coding-rules-scaffold.rb` to the v0.18.1 tag after the tap's bump-formula run (Sting25/homebrew-tap run 33893745050, success). The sha256 was computed locally from the tag tarball and matches the tap's formula; the two files diff as identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)