### PR TITLE
chore(release): v0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 versioning follows [SemVer](https://semver.org/).
 
-## [Unreleased]
+## [v0.19.0] - 2026-09-04
 
 ### Added
 

--- a/COMPONENTS.md
+++ b/COMPONENTS.md
@@ -21,13 +21,13 @@ Commands assume `$SCAFFOLD` points at a copy of this repository. Pick one:
 
 ```sh
 # a pinned clone (no Node needed)
-git clone --branch v0.18.1 https://github.com/Sting25/ai-coding-rules-scaffold ~/src/ai-coding-rules-scaffold
+git clone --branch v0.19.0 https://github.com/Sting25/ai-coding-rules-scaffold ~/src/ai-coding-rules-scaffold
 export SCAFFOLD=~/src/ai-coding-rules-scaffold
 ```
 
 ```sh
 # or the published npm tarball, unpacked, no clone
-cd "$(mktemp -d)" && npm pack ai-coding-rules-scaffold@0.18.1 --silent && tar xzf ai-coding-rules-scaffold-*.tgz
+cd "$(mktemp -d)" && npm pack ai-coding-rules-scaffold@0.19.0 --silent && tar xzf ai-coding-rules-scaffold-*.tgz
 export SCAFFOLD="$PWD/package"
 ```
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ the components you want with the commands in each entry; every entry has a
 verify step, and `scaffold-assess.sh` measures what each would flag first.
 
 ```sh
-git clone --branch v0.18.1 https://github.com/Sting25/ai-coding-rules-scaffold ~/src/ai-coding-rules-scaffold
+git clone --branch v0.19.0 https://github.com/Sting25/ai-coding-rules-scaffold ~/src/ai-coding-rules-scaffold
 export SCAFFOLD=~/src/ai-coding-rules-scaffold
 bash "$SCAFFOLD/scaffold-assess.sh"        # from your project root: what would each component flag?
 ```
@@ -95,7 +95,7 @@ somewhere stable:
 
 ```sh
 # Recommended: pin to a tagged release for reproducibility
-git clone --branch v0.18.1 https://github.com/Sting25/ai-coding-rules-scaffold ~/src/ai-coding-rules-scaffold
+git clone --branch v0.19.0 https://github.com/Sting25/ai-coding-rules-scaffold ~/src/ai-coding-rules-scaffold
 # Or track main if you want the latest changes
 git clone https://github.com/Sting25/ai-coding-rules-scaffold ~/src/ai-coding-rules-scaffold
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-coding-rules-scaffold",
-  "version": "0.18.1",
+  "version": "0.19.0",
   "description": "Agent-agnostic coding-rules scaffold: pre-commit + CI guardrails (file size, forbidden patterns, secret/credential scanning, hygiene) that install into your project, plus `scaffold-doctor` to check they are actually armed and not just present. Run via `npx ai-coding-rules-scaffold`. AI agents: run the installer, never hand-copy files.",
   "bin": {
     "ai-coding-rules-scaffold": "bin/cli.js"


### PR DESCRIPTION
Release prep per RELEASING.md step 1. Promotes `[Unreleased]` to `## [v0.19.0] - 2026-09-04` and bumps the derived pins (README clone lines, COMPONENTS.md clone and npm pack lines, package.json). Minor bump: the section carries two Added entries (the #136 import check and the #133 template-drift note in scaffold-doctor.sh) and one Changed entry (the #134 template hedge).

Pre-push checks run locally: prettier clean on the three markdown files, `check-secrets --ci` over `ls-files` exit 0.

After merge: annotated tag `v0.19.0` on main triggers release.yml (npm via OIDC, GitHub Release from this changelog section), then the tap's bump-formula workflow, then a canonical formula sync PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
