### PR TITLE
doctor: report stale installs (#133, #134, #136)

### DIFF
--- a/AGENTS.md.template
+++ b/AGENTS.md.template
@@ -19,8 +19,10 @@ working tree):
 ruff check .                       # Python  (when ruff.toml / pyproject.toml present)
 npx eslint . && npx tsc --noEmit   # TS/JS   (tsc when tsconfig.json present)
 pytest                             # Python  (from the dir holding the pytest config)
-git hook run pre-commit            # size / pattern / secret / hygiene / filename guards
+git hook run pre-commit            # size / pattern / secret / hygiene / filename guards (see note)
 ```
+
+`git hook run pre-commit` exercises the scaffold guards only when `core.hooksPath` is `.githooks`. install.sh leaves `core.hooksPath` alone when another hooks manager (Husky, lefthook, pre-commit) already owns it; in that configuration run `.githooks/pre-commit` directly, and let the doctor (below) tell you which case you are in.
 
 These are whole-tree commands, and a whole-tree command sees everything **on
 disk**, not everything in git. A vendored toolchain, an agent worktree, or an

--- a/AGENTS.md.template
+++ b/AGENTS.md.template
@@ -22,7 +22,7 @@ pytest                             # Python  (from the dir holding the pytest co
 git hook run pre-commit            # size / pattern / secret / hygiene / filename guards (see note)
 ```
 
-`git hook run pre-commit` exercises the scaffold guards only when `core.hooksPath` is `.githooks`. install.sh leaves `core.hooksPath` alone when another hooks manager (Husky, lefthook, pre-commit) already owns it; in that configuration run `.githooks/pre-commit` directly, and let the doctor (below) tell you which case you are in.
+`git hook run pre-commit` exercises the scaffold guards only when `core.hooksPath` is `.githooks`. install.sh leaves `core.hooksPath` alone when it is already set to something else (Husky does this by default; managers that write into `.git/hooks/` do not); in that configuration run `.githooks/pre-commit` directly, and let the doctor (below) tell you which case you are in.
 
 These are whole-tree commands, and a whole-tree command sees everything **on
 disk**, not everything in git. A vendored toolchain, an agent worktree, or an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,42 @@ All notable changes to this project are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 versioning follows [SemVer](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- **`scaffold-doctor.sh` reports coding-rules.md present but not imported by
+  CLAUDE.md (#136).** AGENTS.md only links coding-rules.md, and a markdown
+  link is not loaded into an agent's context at session start the way a
+  CLAUDE.md `@coding-rules.md` import is. `install_claude_md` has appended
+  that import line since v0.17, so any install from before then carried the
+  gap silently: the rules sat on disk, reachable but never actually loaded.
+  The doctor now reports a gap when coding-rules.md exists and CLAUDE.md
+  does not import it (missing CLAUDE.md entirely, or the import line
+  absent), anchored to the whole line so prose that merely mentions the
+  import is not misread as one.
+- **`scaffold-doctor.sh` notes when AGENTS.md or coding-rules.md predates
+  the shipped template (#133).** install.sh never rewrites an existing
+  AGENTS.md and replaces coding-rules.md only wholesale under `--force`,
+  the right policy for user-owned files, but the side effect was invisible:
+  a release that adds a section to either shipped file left every existing
+  install silently behind. Neither file carries a version marker, so
+  section headings are the inventory: every `## `/`### ` line in the
+  shipped file must appear verbatim in the installed one, with the missing
+  ones named. This is a note, never a gap, since a deliberately trimmed
+  section is legitimate.
+
+### Changed
+
+- **AGENTS.md.template no longer asserts `git hook run pre-commit`
+  unconditionally (#134).** install.sh deliberately leaves `core.hooksPath`
+  alone when another hooks manager (Husky, lefthook, pre-commit) already
+  owns it, so the template's instruction was false in exactly that
+  configuration: an agent could run the command against hooks that were
+  not the scaffold's and read a pass. The template now names the direct
+  fallback (`.githooks/pre-commit`) and points at the doctor, which already
+  reports the unwired-hooksPath state.
+
 ## [v0.18.1] - 2026-09-04
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,11 @@ versioning follows [SemVer](https://semver.org/).
 - **`scaffold-doctor.sh` reports coding-rules.md present but not imported by
   CLAUDE.md (#136).** AGENTS.md only links coding-rules.md, and a markdown
   link is not loaded into an agent's context at session start the way a
-  CLAUDE.md `@coding-rules.md` import is. `install_claude_md` has appended
-  that import line since v0.17, so any install from before then carried the
-  gap silently: the rules sat on disk, reachable but never actually loaded.
+  CLAUDE.md `@coding-rules.md` import is. Since v0.17 `install_claude_md`
+  writes that import into a new or newly merged CLAUDE.md, but a CLAUDE.md
+  that already imported AGENTS.md only gets a one-time note at install, so
+  older installs carried the gap silently: the rules sat on disk, reachable
+  but never actually loaded.
   The doctor now reports a gap when coding-rules.md exists and CLAUDE.md
   does not import it (missing CLAUDE.md entirely, or the import line
   absent), anchored to the whole line so prose that merely mentions the

--- a/COMPONENTS.md
+++ b/COMPONENTS.md
@@ -858,7 +858,10 @@ rm -f .github/rulesets/main-protection.json
 
 `scaffold-doctor.sh` reports, per component, whether it is present, wired and
 actually called, and names every gap. It works on hand-copied installs; it
-does not need the installer's manifest.
+does not need the installer's manifest. It also notes when your installed
+AGENTS.md or coding-rules.md is missing a section the shipped template
+carries, so an install adopted before a later release does not fall behind
+without saying so.
 
 ```sh
 bash "$SCAFFOLD/scaffold-doctor.sh"      # or: npx ai-coding-rules-scaffold doctor

--- a/TECHNICAL.md
+++ b/TECHNICAL.md
@@ -495,6 +495,31 @@ clone) to reuse this logic rather than duplicate it; if that file is ever
 missing next to it, the section reports a note instead of silently skipping
 it.
 
+### Template drift (installs that predate a release)
+
+`install.sh` never rewrites an existing `AGENTS.md`, and it replaces
+`coding-rules.md` only wholesale under `--force`. Both are the right policy
+once a file is user-owned: an installer that overwrote local edits on every
+run would be worse than one that leaves them alone. The side effect is that
+neither file carries a version marker, so a release that adds a section to
+either shipped file leaves every prior install silently behind, and the
+oldest installs fall furthest.
+
+`scaffold-doctor.sh`'s "template drift" section makes that visible: every
+`## ` and `### ` heading in the shipped template becomes the inventory, and
+any heading present in the shipped file but missing from the installed one
+is named. This is always a note, never a gap, because a section a project
+deliberately trimmed is legitimate and must not flip the exit code; the
+note names the missing headings and points at the shipped file to diff
+against. A doctor run from a copy that does not carry the rest of the
+bundle reports that the templates themselves are missing, the same shape as
+the pattern-data and paired-artifacts sections above.
+
+A related but stricter case is #136: `coding-rules.md` existing on disk
+with no `@coding-rules.md` import line in `CLAUDE.md` is a gap, not a note,
+because an unloaded rules file is an unarmed guardrail rather than a
+trimmed one.
+
 ## Customize per project
 
 - **`coding-rules.md`** — short by design. Add a "Project-specific" section at the bottom for stack rules (SQLAlchemy column quirks, import conventions, architectural constraints).

--- a/scaffold-doctor.sh
+++ b/scaffold-doctor.sh
@@ -148,6 +148,28 @@ else
       "git config core.hooksPath .githooks   (or wire the scaffold hook into '$HOOKS_PATH')"
 fi
 
+# core.hooksPath governs whether a COMMIT is checked; whether an AGENT ever
+# reads the rules is a separate wiring question with its own silent-gap shape.
+# AGENTS.md only LINKS coding-rules.md (a markdown link, kept deliberately
+# cross-tool), and a link is not loaded into context at session start — only
+# an `@coding-rules.md` import line in CLAUDE.md does that. install_claude_md
+# has appended that line since v0.17; installs from before then carry the gap
+# with nothing on disk to say so. Nothing to check when this project never had
+# coding-rules.md installed. `CLAUDE.md` may be a symlink to `CLAUDE.md.pointer`
+# in some setups — `[ -f ]` and `grep` both follow it, which is correct here.
+if [ -f coding-rules.md ]; then
+  if [ ! -f CLAUDE.md ]; then
+    gap "coding-rules.md exists but there is no CLAUDE.md to import it"
+  # Anchored, not a substring match: an unanchored '@coding-rules.md' also
+  # matches prose like "we removed the @coding-rules.md import", which would
+  # report the exact opposite of the truth.
+  elif grep -q '^@coding-rules\.md$' CLAUDE.md 2>/dev/null; then
+    ok "CLAUDE.md imports coding-rules.md"
+  else
+    gap "coding-rules.md exists but is not imported by CLAUDE.md (add a line reading @coding-rules.md; AGENTS.md only links the file, so the rules are never loaded)"
+  fi
+fi
+
 # --- 2. hook entry point ----------------------------------------------------
 # git silently ignores a hook file without the executable bit. No error, no
 # warning, no commit blocked — the exact failure mode this script exists for.

--- a/scaffold-doctor.sh
+++ b/scaffold-doctor.sh
@@ -450,6 +450,45 @@ else
   note "scaffold-doctor-gates.sh not found next to scaffold-doctor.sh ($DOCTOR_DIR): the server-side backstop, patch-coverage, lint-ignore and protections-not-enabled checks are skipped; re-fetch the full scaffold bundle, not just this one file"
 fi
 
+# --- 9. template drift (AGENTS.md, coding-rules.md) --------------------------
+# AGENTS.md is never rewritten once it exists, and coding-rules.md is replaced
+# wholesale only under --force — correct, since both are user-owned once
+# installed. The flip side is silent: a scaffold release that adds a section
+# to either shipped file leaves an install behind with nothing on disk saying
+# so (#133). Neither file carries a version marker, so section HEADINGS
+# (every `## `/`### ` line) are the inventory, reported as a NOTE never a gap
+# since a project may have deliberately trimmed one.
+section "template drift"
+# doctor_heading_drift <installed> <shipped> <label> <policy-note>. One awk
+# pass mirrors section 4's forbidden-patterns-vs-template comparison: only
+# headings that were SHIPPED and are now absent are reported (an extra local
+# section is healthy, not drift). The regex skips a `{{...}}`/`<TOKEN>`
+# placeholder install.sh would substitute; neither shipped file has one today
+# (checked), so this guards a future heading rather than a live case.
+doctor_heading_drift() {
+  local td_inst=$1 td_shipped=$2 td_label=$3 td_policy=$4 td_quoted
+  [ -f "$td_inst" ] || return 0
+  if [ ! -f "$td_shipped" ]; then
+    note "$(basename "$td_shipped") not found next to scaffold-doctor.sh ($SCAFFOLD_DIR): $td_label drift cannot be checked; re-fetch the full scaffold bundle, not just this one file"
+    return 0
+  fi
+  td_quoted=$(awk '
+    FNR == NR { have[$0] = 1; next }
+    !/^(## |### )/ { next }
+    /\{\{/ || /<[A-Za-z_-]+>/ { next }
+    !($0 in have) { printf "%s\"%s\"", (n++ ? ", " : ""), $0 }
+  ' "$td_inst" "$td_shipped" 2>/dev/null || true)
+  if [ -z "$td_quoted" ]; then
+    ok "$td_label carries every section of the shipped template"
+    return 0
+  fi
+  note "$(basename "$td_inst") predates the shipped template: missing $td_quoted. diff it against $td_shipped and adopt what applies; $td_policy"
+}
+doctor_heading_drift "AGENTS.md" "$SCAFFOLD_DIR/AGENTS.md.template" "AGENTS.md" \
+  "install.sh never rewrites this file"
+doctor_heading_drift "coding-rules.md" "$SCAFFOLD_DIR/coding-rules.md" "coding-rules.md" \
+  "install.sh --force replaces it wholesale (backup in .scaffold-bak); merging by hand keeps local edits"
+
 # --- summary ----------------------------------------------------------------
 echo ""
 if [ "$GAPS" -eq 0 ]; then

--- a/scaffold-doctor.sh
+++ b/scaffold-doctor.sh
@@ -152,11 +152,11 @@ fi
 # reads the rules is a separate wiring question with its own silent-gap shape.
 # AGENTS.md only LINKS coding-rules.md (a markdown link, kept deliberately
 # cross-tool), and a link is not loaded into context at session start — only
-# an `@coding-rules.md` import line in CLAUDE.md does that. install_claude_md
-# has appended that line since v0.17; installs from before then carry the gap
-# with nothing on disk to say so. Nothing to check when this project never had
-# coding-rules.md installed. `CLAUDE.md` may be a symlink to `CLAUDE.md.pointer`
-# in some setups — `[ -f ]` and `grep` both follow it, which is correct here.
+# an `@coding-rules.md` import line in CLAUDE.md does that. Since v0.17 the
+# installer writes it into a new or merged CLAUDE.md; an already-wired one only
+# gets a one-time note, so older installs carry the gap silently. Nothing to
+# check when coding-rules.md was never installed. `CLAUDE.md` may be a symlink
+# to `CLAUDE.md.pointer` in some setups — `[ -f ]` and `grep` both follow it.
 if [ -f coding-rules.md ]; then
   if [ ! -f CLAUDE.md ]; then
     gap "coding-rules.md exists but there is no CLAUDE.md to import it"

--- a/tests/cases/18-doctor.sh
+++ b/tests/cases/18-doctor.sh
@@ -441,4 +441,31 @@ rm -rf "$DOCT"
 # shipped-rule drift check: same content-vs-arming question, and it carries
 # its own eslint.config.js fixtures.
 
+# (M) coding-rules.md vs. CLAUDE.md (#136). AGENTS.md only LINKS
+# coding-rules.md, so unless CLAUDE.md carries an `@coding-rules.md` import
+# line, the rules are reachable but never loaded into context at session
+# start. install_claude_md has written that line since v0.17; installs from
+# before then carry the gap silently, with nothing on disk to say so.
+doc_remove_coding_rules_import() {
+  sed -i.bak '/^@coding-rules\.md$/d' CLAUDE.md && rm -f CLAUDE.md.bak
+}
+# The match must be ANCHORED to the whole line, not a substring search: prose
+# that merely mentions the import (e.g. explaining that it was removed) is not
+# an import, and an unanchored pattern would misreport it as one.
+doc_prose_coding_rules_import() {
+  sed -i.bak 's/^@coding-rules\.md$/We removed the @coding-rules.md import for now./' CLAUDE.md \
+    && rm -f CLAUDE.md.bak
+}
+
+doc_case "a fresh install imports coding-rules.md into CLAUDE.md (ok, not a gap)" 0 \
+  "CLAUDE.md imports coding-rules.md" true
+doc_case "CLAUDE.md missing the @coding-rules.md import line is reported" 1 \
+  "coding-rules.md exists but is not imported by CLAUDE.md" \
+  doc_remove_coding_rules_import
+doc_case "a prose-only mention of @coding-rules.md does not count as importing it (anchored match)" 1 \
+  "coding-rules.md exists but is not imported by CLAUDE.md" \
+  doc_prose_coding_rules_import
+doc_case "coding-rules.md with no CLAUDE.md at all to import it is reported" 1 \
+  "coding-rules.md exists but there is no CLAUDE.md to import it" rm -f CLAUDE.md
+
 reset_repo

--- a/tests/cases/18-doctor.sh
+++ b/tests/cases/18-doctor.sh
@@ -468,4 +468,10 @@ doc_case "a prose-only mention of @coding-rules.md does not count as importing i
 doc_case "coding-rules.md with no CLAUDE.md at all to import it is reported" 1 \
   "coding-rules.md exists but there is no CLAUDE.md to import it" rm -f CLAUDE.md
 
+# Template drift (AGENTS.md, coding-rules.md vs. the shipped template, #133)
+# is a CONTENT question, the same shape as the shipped-rule-drift and
+# .gitignore-derivation checks below in cases/37, and putting it here would
+# have pushed this file over coding-rules.md rule 1's 500-line cap (measured:
+# 554 lines with it inline). See cases/37 for those cases.
+
 reset_repo

--- a/tests/cases/37-doctor-content-drift.sh
+++ b/tests/cases/37-doctor-content-drift.sh
@@ -1,21 +1,27 @@
 # shellcheck shell=bash
-# cases/37-doctor-content-drift.sh — the two scaffold-doctor checks that judge
+# cases/37-doctor-content-drift.sh — the scaffold-doctor checks that judge
 # CONTENT rather than arming: has the installed pattern data drifted from what
-# the scaffold shipped, and has .gitignore taken tracked source out of ESLint's
-# reach. Sourced into the driver's shell, so the globals
+# the scaffold shipped, has .gitignore taken tracked source out of ESLint's
+# reach, and has AGENTS.md / coding-rules.md drifted from the shipped template
+# (#133). Sourced into the driver's shell, so the globals
 # (PASS/FAIL/HOOK_OUT/SCAFFOLD_DIR) are already in scope.
 #
-# WHY THESE TWO LIVE TOGETHER, AND NOT IN cases/18. Every other doctor
-# assertion asks "is this mechanism armed": a bit, a path, a call site, a file's
-# presence. These two ask a harder question — the mechanism is armed and the
-# file is there, but its CONTENT no longer covers what it is supposed to cover.
-# Both derive their expectation from something else on disk instead of
+# WHY THESE LIVE TOGETHER, AND NOT IN cases/18. Every other doctor assertion
+# asks "is this mechanism armed": a bit, a path, a call site, a file's
+# presence. These ask a harder question — the mechanism is armed and the file
+# is there, but its CONTENT no longer covers what it is supposed to cover.
+# Each derives its expectation from something else on disk instead of
 # hardcoding it (the shipped forbidden-patterns template; the project's own
-# .gitignore), so both are one sloppy edit away from the same failure mode: a
-# check that widens into "report any difference", goes red on legitimate
-# customization, gets switched off, and leaves the real hole open under a green
-# report. That is why each of them is a PAIR here — the red half and the
-# narrowing half — and why the pairs are worth keeping side by side.
+# .gitignore; the shipped AGENTS.md.template / coding-rules.md), so each is one
+# sloppy edit away from the same failure mode: a check that widens into
+# "report any difference", goes red on legitimate customization, gets switched
+# off, and leaves the real hole open under a green report. That is why (A) and
+# (B) below are each a PAIR — the red half and the narrowing half — and why the
+# pairs are worth keeping side by side. (C), the AGENTS.md/coding-rules.md
+# check, is read-only (a NOTE, never a gap) precisely because both files are
+# user-owned once installed, so it does not need a narrowing half the same way:
+# an EXTRA local section was never mistaken for drift in the first place, only
+# a missing shipped one is.
 #
 # cases/18 keeps the arming checks and points here; splitting them was also what
 # kept both files under the 500-line cap in coding-rules.md rule 1.
@@ -25,7 +31,7 @@
 # borrowing a function defined by an earlier file would make the ORDER of the
 # case list load-bearing and would break this file when run on its own.
 
-echo "cases/37: scaffold-doctor's content-drift checks (shipped rules, .gitignore lint holes)"
+echo "cases/37: scaffold-doctor's content-drift checks (shipped rules, .gitignore lint holes, AGENTS.md/coding-rules.md drift)"
 
 # A fresh installed project. --shell deliberately: a package.json fixture makes
 # the hook chase a JS toolchain and go red on one runner only, and that failure
@@ -190,7 +196,107 @@ else
 fi
 rm -rf "$DOCD"
 
+# (C) TEMPLATE DRIFT: AGENTS.md and coding-rules.md vs. what the scaffold
+# ships today (#133). install_agents_md never rewrites an existing AGENTS.md
+# (even under --force: the Project section at its bottom is the user's own
+# text), and coding-rules.md is replaced wholesale only under --force. Both
+# policies are correct — these files are user-owned once installed — but a
+# scaffold release that adds a section to either shipped file then leaves
+# every existing install silently behind, with nothing on disk saying so.
+# Neither file carries a version marker, so section HEADINGS are the
+# inventory. Read-only: a NOTE, never a gap — a project may have deliberately
+# trimmed a section, and surfacing that is this check's job, not failing over it.
+docd_remove_agents_heading() {
+  sed -i.bak '/^## Plain-language change summary$/d' AGENTS.md && rm -f AGENTS.md.bak
+}
+docd_remove_coding_rules_heading() {
+  sed -i.bak '/^## Testing$/d' coding-rules.md && rm -f coding-rules.md.bak
+}
+
+# A fresh install carries every shipped section in both files: two ok lines,
+# no "predates" note anywhere, and the exit code is unchanged from a clean
+# install's baseline (cases/18's case A) — a note-worthy doctor must not also
+# add a gap where install.sh already did the right thing.
+DOCD=$(docd_project)
+docd_rc=0
+( cd "$DOCD" && "$SCAFFOLD_DIR/scaffold-doctor.sh" ) >"$HOOK_OUT" 2>&1 || docd_rc=$?
+if [ "$docd_rc" -eq 0 ] \
+   && grep -qF "AGENTS.md carries every section of the shipped template" "$HOOK_OUT" \
+   && grep -qF "coding-rules.md carries every section of the shipped template" "$HOOK_OUT" \
+   && ! grep -qF "predates the shipped template" "$HOOK_OUT"; then
+  echo "  ✓ a fresh install carries every shipped section in both files (ok, not a note)"
+  PASS=$((PASS + 1))
+else
+  echo "  ✗ fresh install misreported template drift (exit $docd_rc)"
+  sed 's/^/      /' "$HOOK_OUT"
+  FAIL=$((FAIL + 1))
+fi
+rm -rf "$DOCD"
+
+# Deleting ONE section heading from the installed AGENTS.md: named in a note,
+# exit stays 0 (a note is not a gap), and coding-rules.md's own ok line is
+# unaffected by a file it does not share a check with.
+DOCD=$(docd_project)
+( cd "$DOCD" && docd_remove_agents_heading ) >/dev/null 2>&1
+docd_rc=0
+( cd "$DOCD" && "$SCAFFOLD_DIR/scaffold-doctor.sh" ) >"$HOOK_OUT" 2>&1 || docd_rc=$?
+if [ "$docd_rc" -eq 0 ] \
+   && grep -qF 'AGENTS.md predates the shipped template: missing "## Plain-language change summary"' "$HOOK_OUT" \
+   && grep -qF "coding-rules.md carries every section of the shipped template" "$HOOK_OUT"; then
+  echo "  ✓ deleting one AGENTS.md section heading names it in a note, not a gap"
+  PASS=$((PASS + 1))
+else
+  echo "  ✗ a missing AGENTS.md heading was not reported as drift (exit $docd_rc)"
+  sed 's/^/      /' "$HOOK_OUT"
+  FAIL=$((FAIL + 1))
+fi
+rm -rf "$DOCD"
+
+# ...and the same shape, the other direction: coding-rules.md missing a
+# heading must not touch AGENTS.md's report.
+DOCD=$(docd_project)
+( cd "$DOCD" && docd_remove_coding_rules_heading ) >/dev/null 2>&1
+docd_rc=0
+( cd "$DOCD" && "$SCAFFOLD_DIR/scaffold-doctor.sh" ) >"$HOOK_OUT" 2>&1 || docd_rc=$?
+if [ "$docd_rc" -eq 0 ] \
+   && grep -qF 'coding-rules.md predates the shipped template: missing "## Testing"' "$HOOK_OUT" \
+   && grep -qF "AGENTS.md carries every section of the shipped template" "$HOOK_OUT"; then
+  echo "  ✓ deleting one coding-rules.md section heading names it in a note, not a gap"
+  PASS=$((PASS + 1))
+else
+  echo "  ✗ a missing coding-rules.md heading was not reported as drift (exit $docd_rc)"
+  sed 's/^/      /' "$HOOK_OUT"
+  FAIL=$((FAIL + 1))
+fi
+rm -rf "$DOCD"
+
+# A doctor whose scaffold dir lacks the shipped templates (copied without the
+# rest of the bundle, or mid-upgrade) must say so — same "not found next to
+# scaffold-doctor.sh" fallback shape as sections 4 and 8 — rather than
+# silently reporting the false "ok" a missing template would otherwise produce
+# as an empty diff. DRIFTLESS carries only scaffold-doctor.sh itself (section
+# 9 is inline, same as cases/20's DOCLESS fixture for section 8's fallback).
+DRIFTLESS=$(mktemp -d)
+cp "$SCAFFOLD_DIR/scaffold-doctor.sh" "$DRIFTLESS/scaffold-doctor.sh"
+chmod +x "$DRIFTLESS/scaffold-doctor.sh"
+DOCD=$(docd_project)
+docd_rc=0
+( cd "$DOCD" && "$DRIFTLESS/scaffold-doctor.sh" ) >"$HOOK_OUT" 2>&1 || docd_rc=$?
+if [ "$docd_rc" -eq 0 ] \
+   && grep -qF "AGENTS.md.template not found next to scaffold-doctor.sh ($DRIFTLESS): AGENTS.md drift cannot be checked" "$HOOK_OUT" \
+   && grep -qF "coding-rules.md not found next to scaffold-doctor.sh ($DRIFTLESS): coding-rules.md drift cannot be checked" "$HOOK_OUT" \
+   && ! grep -qF "carries every section of the shipped template" "$HOOK_OUT"; then
+  echo "  ✓ a scaffold dir missing the shipped templates reports the fallback note, not a false ok"
+  PASS=$((PASS + 1))
+else
+  echo "  ✗ the missing-shipped-template fallback misbehaved (exit $docd_rc)"
+  sed 's/^/      /' "$HOOK_OUT"
+  FAIL=$((FAIL + 1))
+fi
+rm -rf "$DOCD" "$DRIFTLESS"
+
 unset DOCD docd_rc docd_shipped docd_missing
 unset -f docd_project docd_trim_secrets docd_extend_patterns
 unset -f docd_eslint_derived docd_ignore_source docd_ignore_build_output
+unset -f docd_remove_agents_heading docd_remove_coding_rules_heading
 reset_repo

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -89,7 +89,7 @@ CASE_FLOORS=(
   "15-local-checks.sh:7"
   "16-coverage-gate.sh:6"
   "17-whole-tree-configs.sh:11"
-  "18-doctor.sh:31"
+  "18-doctor.sh:35"
   "19-test-workflow.sh:17"
   "20-paired-artifacts.sh:19"
   "21-ci-workflow-drift.sh:25"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -108,7 +108,7 @@ CASE_FLOORS=(
   "34-shipped-pattern-files.sh:11"
   "35-workflow-template-validity.sh:15"
   "36-red-green-verdict.sh:3"
-  "37-doctor-content-drift.sh:4"
+  "37-doctor-content-drift.sh:8"
   "38-components-catalog.sh:33"
   "39-scaffold-assess.sh:10"
   "40-doctor-required-checks.sh:6"


### PR DESCRIPTION
Closes #136, closes #134, closes #133.

## Why

Nothing on this branch blocks a new install. The problem is the existing ones: the installer never rewrites a user-owned `AGENTS.md`, rewrites `coding-rules.md` only wholesale under `--force`, and prints a one-time note when an already-wired `CLAUDE.md` lacks the `@coding-rules.md` import. So every rule improvement shipped only to new repos, and nothing told older installs they were behind. Visibility, not force, was the missing piece, so all three land in `scaffold-doctor.sh`.

## What changed

- **#136** `scaffold-doctor.sh` reports a gap when `coding-rules.md` exists but `CLAUDE.md` has no line reading exactly `@coding-rules.md` (anchored, so prose mentions do not count), or no `CLAUDE.md` at all.
- **#134** `AGENTS.md.template` no longer asserts `git hook run pre-commit` unconditionally. It now says the command exercises the guards only when `core.hooksPath` is `.githooks`, that `install.sh` leaves an already-set `core.hooksPath` alone (Husky does this by default; managers that write into `.git/hooks/` do not), and to run `.githooks/pre-commit` directly otherwise. The doctor half of #134 was already on main in section 1.
- **#133, option 1** New doctor section "template drift": a note (never a gap, since the files are user-owned) when the installed `AGENTS.md` or `coding-rules.md` lacks any `##` or `###` heading the shipped template carries, naming the missing headings and the fix path. A doctor copied without the rest of the bundle reports the templates as missing rather than a false ok.
- Changelog `[Unreleased]` section, a "Template drift" subsection under the doctor docs in `TECHNICAL.md`, one sentence in `COMPONENTS.md`. No version bump.

## Measurements

| Check | Result |
|---|---|
| `bash tests/run.sh` | 619 passed, 0 failed (main: 611) |
| Branch tests against main's doctor | 8 failed, exactly the 8 new assertions |
| Independent fixtures (fresh-context verifier) | 17 mutations, each check fired or stayed silent as specified |
| prettier on changed docs | clean |
| shellcheck | same 3 pre-existing SC1091 notices, nothing new |
| Em dashes added to customer-facing docs | 0 |

## Not delivered, on purpose

- #136 part 2 (the installer appending the missing import into an already-wired `CLAUDE.md`) is not here and was never delivered by v0.17 either. The doctor gap now makes the state visible; nothing writes the line.
- #133's heading inventory cannot see a prose-only change. Documented in `TECHNICAL.md`.

## Known nits, not fixed here

- The #136 check fires on the scaffold repo itself (shipped `coding-rules.md` as source, no root `CLAUDE.md`), so the doctor on this checkout reports 2 gaps to main's 1. No CI job runs the doctor on the repo, so this is not a red check.
- `scaffold-doctor.sh` is at 499 lines against the 500 cap. The next check added must move out to a module.
- The heading comparison is byte-exact, so a case change or renamed user-owned `## Project` heading produces a note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
