### PR TITLE
test: make a failed fixture install fail the suite loudly

### DIFF
--- a/tests/cases/15-local-checks.sh
+++ b/tests/cases/15-local-checks.sh
@@ -44,18 +44,21 @@ LC_EOF
 # that never ran npm install. Shell mode installs no ruff/eslint/prettier/tsc
 # config, so nothing but the guardrails and local.d can decide the exit status.
 _fixture() {
-  local d; d=$(mktemp -d)
-  ( cd "$d" && git init --quiet && git config user.email test@test.local && git config user.name "Scaffold Test" && git config core.hooksPath .nohooks \
-    && printf '#!/usr/bin/env bash\necho seed\n' >seed.sh && git add -A \
-    && git -c user.email=t@t -c user.name=t commit --quiet -m seed \
-    && "$SCAFFOLD_DIR/install.sh" --shell ) >/dev/null 2>&1
-  ( cd "$d" && git config --unset core.hooksPath && git config core.hooksPath .githooks )
-  printf '%s' "$d"
+  local __fixture_var=$1 d
+  fixture_repo d
+  git -C "$d" config core.hooksPath .nohooks
+  printf '#!/usr/bin/env bash\necho seed\n' >"$d/seed.sh"
+  git -C "$d" add -A
+  git -C "$d" -c user.email=t@t -c user.name=t commit --quiet -m seed
+  fixture_install "$d" --shell
+  git -C "$d" config --unset core.hooksPath
+  git -C "$d" config core.hooksPath .githooks
+  printf -v "$__fixture_var" '%s' "$d"
 }
 
 # (T) install.sh creates local.d with an INERT README — inert because the hook's
 #     -x guard skips it. A README that arrived executable would be RUN.
-LTMP=$(_fixture)
+_fixture LTMP
 if [ -f "$LTMP/.githooks/local.d/README.md" ] && [ ! -x "$LTMP/.githooks/local.d/README.md" ]; then
   echo "  ✓ install.sh creates .githooks/local.d/ with a non-executable README"; PASS=$((PASS + 1))
 else

--- a/tests/cases/18-doctor.sh
+++ b/tests/cases/18-doctor.sh
@@ -14,12 +14,14 @@ echo "cases/18 — scaffold-doctor (armed vs merely installed)"
 # the hook chase a JS toolchain and go red on one runner only, and that failure
 # then gets misread as a verdict on whatever was actually under test.
 doc_project() {
-  local t
-  t=$(mktemp -d)
-  ( cd "$t" && git init --quiet && git config user.email test@test.local && git config user.name "Scaffold Test" \
-    && echo '#!/usr/bin/env bash' >run.sh \
-    && "$SCAFFOLD_DIR/install.sh" --shell --no-verify ) >/dev/null 2>&1
-  printf '%s' "$t"
+  # __doc_project_dir, not "t": doc_case below also has `local t`, and a
+  # same-named local here would shadow it (dynamic scoping), so `printf -v
+  # "$1"` would bind to this function's own shadow instead of the caller's.
+  local __doc_project_var=$1 __doc_project_dir
+  fixture_repo __doc_project_dir
+  echo '#!/usr/bin/env bash' >"$__doc_project_dir/run.sh"
+  fixture_install "$__doc_project_dir" --shell --no-verify
+  printf -v "$__doc_project_var" '%s' "$__doc_project_dir"
 }
 
 # Mutations that need a variable expanded at run time are shell FUNCTIONS, not
@@ -37,7 +39,7 @@ doc_case() {
   local name=$1 want=$2 expect=$3
   shift 3
   local t rc=0
-  t=$(doc_project)
+  doc_project t
   ( cd "$t" && "$@" ) >/dev/null 2>&1 || true
   ( cd "$t" && "$SCAFFOLD_DIR/scaffold-doctor.sh" ) >"$HOOK_OUT" 2>&1 || rc=$?
   if [ "$rc" -eq "$want" ] && grep -qF "$expect" "$HOOK_OUT"; then
@@ -84,7 +86,7 @@ doc_case "a trailing-slash core.hooksPath is armed, not a gap" 0 \
 # spelling family was certified healthy in exactly the environment that works.
 doc_hookspath_relative() { git config core.hooksPath ./.githooks; }
 for doc_spell in doc_hookspath_absolute doc_hookspath_relative; do
-  DOCT=$(doc_project)
+  doc_project DOCT
   ( cd "$DOCT" && "$doc_spell" ) >/dev/null 2>&1
   doc_rc=0
   ( cd "$DOCT" && CDPATH=. "$SCAFFOLD_DIR/scaffold-doctor.sh" --quiet ) >"$HOOK_OUT" 2>&1 || doc_rc=$?
@@ -171,7 +173,7 @@ CAPS_TOML
 # not mistaken for "the report counts it".
 doc_note_count() { sed -n 's/.*, \([0-9][0-9]*\) note(s).*/\1/p' "$1" | tail -1; }
 
-DOCT=$(doc_project)
+doc_project DOCT
 doc_rc=0
 ( cd "$DOCT" && "$SCAFFOLD_DIR/scaffold-doctor.sh" --quiet ) >"$HOOK_OUT" 2>&1 || doc_rc=$?
 doc_notes_before=$(doc_note_count "$HOOK_OUT")
@@ -208,7 +210,7 @@ rm -rf "$DOCT"
 # A raised cap disarms a guardrail exactly as a disable does, so it is reported
 # the same way, with the new value, because "500 KB" is the thing the reader
 # believes is in force.
-DOCT=$(doc_project)
+doc_project DOCT
 ( cd "$DOCT" && doc_raise_caps ) >/dev/null 2>&1
 doc_rc=0
 ( cd "$DOCT" && "$SCAFFOLD_DIR/scaffold-doctor.sh" --quiet ) >"$HOOK_OUT" 2>&1 || doc_rc=$?
@@ -225,7 +227,7 @@ rm -rf "$DOCT"
 # ...and the shipped, override-free .scaffold.toml must stay silent: a doctor
 # that reported an off-switch on every clean project would train the reader to
 # skip the line that matters.
-DOCT=$(doc_project)
+doc_project DOCT
 doc_rc=0
 ( cd "$DOCT" && "$SCAFFOLD_DIR/scaffold-doctor.sh" --quiet ) >"$HOOK_OUT" 2>&1 || doc_rc=$?
 if [ "$doc_rc" -eq 0 ] && grep -qF "0 gaps" "$HOOK_OUT" \
@@ -275,7 +277,7 @@ doc_drop_all_callsites() {
   chmod +x .githooks/pre-commit
 }
 
-DOCT=$(doc_project)
+doc_project DOCT
 ( cd "$DOCT" && doc_drop_all_callsites ) >/dev/null 2>&1
 doc_rc=0
 ( cd "$DOCT" && "$SCAFFOLD_DIR/scaffold-doctor.sh" ) >"$HOOK_OUT" 2>&1 || doc_rc=$?
@@ -296,7 +298,7 @@ rm -rf "$DOCT"
 # inert: a note, not a gap. It must survive --quiet, because that is the mode a
 # CI step or a pre-flight script reads, and "armed, 0 gaps" over a check no CI
 # job runs is the misleading summary #72 was made of.
-DOCT=$(doc_project)
+doc_project DOCT
 ( cd "$DOCT" && doc_drop_ci_callsite ) >/dev/null 2>&1
 doc_rc=0
 ( cd "$DOCT" && "$SCAFFOLD_DIR/scaffold-doctor.sh" --quiet ) >"$HOOK_OUT" 2>&1 || doc_rc=$?
@@ -334,7 +336,7 @@ doc_minbin() {
   printf '%s' "$d"
 }
 
-DOCT=$(doc_project)
+doc_project DOCT
 DOCBIN=$(doc_minbin)
 cp "$SCAFFOLD_DIR/githooks/lib/check-gitleaks.template" "$DOCT/.githooks/lib/check-gitleaks"
 chmod +x "$DOCT/.githooks/lib/check-gitleaks"
@@ -351,7 +353,7 @@ fi
 rm -rf "$DOCT"
 
 # agent-precheck with no jq says NOTHING, anywhere, ever — so it is a gap.
-DOCT=$(doc_project)
+doc_project DOCT
 cp "$SCAFFOLD_DIR/githooks/lib/agent-precheck.template" "$DOCT/.githooks/lib/agent-precheck"
 chmod +x "$DOCT/.githooks/lib/agent-precheck"
 doc_rc=0
@@ -372,7 +374,7 @@ rm -rf "$DOCT" "$DOCBIN"
 # agent runtimes block only on exit 2. Measured: the tool call proceeds, and
 # nothing is printed anywhere. The doctor reported "armed" for this until it
 # was caught in review.
-DOCT=$(doc_project)
+doc_project DOCT
 cp "$SCAFFOLD_DIR/githooks/lib/agent-precheck.template" "$DOCT/.githooks/lib/agent-precheck"
 chmod -x "$DOCT/.githooks/lib/agent-precheck"
 doc_rc=0
@@ -390,7 +392,7 @@ rm -rf "$DOCT"
 # (I) The shipped checks read their config by bare relative path, which works
 # only because git runs hooks from the top of the tree. A doctor run from a
 # subdirectory must reproduce that or it reports phantom gaps.
-DOCT=$(doc_project)
+doc_project DOCT
 mkdir -p "$DOCT/src/deep"
 doc_rc=0
 ( cd "$DOCT/src/deep" && "$SCAFFOLD_DIR/scaffold-doctor.sh" ) >"$HOOK_OUT" 2>&1 || doc_rc=$?
@@ -422,7 +424,7 @@ rm -rf "$DOCT"
 # (K) --quiet is what a CI step or a pre-flight script would call: gaps and the
 # summary only, with the section named inline since the headers are suppressed.
 doc_rc=0
-DOCT=$(doc_project)
+doc_project DOCT
 chmod -x "$DOCT/.githooks/pre-commit"
 ( cd "$DOCT" && "$SCAFFOLD_DIR/scaffold-doctor.sh" --quiet ) >"$HOOK_OUT" 2>&1 || doc_rc=$?
 if [ "$doc_rc" -eq 1 ] && grep -qF "[hook entry point]" "$HOOK_OUT" && ! grep -qF "✓" "$HOOK_OUT"; then
@@ -473,5 +475,26 @@ doc_case "coding-rules.md with no CLAUDE.md at all to import it is reported" 1 \
 # .gitignore-derivation checks below in cases/37, and putting it here would
 # have pushed this file over coding-rules.md rule 1's 500-line cap (measured:
 # 554 lines with it inline). See cases/37 for those cases.
+
+# (N) fixture_install itself must fail LOUD: the positive proof for the fix
+# behind tests/lib/common.sh's fixture_repo/fixture_install (CI run
+# 33922341907 died with exit 2 and no assertion printed — see that file's
+# comment for the mechanism). Wrapped in "( ... )": fixture_install's
+# failure path ends in `exit 1` on purpose, so calling it unwrapped here
+# would end this run, not just this one assertion.
+fixture_repo FI_D
+FI_OUT=$(mktemp)
+FI_RC=0
+( fixture_install "$FI_D" --no-such-flag ) >"$FI_OUT" 2>&1 || FI_RC=$?
+if [ "$FI_RC" -eq 1 ] && grep -qF "FIXTURE INSTALL FAILED" "$FI_OUT"; then
+  echo "  ✓ fixture_install fails the suite loudly when install.sh fails"
+  PASS=$((PASS + 1))
+else
+  echo "  ✗ fixture_install did not fail loudly (exit $FI_RC, or missing: FIXTURE INSTALL FAILED)"
+  sed 's/^/      /' "$FI_OUT"
+  FAIL=$((FAIL + 1))
+fi
+rm -rf "$FI_D"
+rm -f "$FI_OUT"
 
 reset_repo

--- a/tests/cases/20-paired-artifacts.sh
+++ b/tests/cases/20-paired-artifacts.sh
@@ -17,31 +17,35 @@
 
 echo "cases/20: paired-artifact half-install detection (#96)"
 
+# Every project-fn below names its inner directory var __pa_dir, never "t":
+# pa_case/pa_case_absent below both declare `local t`, and bash's dynamic
+# scoping means a `local t` in one of these functions would shadow the
+# caller's `t` for the call's whole duration, so `printf -v "$1"` (called as
+# `"$projfn" t`) would bind to the shadow instead of the caller's variable,
+# silently leaving it empty (measured while writing this conversion — see
+# cases/18-doctor.sh's doc_project for the reproduction).
 pa_python_project() {
-  local t
-  t=$(mktemp -d)
-  ( cd "$t" && git init --quiet && git config user.email test@test.local && git config user.name "Scaffold Test" \
-    && echo 'name = "test"' >pyproject.toml \
-    && "$SCAFFOLD_DIR/install.sh" --python --no-verify ) >/dev/null 2>&1
-  printf '%s' "$t"
+  local __pa_var=$1 __pa_dir
+  fixture_repo __pa_dir
+  echo 'name = "test"' >"$__pa_dir/pyproject.toml"
+  fixture_install "$__pa_dir" --python --no-verify
+  printf -v "$__pa_var" '%s' "$__pa_dir"
 }
 
 pa_shell_project() {
-  local t
-  t=$(mktemp -d)
-  ( cd "$t" && git init --quiet && git config user.email test@test.local && git config user.name "Scaffold Test" \
-    && echo '#!/usr/bin/env bash' >run.sh \
-    && "$SCAFFOLD_DIR/install.sh" --shell --no-verify ) >/dev/null 2>&1
-  printf '%s' "$t"
+  local __pa_var=$1 __pa_dir
+  fixture_repo __pa_dir
+  echo '#!/usr/bin/env bash' >"$__pa_dir/run.sh"
+  fixture_install "$__pa_dir" --shell --no-verify
+  printf -v "$__pa_var" '%s' "$__pa_dir"
 }
 
 pa_frontend_coverage_project() {
-  local t
-  t=$(mktemp -d)
-  ( cd "$t" && git init --quiet && git config user.email test@test.local && git config user.name "Scaffold Test" \
-    && echo '{"name":"t"}' >package.json \
-    && "$SCAFFOLD_DIR/install.sh" --frontend --coverage-gate --no-verify ) >/dev/null 2>&1
-  printf '%s' "$t"
+  local __pa_var=$1 __pa_dir
+  fixture_repo __pa_dir
+  echo '{"name":"t"}' >"$__pa_dir/package.json"
+  fixture_install "$__pa_dir" --frontend --coverage-gate --no-verify
+  printf -v "$__pa_var" '%s' "$__pa_dir"
 }
 
 # Mutations that need a variable expanded at run time are shell FUNCTIONS, not
@@ -65,7 +69,7 @@ pa_case() {
   local name=$1 projfn=$2 want=$3 expect=$4
   shift 4
   local t rc=0
-  t=$("$projfn")
+  "$projfn" t
   ( cd "$t" && "$@" ) >/dev/null 2>&1 || true
   ( cd "$t" && "$SCAFFOLD_DIR/scaffold-doctor.sh" ) >"$HOOK_OUT" 2>&1 || rc=$?
   if [ "$rc" -eq "$want" ] && grep -qF "$expect" "$HOOK_OUT"; then
@@ -87,7 +91,7 @@ pa_case_absent() {
   local name=$1 projfn=$2 not_expect=$3
   shift 3
   local t rc=0
-  t=$("$projfn")
+  "$projfn" t
   ( cd "$t" && "$@" ) >/dev/null 2>&1 || true
   ( cd "$t" && "$SCAFFOLD_DIR/scaffold-doctor.sh" ) >"$HOOK_OUT" 2>&1 || rc=$?
   if ! grep -qF "$not_expect" "$HOOK_OUT"; then
@@ -186,7 +190,7 @@ rm -rf "$IT"
 DOCLESS=$(mktemp -d)
 cp "$SCAFFOLD_DIR/scaffold-doctor.sh" "$DOCLESS/scaffold-doctor.sh"
 chmod +x "$DOCLESS/scaffold-doctor.sh"
-PT=$(pa_shell_project)
+pa_shell_project PT
 doc_rc=0
 ( cd "$PT" && "$DOCLESS/scaffold-doctor.sh" ) >"$HOOK_OUT" 2>&1 || doc_rc=$?
 if [ "$doc_rc" -eq 0 ] && grep -qF "install-wiring.sh not found next to scaffold-doctor.sh" "$HOOK_OUT"; then
@@ -210,24 +214,22 @@ reset_repo
 # `grep -rl agent-precheck .claude .cursor` found nothing while the doctor's
 # output was byte-identical to a correctly-wired install's.
 pa_stub_agent_project() {
-  local t
-  t=$(mktemp -d)
-  ( cd "$t" && git init --quiet && git config user.email test@test.local && git config user.name "Scaffold Test" \
-    && echo '{"name":"t"}' >package.json \
-    && mkdir -p .claude .cursor \
-    && echo '{"permissions":{"allow":["Bash(ls:*)"]}}' >.claude/settings.json \
-    && echo '{"hooks":{}}' >.cursor/hooks.json \
-    && "$SCAFFOLD_DIR/install.sh" --frontend --claude --cursor --no-verify ) >/dev/null 2>&1
-  printf '%s' "$t"
+  local __pa_var=$1 __pa_dir
+  fixture_repo __pa_dir
+  echo '{"name":"t"}' >"$__pa_dir/package.json"
+  mkdir -p "$__pa_dir/.claude" "$__pa_dir/.cursor"
+  echo '{"permissions":{"allow":["Bash(ls:*)"]}}' >"$__pa_dir/.claude/settings.json"
+  echo '{"hooks":{}}' >"$__pa_dir/.cursor/hooks.json"
+  fixture_install "$__pa_dir" --frontend --claude --cursor --no-verify
+  printf -v "$__pa_var" '%s' "$__pa_dir"
 }
 
 pa_wired_agent_project() {
-  local t
-  t=$(mktemp -d)
-  ( cd "$t" && git init --quiet && git config user.email test@test.local && git config user.name "Scaffold Test" \
-    && echo '{"name":"t"}' >package.json \
-    && "$SCAFFOLD_DIR/install.sh" --frontend --claude --no-verify ) >/dev/null 2>&1
-  printf '%s' "$t"
+  local __pa_var=$1 __pa_dir
+  fixture_repo __pa_dir
+  echo '{"name":"t"}' >"$__pa_dir/package.json"
+  fixture_install "$__pa_dir" --frontend --claude --no-verify
+  printf -v "$__pa_var" '%s' "$__pa_dir"
 }
 
 pa_case "agent-precheck installed with configs that never invoke it is a gap" \

--- a/tests/cases/21-ci-workflow-drift.sh
+++ b/tests/cases/21-ci-workflow-drift.sh
@@ -42,8 +42,9 @@
 
 echo "cases/21: CI workflow drift-preserving install policy (lint.yml #105, tests/coverage/gitleaks.yml #110, dependency-review.yml #113, zizmor/socket-security P-19)"
 
-# _wd_fixture EXTRA_FLAG: a throwaway frontend-mode repo with the scaffold
-# installed. EXTRA_FLAG is the flag (if any) needed for this run to touch the
+# _wd_fixture VAR EXTRA_FLAG: a throwaway frontend-mode repo with the scaffold
+# installed, its path assigned to the variable named VAR. EXTRA_FLAG is the
+# flag (if any) needed for this run to touch the
 # workflow under test: coverage.yml only installs under --coverage-gate,
 # gitleaks.yml only installs under --gitleaks-ci (an opt-in workflow install.sh
 # only ever writes to when the flag is passed on THAT run, unlike coverage.yml
@@ -51,16 +52,15 @@ echo "cases/21: CI workflow drift-preserving install policy (lint.yml #105, test
 # need nothing extra. Branches on EXTRA_FLAG rather than an unquoted expansion
 # so an empty flag never turns into a stray empty-string argument.
 _wd_fixture() {
-  local extra=$1 t
-  t=$(mktemp -d)
+  local __wd_var=$1 extra=$2 t
+  fixture_repo t
+  echo '{"name":"x"}' >"$t/package.json"
   if [ -n "$extra" ]; then
-    ( cd "$t" && git init --quiet && git config user.email test@test.local && git config user.name "Scaffold Test" && echo '{"name":"x"}' >package.json \
-      && "$SCAFFOLD_DIR/install.sh" --frontend --no-verify "$extra" ) >/dev/null 2>&1
+    fixture_install "$t" --frontend --no-verify "$extra"
   else
-    ( cd "$t" && git init --quiet && git config user.email test@test.local && git config user.name "Scaffold Test" && echo '{"name":"x"}' >package.json \
-      && "$SCAFFOLD_DIR/install.sh" --frontend --no-verify ) >/dev/null 2>&1
+    fixture_install "$t" --frontend --no-verify
   fi
-  printf '%s' "$t"
+  printf -v "$__wd_var" '%s' "$t"
 }
 
 # _wd_install DIR EXTRA_FLAG [MORE_FLAGS...]: re-run install.sh in DIR with
@@ -85,7 +85,7 @@ _wd_case() {
 
   # (T) a drifted FILE is PRESERVED and the drift note is printed, with no
   #     .scaffold-bak: cp_scaffold_preserve only backs up under --force.
-  T1=$(_wd_fixture "$extra")
+  _wd_fixture T1 "$extra"
   printf '\n# local CI customization: setup-node for a local.d check\n' >>"$T1/$rel"
   _wd_install "$T1" "$extra"
   if grep -qF "local CI customization" "$T1/$rel" \
@@ -100,7 +100,7 @@ _wd_case() {
 
   # (T) --force on a drifted FILE backs up the user's version, then installs
   #     the shipped one: the documented escape hatch from the drift note.
-  T2=$(_wd_fixture "$extra")
+  _wd_fixture T2 "$extra"
   printf '\n# local CI customization: setup-node for a local.d check\n' >>"$T2/$rel"
   _wd_install "$T2" "$extra" --force
   if [ -f "$T2/$rel.scaffold-bak" ] \
@@ -118,7 +118,7 @@ _wd_case() {
   #     filename appears nowhere in the output", since coverage.yml and
   #     gitleaks.yml both print an unconditional explanatory "note:" line on
   #     every run regardless of drift state.
-  T3=$(_wd_fixture "$extra")
+  _wd_fixture T3 "$extra"
   _wd_install "$T3" "$extra"
   if cmp -s "$tpl" "$T3/$rel" \
      && ! grep -q "note (drift):.*$base" "$HOOK_OUT" \
@@ -145,7 +145,7 @@ _wd_case "test-guard.yml" ".github/workflows/test-guard.yml" "$SCAFFOLD_DIR/.git
 # default-on would break consumer CI (#113). Same shape as the opt-in check
 # _wd_case already proves per-workflow above, but this asserts ABSENCE on the
 # plain, no-flag install path rather than presence behind its own flag.
-T4=$(_wd_fixture "")
+_wd_fixture T4 ""
 if [ ! -e "$T4/.github/workflows/dependency-review.yml" ]; then
   echo "  ✓ [dependency-review.yml] a default install does not create it"; PASS=$((PASS + 1))
 else

--- a/tests/cases/23-npm-cooldown.sh
+++ b/tests/cases/23-npm-cooldown.sh
@@ -10,14 +10,15 @@
 echo "cases/23: --npm-cooldown opt-in flag (#117)"
 
 _npmc_fixture() {
-  local t; t=$(mktemp -d)
-  ( cd "$t" && git init --quiet && git config user.email test@test.local && git config user.name "Scaffold Test" && echo '{"name":"x"}' >package.json \
-    && "$SCAFFOLD_DIR/install.sh" --frontend --no-verify "$@" ) >/dev/null 2>&1
-  printf '%s' "$t"
+  local __npmc_var=$1 t; shift
+  fixture_repo t
+  echo '{"name":"x"}' >"$t/package.json"
+  fixture_install "$t" --frontend --no-verify "$@"
+  printf -v "$__npmc_var" '%s' "$t"
 }
 
 # (T) a default install (no flag) writes no .npmrc: stays opt-in.
-D=$(_npmc_fixture)
+_npmc_fixture D
 if [ ! -e "$D/.npmrc" ]; then
   echo "  ✓ a default install creates no .npmrc"; PASS=$((PASS + 1))
 else
@@ -27,7 +28,7 @@ rm -rf "$D"
 
 # (T) --npm-cooldown installs .npmrc with min-release-age=7, byte-identical
 # to the shipped template.
-N=$(_npmc_fixture --npm-cooldown)
+_npmc_fixture N --npm-cooldown
 if [ -f "$N/.npmrc" ] && grep -q '^min-release-age=7$' "$N/.npmrc" \
    && cmp -s "$SCAFFOLD_DIR/.npmrc.template" "$N/.npmrc"; then
   echo "  ✓ --npm-cooldown installs .npmrc with min-release-age=7"; PASS=$((PASS + 1))
@@ -39,7 +40,7 @@ rm -rf "$N"
 # (T) cp_safe semantics: a hand-edited .npmrc is left alone on a plain
 # re-run (no drift note, no backup), and --force backs it up then replaces
 # it with the shipped version.
-S=$(_npmc_fixture --npm-cooldown)
+_npmc_fixture S --npm-cooldown
 printf '\n# local override\nregistry=https://example.invalid/\n' >>"$S/.npmrc"
 ( cd "$S" && "$SCAFFOLD_DIR/install.sh" --frontend --no-verify --npm-cooldown ) >"$HOOK_OUT" 2>&1
 if grep -qF "local override" "$S/.npmrc" && [ ! -e "$S/.npmrc.scaffold-bak" ] \
@@ -58,7 +59,7 @@ fi
 rm -rf "$S"
 
 # (T) uninstall.sh removes an unmodified .npmrc.
-U=$(_npmc_fixture --npm-cooldown)
+_npmc_fixture U --npm-cooldown
 ( cd "$U" && "$SCAFFOLD_DIR/uninstall.sh" ) >"$HOOK_OUT" 2>&1
 if [ ! -e "$U/.npmrc" ]; then
   echo "  ✓ uninstall.sh removes an unmodified .npmrc"; PASS=$((PASS + 1))

--- a/tests/cases/24-claude-skill.sh
+++ b/tests/cases/24-claude-skill.sh
@@ -10,14 +10,16 @@
 echo "cases/24: --claude-skill opt-in flag (#118 pt 2)"
 
 _cskill_fixture() {
-  local t; t=$(mktemp -d)
-  ( cd "$t" && git init --quiet && git config user.email test@test.local && git config user.name "Scaffold Test" && echo '{"name":"x"}' >package.json \
-    && "$SCAFFOLD_DIR/install.sh" --frontend --no-verify "$@" ) >/dev/null 2>&1
-  printf '%s' "$t"
+  local __cskill_fixture_var=$1 t
+  shift
+  fixture_repo t
+  echo '{"name":"x"}' >"$t/package.json"
+  fixture_install "$t" --frontend --no-verify "$@"
+  printf -v "$__cskill_fixture_var" '%s' "$t"
 }
 
 # (T) a default install (no flag) writes no Skill file: stays opt-in.
-D=$(_cskill_fixture)
+_cskill_fixture D
 if [ ! -e "$D/.claude/skills/coding-rules/SKILL.md" ]; then
   echo "  ✓ a default install creates no Claude Skill"; PASS=$((PASS + 1))
 else
@@ -27,7 +29,7 @@ rm -rf "$D"
 
 # (T) --claude-skill installs SKILL.md, byte-identical to the shipped
 # template, with valid frontmatter naming both installed rules files.
-K=$(_cskill_fixture --claude-skill)
+_cskill_fixture K --claude-skill
 SKILL_PATH="$K/.claude/skills/coding-rules/SKILL.md"
 if [ -f "$SKILL_PATH" ] \
    && cmp -s "$SCAFFOLD_DIR/claude-skill/coding-rules/SKILL.md.template" "$SKILL_PATH" \
@@ -45,7 +47,7 @@ rm -rf "$K"
 # (T) cp_safe semantics: a hand-edited SKILL.md is left alone on a plain
 # re-run (no drift note, no backup), and --force backs it up then replaces
 # it with the shipped version.
-S=$(_cskill_fixture --claude-skill)
+_cskill_fixture S --claude-skill
 SKILL_PATH="$S/.claude/skills/coding-rules/SKILL.md"
 printf '\nlocal note\n' >>"$SKILL_PATH"
 ( cd "$S" && "$SCAFFOLD_DIR/install.sh" --frontend --no-verify --claude-skill ) >"$HOOK_OUT" 2>&1
@@ -66,7 +68,7 @@ rm -rf "$S"
 
 # (T) uninstall.sh removes an unmodified SKILL.md and sweeps the now-empty
 # .claude/skills/coding-rules + .claude/skills directories.
-U=$(_cskill_fixture --claude-skill)
+_cskill_fixture U --claude-skill
 ( cd "$U" && "$SCAFFOLD_DIR/uninstall.sh" ) >"$HOOK_OUT" 2>&1
 if [ ! -e "$U/.claude/skills/coding-rules/SKILL.md" ] && [ ! -d "$U/.claude/skills" ]; then
   echo "  ✓ uninstall.sh removes an unmodified SKILL.md and sweeps the emptied dirs"; PASS=$((PASS + 1))

--- a/tests/cases/26-repo-adaptation-warn.sh
+++ b/tests/cases/26-repo-adaptation-warn.sh
@@ -14,16 +14,17 @@
 echo "cases/26: _backup warns on a dropped '# Repo adaptation:' marker (#127)"
 
 _radapt_fixture() {
-  local t; t=$(mktemp -d)
-  ( cd "$t" && git init --quiet && git config user.email test@test.local && git config user.name "Scaffold Test" && echo '{"name":"x"}' >package.json \
-    && "$SCAFFOLD_DIR/install.sh" --frontend --no-verify --coverage-gate ) >/dev/null 2>&1
-  printf '%s' "$t"
+  local __radapt_var=$1 t
+  fixture_repo t
+  echo '{"name":"x"}' >"$t/package.json"
+  fixture_install "$t" --frontend --no-verify --coverage-gate
+  printf -v "$__radapt_var" '%s' "$t"
 }
 
 # (T) cp_scaffold_preserve's --force path: a coverage.yml with a marked line
 # is overwritten (that's the point of --force), but now warns by name and
 # points at the backup, instead of a bare "backed up:"/"installed:" pair.
-F=$(_radapt_fixture)
+_radapt_fixture F
 sed -i.bak '1a\
       # Repo adaptation: gate frontend on vitest actually being declared
 ' "$F/.github/workflows/coverage.yml" && rm -f "$F/.github/workflows/coverage.yml.bak"
@@ -41,7 +42,7 @@ rm -rf "$F"
 # (T) cp_scaffold's unconditional-refresh path (.githooks/pre-commit): the
 # same warning fires even without --force, since cp_scaffold always
 # refreshes a drifted scaffold-owned file.
-P=$(_radapt_fixture)
+_radapt_fixture P
 sed -i.bak '2a\
 # Repo adaptation: local hook tweak
 ' "$P/.githooks/pre-commit" && rm -f "$P/.githooks/pre-commit.bak"
@@ -56,7 +57,7 @@ rm -rf "$P"
 
 # (T) no marker present: an ordinary drifted-file overwrite stays exactly as
 # before, no warning noise for the common case.
-N=$(_radapt_fixture)
+_radapt_fixture N
 printf '\n# ordinary local edit, no marker\n' >>"$N/.githooks/pre-commit"
 ( cd "$N" && "$SCAFFOLD_DIR/install.sh" --frontend --no-verify --coverage-gate ) >"$HOOK_OUT" 2>&1
 if ! grep -q "Repo adaptation" "$HOOK_OUT" && grep -q "backed up:    .githooks/pre-commit" "$HOOK_OUT"; then
@@ -74,7 +75,7 @@ rm -rf "$N"
 # `// Repo adaptation:` line in eslint.config.js, `install.sh --frontend --force`
 # warned by name about the first and overwrote the second in total silence; the
 # marker was afterwards found only in eslint.config.js.scaffold-bak.
-JS=$(_radapt_fixture)
+_radapt_fixture JS
 printf '\n// Repo adaptation: relaxed no-console for the vendored worker\n' >>"$JS/eslint.config.js"
 ( cd "$JS" && "$SCAFFOLD_DIR/install.sh" --frontend --no-verify --coverage-gate --force ) >"$HOOK_OUT" 2>&1
 if grep -q "warning: eslint.config.js carried 1 'Repo adaptation' line(s)" "$HOOK_OUT" \
@@ -91,7 +92,7 @@ rm -rf "$JS"
 # tsconfig.json / .prettierrc.json / the agent configs is a `//`-prefixed KEY,
 # which is valid JSON and must be matched by the same pattern. Inserted after
 # the opening brace, where the shipped tsconfig.json already carries `//` lines.
-JN=$(_radapt_fixture)
+_radapt_fixture JN
 awk 'NR == 1 { print; print "  \"// Repo adaptation: kept ES2019 for the vendored runtime\": true," ; next } { print }' \
   "$JN/tsconfig.json" >"$JN/tsconfig.next" && mv "$JN/tsconfig.next" "$JN/tsconfig.json"
 ( cd "$JN" && "$SCAFFOLD_DIR/install.sh" --frontend --no-verify --coverage-gate --force ) >"$HOOK_OUT" 2>&1
@@ -106,7 +107,7 @@ rm -rf "$JN"
 # (T) the broadened pattern still requires the marker to FOLLOW the comment
 # leader: a line that merely mentions it mid-sentence, and a URL's '//', stay
 # quiet. Without this the warning would fire on prose and stop meaning anything.
-JQ=$(_radapt_fixture)
+_radapt_fixture JQ
 printf '\n# notes: Repo adaptation: this one is recorded elsewhere\n' >>"$JQ/.githooks/pre-commit"
 printf '# see https://example.invalid/docs for the convention\n' >>"$JQ/.githooks/pre-commit"
 ( cd "$JQ" && "$SCAFFOLD_DIR/install.sh" --frontend --no-verify --coverage-gate ) >"$HOOK_OUT" 2>&1

--- a/tests/cases/27-test-guard.sh
+++ b/tests/cases/27-test-guard.sh
@@ -19,16 +19,22 @@
 
 echo "cases/27: --test-guard opt-in red-green gate (#140)"
 
+# The inner directory var is __tg_dir, not "t": _rg_fixture below also
+# declares `local t`, and calling `_tg_fixture t ...` from inside it would
+# otherwise let bash's dynamic scoping shadow the caller's `t` with this
+# function's own (see cases/18-doctor.sh's doc_project for the measured
+# reproduction of that failure mode).
 _tg_fixture() {
-  local t; t=$(mktemp -d)
-  ( cd "$t" && git init --quiet && git config user.email test@test.local && git config user.name "Scaffold Test" && echo '{"name":"x"}' >package.json \
-    && "$SCAFFOLD_DIR/install.sh" --frontend --no-verify "$@" ) >/dev/null 2>&1
-  printf '%s' "$t"
+  local __tg_var=$1 __tg_dir; shift
+  fixture_repo __tg_dir
+  echo '{"name":"x"}' >"$__tg_dir/package.json"
+  fixture_install "$__tg_dir" --frontend --no-verify "$@"
+  printf -v "$__tg_var" '%s' "$__tg_dir"
 }
 
 # (T) a default install (no flag) creates none of the four artifacts:
 # stays opt-in.
-D=$(_tg_fixture)
+_tg_fixture D
 if [ ! -e "$D/.githooks/lib/check-red-green" ] && [ ! -e "$D/.githooks/lib/check-mutation-diff" ] \
    && [ ! -e "$D/.github/workflows/test-guard.yml" ] \
    && ! grep -q 'ai-coding-rules-scaffold:test-guard:begin' "$D/coding-rules.md"; then
@@ -42,7 +48,7 @@ rm -rf "$D"
 # byte-identical to their shipped templates), the workflow (byte-identical),
 # and the rules section appended to coding-rules.md exactly once, with the
 # original coding-rules.md content still in place above it.
-T=$(_tg_fixture --test-guard)
+_tg_fixture T --test-guard
 if [ -x "$T/.githooks/lib/check-red-green" ] \
    && cmp -s "$SCAFFOLD_DIR/githooks/lib/check-red-green.template" "$T/.githooks/lib/check-red-green" \
    && [ -x "$T/.githooks/lib/check-mutation-diff" ] \
@@ -97,7 +103,7 @@ rm -rf "$T"
 
 # (T) uninstall.sh removes the unmodified checks and workflow, and leaves
 # coding-rules.md (user-owned) with the appended section intact.
-U=$(_tg_fixture --test-guard)
+_tg_fixture U --test-guard
 ( cd "$U" && "$SCAFFOLD_DIR/uninstall.sh" ) >"$HOOK_OUT" 2>&1
 if [ ! -e "$U/.githooks/lib/check-red-green" ] && [ ! -e "$U/.githooks/lib/check-mutation-diff" ] \
    && [ ! -e "$U/.github/workflows/test-guard.yml" ] \
@@ -130,7 +136,8 @@ else
   # Base commit: calc.add(), one existing test, and a pytest.ini registering the
   # characterization marker (the scaffold documents registering it there).
   _rg_fixture() {
-    local t; t=$(_tg_fixture --test-guard)
+    local __rg_var=$1 t
+    _tg_fixture t --test-guard
     (
       cd "$t" || exit 1
       git config user.email "test@test.local"
@@ -141,13 +148,13 @@ else
       printf 'import calc\n\n\ndef test_add_base():\n    assert calc.add(1, 1) == 2\n' >tests/test_base.py
       git add -A && git commit --quiet -m base --no-verify  # scaffold-allow: test fixture
     ) >/dev/null 2>&1
-    printf '%s' "$t"
+    printf -v "$__rg_var" '%s' "$t"
   }
 
   # (T) RED, the path a healthy PR takes: HEAD adds calc.mul() and a test for
   #     it. On base calc.mul does not exist, so the new test fails there and the
   #     gate passes, with the accounting line that proves it actually ran.
-  RG=$(_rg_fixture)
+  _rg_fixture RG
   (
     cd "$RG" || exit 1
     printf 'def add(a, b):\n    return a + b\n\n\ndef mul(a, b):\n    return a * b\n' >calc.py
@@ -180,7 +187,7 @@ else
   #     behaviour that already worked and changes no source. It passes against
   #     base, so it is not evidence for the change and must be REJECTED, naming
   #     the offending node ID.
-  GG=$(_rg_fixture)
+  _rg_fixture GG
   (
     cd "$GG" || exit 1
     printf 'import calc\n\n\ndef test_add_again():\n    assert calc.add(2, 2) == 4\n' >tests/test_green.py
@@ -200,7 +207,7 @@ else
   #     @pytest.mark.characterization(reason=...), is allowed and reported as
   #     exempt. Without this the previous case could be satisfied by a check that
   #     rejects every new test, which would make the gate unusable.
-  CG=$(_rg_fixture)
+  _rg_fixture CG
   (
     cd "$CG" || exit 1
     {
@@ -232,7 +239,7 @@ fi
 # characterization-marker contract that had vanished from the document the
 # agents read. The append is now gated on the gate being PRESENT, so the same
 # run that removes the section puts it back.
-TGF=$(_tg_fixture --test-guard)
+_tg_fixture TGF --test-guard
 ( cd "$TGF" && "$SCAFFOLD_DIR/install.sh" --frontend --no-verify --force ) >"$HOOK_OUT" 2>&1
 if [ "$(grep -c 'ai-coding-rules-scaffold:test-guard:begin' "$TGF/coding-rules.md")" -eq 1 ] \
    && grep -q 'characterization' "$TGF/coding-rules.md" \
@@ -247,7 +254,7 @@ rm -rf "$TGF"
 
 # (T) a plain re-run of a test-guard project (no flag, no --force) also restores
 # the section if it was removed by hand: presence, not the flag, is the gate.
-TGR=$(_tg_fixture --test-guard)
+_tg_fixture TGR --test-guard
 grep -v 'ai-coding-rules-scaffold:test-guard' "$TGR/coding-rules.md" >"$TGR/cr.tmp" && mv "$TGR/cr.tmp" "$TGR/coding-rules.md"
 ( cd "$TGR" && "$SCAFFOLD_DIR/install.sh" --frontend --no-verify ) >"$HOOK_OUT" 2>&1
 if [ "$(grep -c 'ai-coding-rules-scaffold:test-guard:begin' "$TGR/coding-rules.md")" -eq 1 ]; then
@@ -260,7 +267,7 @@ rm -rf "$TGR"
 # (T) the control: presence-gating must not turn the section on for a project
 # that never installed the gate. --force on a plain install leaves coding-rules.md
 # exactly as shipped, with no test-guard section.
-TGN=$(_tg_fixture)
+_tg_fixture TGN
 ( cd "$TGN" && "$SCAFFOLD_DIR/install.sh" --frontend --no-verify --force ) >"$HOOK_OUT" 2>&1
 if ! grep -q 'ai-coding-rules-scaffold:test-guard:begin' "$TGN/coding-rules.md" \
    && cmp -s "$SCAFFOLD_DIR/coding-rules.md" "$TGN/coding-rules.md"; then

--- a/tests/cases/28-check-patterns-scope.sh
+++ b/tests/cases/28-check-patterns-scope.sh
@@ -309,10 +309,9 @@ echo "uninstall.sh --drop-lang, the supported way to clear a #159 manifest entry
 # file and the entry TOGETHER — and these assert both halves of the bargain:
 # that the route works, and that NOTHING ELSE does it, which is the security
 # property the guard is made of.
-MFD=$(mktemp -d)
-( cd "$MFD" && git init --quiet && git config user.email test@test.local && git config user.name "Scaffold Test" \
-  && echo '{"name":"x"}' >package.json \
-  && "$SCAFFOLD_DIR/install.sh" --frontend --all-langs --no-verify ) >/dev/null 2>&1
+fixture_repo MFD
+echo '{"name":"x"}' >"$MFD/package.json"
+fixture_install "$MFD" --frontend --all-langs --no-verify
 ( cd "$MFD" && printf 'package main\n' >drop.go && git add drop.go ) >/dev/null 2>&1
 
 # _mfd_cp: run the installed check-patterns in $MFD over the one staged file,

--- a/tests/cases/30-install-manifest.sh
+++ b/tests/cases/30-install-manifest.sh
@@ -29,10 +29,11 @@ echo "cases/30: the install manifest refreshes untouched files on upgrade (audit
 
 # _mf_project: a fresh frontend repo with the scaffold installed from HEAD.
 _mf_project() {
-  local t; t=$(mktemp -d)
-  ( cd "$t" && git init --quiet && git config user.email test@test.local && git config user.name "Scaffold Test" && echo '{"name":"x"}' >package.json \
-    && "$SCAFFOLD_DIR/install.sh" --frontend --no-verify ) >/dev/null 2>&1
-  printf '%s' "$t"
+  local __mf_project_var=$1 t
+  fixture_repo t
+  echo '{"name":"x"}' >"$t/package.json"
+  fixture_install "$t" --frontend --no-verify
+  printf -v "$__mf_project_var" '%s' "$t"
 }
 
 # _mf_sha FILE: the same portable hash install-manifest.sh records, so these
@@ -62,7 +63,7 @@ MFNEXT=$(_mf_next_scaffold)
 # (T) a plain install writes the manifest, records the version, and records the
 #     files it wrote. This is enh-upgrade-1: before it, nothing on disk said
 #     which scaffold version a repo had.
-MF1=$(_mf_project)
+_mf_project MF1
 MFVER=$(awk -F'"' '/^[[:space:]]*"version"[[:space:]]*:/ { print $4; exit }' "$SCAFFOLD_DIR/package.json")
 if [ -f "$MF1/.githooks/.scaffold-manifest" ] \
    && grep -q " $MFVER .githooks/pre-commit\$" "$MF1/.githooks/.scaffold-manifest" \
@@ -138,7 +139,7 @@ rm -rf "$MF1"
 #     the manifest is telling the two apart, so this is the half that must not
 #     regress. The user's line survives, the shipped one does not arrive, and
 #     the note now says plainly that this is an edit.
-MF2=$(_mf_project)
+_mf_project MF2
 printf '\n(?-i)mf_my_own_rule_[0-9]{6}\ta rule this team added\n' >>"$MF2/.forbidden-patterns/secrets.txt"
 ( cd "$MF2" && "$MFNEXT/install.sh" --frontend --no-verify ) >"$HOOK_OUT" 2>&1
 if grep -q 'mf_my_own_rule_' "$MF2/.forbidden-patterns/secrets.txt" \
@@ -153,7 +154,7 @@ rm -rf "$MF2"
 
 # (T) --force still wins over the manifest: it backs the user's version up and
 #     installs the shipped one, unchanged from the documented escape hatch.
-MF3=$(_mf_project)
+_mf_project MF3
 printf '\n(?-i)mf_my_own_rule_[0-9]{6}\ta rule this team added\n' >>"$MF3/.forbidden-patterns/secrets.txt"
 ( cd "$MF3" && "$MFNEXT/install.sh" --frontend --no-verify --force ) >"$HOOK_OUT" 2>&1
 if grep -q 'mf_newdetector_' "$MF3/.forbidden-patterns/secrets.txt" \
@@ -168,7 +169,7 @@ rm -rf "$MF3"
 #     no entry, so it is kept exactly as before, but the message no longer
 #     claims it is the user's customization, because nothing on disk says that.
 #     This is the honest half of the pre-manifest upgrade path.
-MF4=$(_mf_project)
+_mf_project MF4
 printf '\n# an edit made before any manifest existed\n' >>"$MF4/.github/workflows/lint.yml"
 rm -f "$MF4/.githooks/.scaffold-manifest"
 ( cd "$MF4" && "$MFNEXT/install.sh" --frontend --no-verify ) >"$HOOK_OUT" 2>&1
@@ -186,7 +187,7 @@ rm -rf "$MF4"
 #     recording a drifted file would make the next run believe the scaffold
 #     produced those bytes and refresh straight over the user's edit. This is
 #     the assertion that stops the mechanism becoming a data-loss path.
-MF5=$(_mf_project)
+_mf_project MF5
 printf '\n# a local CI customization\n' >>"$MF5/.github/workflows/lint.yml"
 ( cd "$MF5" && "$SCAFFOLD_DIR/install.sh" --frontend --no-verify ) >"$HOOK_OUT" 2>&1
 MF5_REC=$(awk '$3 == ".github/workflows/lint.yml" { print $1 }' "$MF5/.githooks/.scaffold-manifest" 2>/dev/null || true)
@@ -207,7 +208,7 @@ rm -rf "$MF5"
 #     reverted to pre-manifest behavior on every later upgrade (audit verify-6).
 #     Trigger: something that is not a regular file at the manifest path, which
 #     no mode bit can make succeed, so this runs the same way for every user.
-MF6=$(_mf_project)
+_mf_project MF6
 rm -f "$MF6/.githooks/.scaffold-manifest"
 mkdir -p "$MF6/.githooks/.scaffold-manifest"
 MF6_RC=0
@@ -227,7 +228,7 @@ rm -rf "$MF6"
 #     .githooks, where the write itself fails rather than being refused up
 #     front. A mode bit means nothing to root, so the case asserts whichever
 #     outcome is honest for the user running it: the probe decides which.
-MF7=$(_mf_project)
+_mf_project MF7
 chmod 555 "$MF7/.githooks"
 MF7_RC=0
 # 2>/dev/null goes FIRST: redirections apply left to right, so with the probe
@@ -264,7 +265,7 @@ rm -rf "$MF7"
 #     it was reintroduced by the manifest itself (audit verify-7). Both halves
 #     are asserted, plus the positive outcome that the run still recorded the
 #     manifest it was cleaning up around.
-MF8=$(_mf_project)
+_mf_project MF8
 : >"$MF8/.githooks/.scaffold-manifest.new.999999"
 : >"$MF8/.githooks/.scaffold-manifest.tmp.999999"
 MF8_IGN=0
@@ -291,10 +292,10 @@ rm -rf "$MF8"
 #     reintroduced by the new file. The .gitignore block install.sh appends was
 #     never named or removed. Both are asserted here, together with the half
 #     that must not break: the project's own ignore rules survive.
-MF9=$(mktemp -d)
-( cd "$MF9" && git init --quiet && git config user.email test@test.local && git config user.name "Scaffold Test" && echo '{"name":"x"}' >package.json \
-  && printf 'node_modules/\n' >.gitignore \
-  && "$SCAFFOLD_DIR/install.sh" --frontend --no-verify ) >/dev/null 2>&1
+fixture_repo MF9
+echo '{"name":"x"}' >"$MF9/package.json"
+printf 'node_modules/\n' >"$MF9/.gitignore"
+fixture_install "$MF9" --frontend --no-verify
 ( cd "$MF9" && "$SCAFFOLD_DIR/uninstall.sh" --all ) >"$HOOK_OUT" 2>&1
 if [ ! -e "$MF9/.githooks" ] \
    && grep -q 'removed: *\.githooks/\.scaffold-manifest' "$HOOK_OUT" \

--- a/tests/cases/32-uninstall-report.sh
+++ b/tests/cases/32-uninstall-report.sh
@@ -16,11 +16,11 @@ echo "uninstall.sh reporting (dry run, leftovers):"
 # un_project, a fresh frontend install in a throwaway repo. --frontend keeps the
 # install fast and deterministic (no Python toolchain probing).
 un_project() {
-  local t
-  t=$(mktemp -d)
-  ( cd "$t" && git init --quiet && git config user.email test@test.local && git config user.name "Scaffold Test" && echo '{"name":"x"}' >package.json \
-    && "$SCAFFOLD_DIR/install.sh" --frontend --no-verify ) >/dev/null 2>&1
-  printf '%s' "$t"
+  local __un_project_var=$1 t
+  fixture_repo t
+  echo '{"name":"x"}' >"$t/package.json"
+  fixture_install "$t" --frontend --no-verify
+  printf -v "$__un_project_var" '%s' "$t"
 }
 
 # (A) --dry-run must not touch the filesystem. The empty-directory sweep at the
@@ -30,15 +30,15 @@ un_project() {
 # "no files changed". Both halves are asserted: the tree is identical afterwards
 # AND the run still names what it would remove, because a dry run that prints
 # nothing is equally "harmless" and equally useless.
-UDRY=$(un_project)
-UDRO=$(mktemp -d)
+un_project UDRY
+UDRY_LOG=$(mktemp -d)
 ( cd "$UDRY" && mkdir -p .claude .cursor \
-  && find . -path ./.git -prune -o -print | sort >"$UDRO/before.list" \
+  && find . -path ./.git -prune -o -print | sort >"$UDRY_LOG/before.list" \
   && "$SCAFFOLD_DIR/uninstall.sh" --dry-run \
-  && find . -path ./.git -prune -o -print | sort >"$UDRO/after.list" ) >"$HOOK_OUT" 2>&1
+  && find . -path ./.git -prune -o -print | sort >"$UDRY_LOG/after.list" ) >"$HOOK_OUT" 2>&1
 UDRY_HOOKS=$( cd "$UDRY" || exit 0
               git config --get core.hooksPath || true )
-if diff -q "$UDRO/before.list" "$UDRO/after.list" >/dev/null 2>&1 \
+if diff -q "$UDRY_LOG/before.list" "$UDRY_LOG/after.list" >/dev/null 2>&1 \
    && [ -d "$UDRY/.claude" ] && [ -d "$UDRY/.cursor" ] \
    && [ -f "$UDRY/.githooks/pre-commit" ] \
    && [ "$UDRY_HOOKS" = ".githooks" ] \
@@ -48,10 +48,10 @@ if diff -q "$UDRO/before.list" "$UDRO/after.list" >/dev/null 2>&1 \
   echo "  ✓ --dry-run deletes nothing and still names what it would remove"; PASS=$((PASS + 1))
 else
   echo "  ✗ --dry-run changed the tree (or stopped naming removals)"
-  diff "$UDRO/before.list" "$UDRO/after.list" | sed 's/^/      /' || true
+  diff "$UDRY_LOG/before.list" "$UDRY_LOG/after.list" | sed 's/^/      /' || true
   sed 's/^/      /' "$HOOK_OUT"; FAIL=$((FAIL + 1))
 fi
-rm -rf "$UDRY" "$UDRO"
+rm -rf "$UDRY" "$UDRY_LOG"
 
 # (B) ...and the dry run must be TRUTHFUL, not merely inert: the directories it
 # says it would clear are exactly the ones a real run does clear. Nothing is
@@ -59,21 +59,21 @@ rm -rf "$UDRY" "$UDRO"
 # .githooks/lib is empty (it still holds every file); it has to replay the
 # removals it just reported. A fix that only skipped rmdir would print an empty
 # list here and still pass (A).
-UDT=$(un_project)
-UDTO=$(mktemp -d)
-( cd "$UDT" && "$SCAFFOLD_DIR/uninstall.sh" --dry-run ) >"$UDTO/dry.txt" 2>&1
-( cd "$UDT" && "$SCAFFOLD_DIR/uninstall.sh" ) >"$UDTO/real.txt" 2>&1
-sed -n 's/^would remove empty: //p' "$UDTO/dry.txt"  | sort >"$UDTO/dry.dirs"
-sed -n 's/^removed empty: //p'      "$UDTO/real.txt" | sort >"$UDTO/real.dirs"
-if [ -s "$UDTO/dry.dirs" ] && grep -qx '.githooks/lib' "$UDTO/dry.dirs" \
-   && diff -q "$UDTO/dry.dirs" "$UDTO/real.dirs" >/dev/null 2>&1; then
+un_project UDT
+UDT_LOG=$(mktemp -d)
+( cd "$UDT" && "$SCAFFOLD_DIR/uninstall.sh" --dry-run ) >"$UDT_LOG/dry.txt" 2>&1
+( cd "$UDT" && "$SCAFFOLD_DIR/uninstall.sh" ) >"$UDT_LOG/real.txt" 2>&1
+sed -n 's/^would remove empty: //p' "$UDT_LOG/dry.txt"  | sort >"$UDT_LOG/dry.dirs"
+sed -n 's/^removed empty: //p'      "$UDT_LOG/real.txt" | sort >"$UDT_LOG/real.dirs"
+if [ -s "$UDT_LOG/dry.dirs" ] && grep -qx '.githooks/lib' "$UDT_LOG/dry.dirs" \
+   && diff -q "$UDT_LOG/dry.dirs" "$UDT_LOG/real.dirs" >/dev/null 2>&1; then
   echo "  ✓ --dry-run reports the same empty dirs a real run removes"; PASS=$((PASS + 1))
 else
   echo "  ✗ dry-run empty-dir report does not match the real run"
-  diff "$UDTO/dry.dirs" "$UDTO/real.dirs" | sed 's/^/      /' || true
+  diff "$UDT_LOG/dry.dirs" "$UDT_LOG/real.dirs" | sed 's/^/      /' || true
   FAIL=$((FAIL + 1))
 fi
-rm -rf "$UDT" "$UDTO"
+rm -rf "$UDT" "$UDT_LOG"
 
 # (C) --help printed its usage header through a hardcoded sed line range that
 # was one line short, so the last line of the header, the --help flag itself,
@@ -101,7 +101,7 @@ rm -rf "$UHLP"
 # header, so the run ended with "Done." over a project that still had six
 # scaffold files in it and no way to know. Assert every kept path is named, and
 # that the line names the flag that finishes the job.
-ULFT=$(un_project)
+un_project ULFT
 ( cd "$ULFT" && "$SCAFFOLD_DIR/uninstall.sh" ) >"$HOOK_OUT" 2>&1
 if grep -qF "kept (likely customized):" "$HOOK_OUT" \
    && grep -qF "AGENTS.md" "$HOOK_OUT" \
@@ -121,9 +121,9 @@ rm -rf "$ULFT"
 # edits, so uninstall must not delete them. It must still say they are there:
 # they are scaffold-created files with a scaffold-shaped name, and a user who
 # does not know they exist never merges anything back out of them.
-UBAK=$(un_project)
-( cd "$UBAK" && printf '# local edit\n' >>.githooks/pre-commit \
-  && "$SCAFFOLD_DIR/install.sh" --frontend --force --no-verify ) >/dev/null 2>&1
+un_project UBAK
+printf '# local edit\n' >>"$UBAK/.githooks/pre-commit"
+fixture_install "$UBAK" --frontend --force --no-verify
 ( cd "$UBAK" && "$SCAFFOLD_DIR/uninstall.sh" ) >"$HOOK_OUT" 2>&1
 if [ -f "$UBAK/.githooks/pre-commit.scaffold-bak" ] \
    && grep -qF "local edit" "$UBAK/.githooks/pre-commit.scaffold-bak" \
@@ -139,7 +139,7 @@ rm -rf "$UBAK"
 # (F) --all really does remove the kept set, so the closing line is not advice
 # that goes nowhere. The kept block must NOT claim a file is still there when
 # the run just deleted it.
-UALL=$(un_project)
+un_project UALL
 ( cd "$UALL" && "$SCAFFOLD_DIR/uninstall.sh" --all ) >"$HOOK_OUT" 2>&1
 if [ ! -e "$UALL/AGENTS.md" ] && [ ! -e "$UALL/coding-rules.md" ] \
    && [ ! -e "$UALL/.forbidden-patterns" ] \

--- a/tests/cases/37-doctor-content-drift.sh
+++ b/tests/cases/37-doctor-content-drift.sh
@@ -37,12 +37,11 @@ echo "cases/37: scaffold-doctor's content-drift checks (shipped rules, .gitignor
 # the hook chase a JS toolchain and go red on one runner only, and that failure
 # then gets misread as a verdict on whatever was actually under test.
 docd_project() {
-  local t
-  t=$(mktemp -d)
-  ( cd "$t" && git init --quiet && git config user.email test@test.local && git config user.name "Scaffold Test" \
-    && echo '#!/usr/bin/env bash' >run.sh \
-    && "$SCAFFOLD_DIR/install.sh" --shell --no-verify ) >/dev/null 2>&1
-  printf '%s' "$t"
+  local __docd_var=$1 t
+  fixture_repo t
+  echo '#!/usr/bin/env bash' >"$t/run.sh"
+  fixture_install "$t" --shell --no-verify
+  printf -v "$__docd_var" '%s' "$t"
 }
 
 # (A) SHIPPED-RULE DRIFT. Counting active patterns only catches the file gutted
@@ -58,7 +57,7 @@ docd_trim_secrets() {
   grep -vE '^[[:space:]]*(#|$)' .forbidden-patterns/secrets.txt | head -1 >secrets.tmp \
     && mv secrets.tmp .forbidden-patterns/secrets.txt
 }
-DOCD=$(docd_project)
+docd_project DOCD
 ( cd "$DOCD" && docd_trim_secrets ) >/dev/null 2>&1
 docd_rc=0
 ( cd "$DOCD" && "$SCAFFOLD_DIR/scaffold-doctor.sh" ) >"$HOOK_OUT" 2>&1 || docd_rc=$?
@@ -91,7 +90,7 @@ docd_extend_patterns() {
   printf '# a house rule of our own\n' >>.forbidden-patterns/shell.txt
   printf 'acme_deploy_prod\tno prod deploys from a shell script\n' >>.forbidden-patterns/shell.txt
 }
-DOCD=$(docd_project)
+docd_project DOCD
 ( cd "$DOCD" && docd_extend_patterns ) >/dev/null 2>&1
 docd_rc=0
 ( cd "$DOCD" && "$SCAFFOLD_DIR/scaffold-doctor.sh" ) >"$HOOK_OUT" 2>&1 || docd_rc=$?
@@ -153,7 +152,7 @@ docd_ignore_build_output() {
   printf 'node_modules/\ndist/\nbuild/\ncoverage/\n*.min.js\nvendor/\n*.d.ts\n.next/\nout/\n' >>.gitignore
 }
 
-DOCD=$(docd_project)
+docd_project DOCD
 ( cd "$DOCD" && docd_ignore_source ) >/dev/null 2>&1
 docd_rc=0
 ( cd "$DOCD" && "$SCAFFOLD_DIR/scaffold-doctor.sh" ) >"$HOOK_OUT" 2>&1 || docd_rc=$?
@@ -180,7 +179,7 @@ rm -rf "$DOCD"
 # hole above is open again with a green report over it. The armed line is
 # asserted too: without it, a check that had stopped running entirely would sail
 # through this case on exit 0 alone.
-DOCD=$(docd_project)
+docd_project DOCD
 ( cd "$DOCD" && docd_ignore_build_output ) >/dev/null 2>&1
 docd_rc=0
 ( cd "$DOCD" && "$SCAFFOLD_DIR/scaffold-doctor.sh" ) >"$HOOK_OUT" 2>&1 || docd_rc=$?
@@ -217,7 +216,7 @@ docd_remove_coding_rules_heading() {
 # no "predates" note anywhere, and the exit code is unchanged from a clean
 # install's baseline (cases/18's case A) — a note-worthy doctor must not also
 # add a gap where install.sh already did the right thing.
-DOCD=$(docd_project)
+docd_project DOCD
 docd_rc=0
 ( cd "$DOCD" && "$SCAFFOLD_DIR/scaffold-doctor.sh" ) >"$HOOK_OUT" 2>&1 || docd_rc=$?
 if [ "$docd_rc" -eq 0 ] \
@@ -236,7 +235,7 @@ rm -rf "$DOCD"
 # Deleting ONE section heading from the installed AGENTS.md: named in a note,
 # exit stays 0 (a note is not a gap), and coding-rules.md's own ok line is
 # unaffected by a file it does not share a check with.
-DOCD=$(docd_project)
+docd_project DOCD
 ( cd "$DOCD" && docd_remove_agents_heading ) >/dev/null 2>&1
 docd_rc=0
 ( cd "$DOCD" && "$SCAFFOLD_DIR/scaffold-doctor.sh" ) >"$HOOK_OUT" 2>&1 || docd_rc=$?
@@ -254,7 +253,7 @@ rm -rf "$DOCD"
 
 # ...and the same shape, the other direction: coding-rules.md missing a
 # heading must not touch AGENTS.md's report.
-DOCD=$(docd_project)
+docd_project DOCD
 ( cd "$DOCD" && docd_remove_coding_rules_heading ) >/dev/null 2>&1
 docd_rc=0
 ( cd "$DOCD" && "$SCAFFOLD_DIR/scaffold-doctor.sh" ) >"$HOOK_OUT" 2>&1 || docd_rc=$?
@@ -279,7 +278,7 @@ rm -rf "$DOCD"
 DRIFTLESS=$(mktemp -d)
 cp "$SCAFFOLD_DIR/scaffold-doctor.sh" "$DRIFTLESS/scaffold-doctor.sh"
 chmod +x "$DRIFTLESS/scaffold-doctor.sh"
-DOCD=$(docd_project)
+docd_project DOCD
 docd_rc=0
 ( cd "$DOCD" && "$DRIFTLESS/scaffold-doctor.sh" ) >"$HOOK_OUT" 2>&1 || docd_rc=$?
 if [ "$docd_rc" -eq 0 ] \

--- a/tests/cases/40-doctor-required-checks.sh
+++ b/tests/cases/40-doctor-required-checks.sh
@@ -15,15 +15,15 @@
 echo "cases/40: scaffold-doctor reports what it could not measure about required status checks"
 
 _rc_fixture() {
-  local t; t=$(mktemp -d)
-  ( cd "$t" && git init -q && git config user.email t@test.local && git config user.name "Scaffold Test" \
-      && "$SCAFFOLD_DIR/install.sh" --shell --no-verify ) >/dev/null 2>&1
-  printf '%s' "$t"
+  local __rc_fixture_var=$1 t
+  fixture_repo t
+  fixture_install "$t" --shell --no-verify
+  printf -v "$__rc_fixture_var" '%s' "$t"
 }
 
 # 1. No GitHub remote: a local-only repo, the common case in this suite.
-_rc_repo=$(_rc_fixture)
-( cd "$_rc_repo" && "$SCAFFOLD_DIR/scaffold-doctor.sh" ) >"$HOOK_OUT" 2>&1 || true
+_rc_fixture _RC_REPO
+( cd "$_RC_REPO" && "$SCAFFOLD_DIR/scaffold-doctor.sh" ) >"$HOOK_OUT" 2>&1 || true
 if grep -q 'required status checks: not checked (remote.origin is not a github.com URL)' "$HOOK_OUT"; then
   echo "  ✓ no GitHub remote: reported as not checked, with the reason"
   PASS=$((PASS + 1))
@@ -34,13 +34,13 @@ fi
 
 # 2. GitHub remote but no gh on PATH: a PATH with only the directories the
 # doctor's other checks need, minus wherever gh lives.
-( cd "$_rc_repo" && git remote add origin git@github.com:example/project.git )
+( cd "$_RC_REPO" && git remote add origin git@github.com:example/project.git )
 _rc_nogh=$(mktemp -d)
 for _rc_tool in bash git grep sed awk sort uniq cut tr wc head tail mktemp basename dirname cat cmp find xargs jq python3 ls test; do
   _rc_path=$(command -v "$_rc_tool" 2>/dev/null || true)
   [ -n "$_rc_path" ] && ln -s "$_rc_path" "$_rc_nogh/$_rc_tool" 2>/dev/null
 done
-( cd "$_rc_repo" && PATH="$_rc_nogh" "$SCAFFOLD_DIR/scaffold-doctor.sh" ) >"$HOOK_OUT" 2>&1 || true
+( cd "$_RC_REPO" && PATH="$_rc_nogh" "$SCAFFOLD_DIR/scaffold-doctor.sh" ) >"$HOOK_OUT" 2>&1 || true
 if grep -q 'required status checks: not checked (gh CLI not installed' "$HOOK_OUT"; then
   echo "  ✓ GitHub remote, no gh: reported as not checked, names the missing tool"
   PASS=$((PASS + 1))
@@ -55,7 +55,7 @@ cat > "$_rc_nogh/gh" <<'GH'
 exit 1
 GH
 chmod +x "$_rc_nogh/gh"
-( cd "$_rc_repo" && PATH="$_rc_nogh" "$SCAFFOLD_DIR/scaffold-doctor.sh" ) >"$HOOK_OUT" 2>&1 || true
+( cd "$_RC_REPO" && PATH="$_rc_nogh" "$SCAFFOLD_DIR/scaffold-doctor.sh" ) >"$HOOK_OUT" 2>&1 || true
 if grep -q 'required status checks: not checked (gh is not logged in' "$HOOK_OUT"; then
   echo "  ✓ gh present, not logged in: reported as not checked, says how to fix"
   PASS=$((PASS + 1))
@@ -85,7 +85,7 @@ _rc_stub() {
   chmod +x "$_rc_nogh/gh"
 }
 _rc_stub 0 0
-_rc_rc=0; ( cd "$_rc_repo" && PATH="$_rc_nogh" "$SCAFFOLD_DIR/scaffold-doctor.sh" ) >"$HOOK_OUT" 2>&1 || _rc_rc=$?
+_rc_rc=0; ( cd "$_RC_REPO" && PATH="$_rc_nogh" "$SCAFFOLD_DIR/scaffold-doctor.sh" ) >"$HOOK_OUT" 2>&1 || _rc_rc=$?
 if [ "$_rc_rc" -eq 1 ] && grep -q "requires NO status checks" "$HOOK_OUT" && grep -q 'fix: import .github/rulesets/main-protection.json' "$HOOK_OUT"; then
   echo "  ✓ measured zero required checks: a gap with the fix named, exit 1"
   PASS=$((PASS + 1))
@@ -94,7 +94,7 @@ else
   FAIL=$((FAIL + 1))
 fi
 _rc_stub 6 0
-( cd "$_rc_repo" && PATH="$_rc_nogh" "$SCAFFOLD_DIR/scaffold-doctor.sh" ) >"$HOOK_OUT" 2>&1 || true
+( cd "$_RC_REPO" && PATH="$_rc_nogh" "$SCAFFOLD_DIR/scaffold-doctor.sh" ) >"$HOOK_OUT" 2>&1 || true
 if grep -q '✓ main requires status checks before merge (6 via branch protection, 0 ruleset rule(s))' "$HOOK_OUT"; then
   echo "  ✓ measured six required checks: reported armed with the counts"
   PASS=$((PASS + 1))
@@ -103,6 +103,6 @@ else
   FAIL=$((FAIL + 1))
 fi
 
-rm -rf "$_rc_repo" "$_rc_nogh"
-unset _rc_repo _rc_nogh _rc_tool _rc_path _rc_rc
+rm -rf "$_RC_REPO" "$_rc_nogh"
+unset _RC_REPO _rc_nogh _rc_tool _rc_path _rc_rc
 unset -f _rc_fixture _rc_stub

--- a/tests/lib/common.sh
+++ b/tests/lib/common.sh
@@ -54,6 +54,81 @@ assert_passes() {
   reset_repo
 }
 
+# --- fixture-project helpers ------------------------------------------------
+# Case files build their own throwaway projects, install the scaffold into
+# them, and assert against the result. Until now that install ran inside
+# "( cd "$t" && ... && install.sh ... ) >/dev/null 2>&1", with the whole
+# thing called as "T=$(some_helper)": bash disables errexit inside a "$(...)"
+# command substitution unless "shopt -s inherit_errexit" is set (this suite
+# doesn't set it), so a failing install.sh inside that subshell did not stop
+# anything — the helper still reached its final "printf '%s' "$t"" and handed
+# the caller a path, exit 0, with the installer's own stderr thrown away by
+# ">/dev/null 2>&1". Whatever the case ran next then failed on a fixture that
+# was never actually built, for a reason nobody could see.
+#
+# Measured: CI run 33922341907 (ubuntu) died in cases/37-doctor-content-drift.sh
+# with exit 2 and no failing assertion printed, 0.22s after the case's own
+# banner. docd_project's install.sh failed silently exactly as above; the next
+# unprotected line ran `grep` over a file the failed install never wrote, grep
+# exited 2 for the missing file, pipefail carried that 2 out, and run.sh's own
+# `set -euo pipefail` (line 17) killed the whole suite with nothing to say why.
+#
+# fixture_repo and fixture_install replace that pattern. Both are meant to be
+# called as bare statements, never wrapped in "$(...)": that is what lets a
+# real failure trip the driver's own set -e instead of being absorbed by the
+# command-substitution boundary above.
+
+# fixture_repo VAR — creates a throwaway git repo (mktemp -d, git init, the
+# fixture test identity used by every case) and assigns its path to the
+# variable named VAR via `printf -v`, so callers write `fixture_repo T` instead
+# of `T=$(fixture_repo)`. Runs directly in the caller's shell, not inside a
+# "( ... )" subshell and not inside "$(...)": a failed git-init here is a bare
+# statement under the driver's `set -e`, so it stops the run loudly with git's
+# own error on stderr instead of silently handing back an empty or half-built
+# path.
+fixture_repo() {
+  local __fixture_repo_var=$1 __fixture_repo_dir
+  __fixture_repo_dir=$(mktemp -d)
+  git -C "$__fixture_repo_dir" init --quiet
+  git -C "$__fixture_repo_dir" config user.email "test@test.local"
+  git -C "$__fixture_repo_dir" config user.name "Scaffold Test"
+  printf -v "$__fixture_repo_var" '%s' "$__fixture_repo_dir"
+}
+
+# fixture_install DIR ARGS... — runs "$SCAFFOLD_DIR/install.sh" ARGS... inside
+# DIR. Combined stdout+stderr is captured to a log file OUTSIDE the fixture
+# (its own mktemp file, not something written under DIR), so a failed install
+# never leaves a stray log for a case's content checks to trip over.
+#
+# On a non-zero exit: print the failing command and its exit code, then the
+# last 30 lines of the captured log, to stderr, and `exit 1` — ending the
+# whole suite, on purpose, the same way any other unguarded failing command
+# under run.sh's `set -e` would. A case that deliberately expects install.sh
+# to FAIL (a refusal test) must not call this helper for that install; run it
+# directly and assert on it instead.
+#
+# On success: delete the log and return 0.
+fixture_install() {
+  local dir=$1
+  shift
+  local log rc=0
+  log=$(mktemp)
+  # `rc=$?` must be captured via `|| rc=$?` on the command itself, not read
+  # back inside an `if ! ( ... ); then` body: `$?` at that point belongs to
+  # the negated `if` test (always 0 once the then-branch is entered), not to
+  # install.sh. Measured while writing this: the naive `if !` form reported
+  # "FIXTURE INSTALL FAILED (exit 0)" for a real non-zero install.sh failure.
+  ( cd "$dir" && "$SCAFFOLD_DIR/install.sh" "$@" ) >"$log" 2>&1 || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "FIXTURE INSTALL FAILED (exit $rc): install.sh $* in $dir" >&2
+    tail -n 30 "$log" >&2
+    rm -f "$log"
+    exit 1
+  fi
+  rm -f "$log"
+  return 0
+}
+
 # --- bootstrap a temp project + install the scaffold ----------------------
 # set -euo pipefail is inherited from the driver (run.sh), so a failed cd aborts
 # the whole run — same guarantee the original single-file harness had.

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -89,7 +89,7 @@ CASE_FLOORS=(
   "15-local-checks.sh:7"
   "16-coverage-gate.sh:6"
   "17-whole-tree-configs.sh:11"
-  "18-doctor.sh:35"
+  "18-doctor.sh:36"
   "19-test-workflow.sh:17"
   "20-paired-artifacts.sh:19"
   "21-ci-workflow-drift.sh:25"


### PR DESCRIPTION
## Why

CI on main at dc4cc7d (tests run 33922341907, Ubuntu) died in `tests/cases/37-doctor-content-drift.sh` with `Process completed with exit code 2`, no failing assertion, 0.22 s after the case banner. The same content passed on macOS and on both PR runs (#186, #188).

The suite hid the cause. Fixture helpers ran `( cd "$t" && git init ... && install.sh ... ) >/dev/null 2>&1` inside a `$(...)` command substitution, where bash disables `set -e`. A failed install therefore returned a half-built fixture with the installer's output discarded. The next unprotected `grep` in the case hit a file the install never wrote, exited 2 for the missing file, and `set -euo pipefail` in run.sh ended the suite with nothing printed. 40 local runs of the exact fixture passed, so the underlying installer failure on that runner is still unknown. What this PR fixes is the silence, so the next occurrence names its cause.

## What changed

- `tests/lib/common.sh` gains `fixture_repo VAR` and `fixture_install DIR ARGS...`. Both run as bare statements in the caller's shell. A failed install prints `FIXTURE INSTALL FAILED (exit N): install.sh ARGS in DIR` plus the last 30 lines of the captured installer output to stderr, then exits 1.
- 19 fixture sites across 15 case files converted from `X=$(helper)` to `helper X`. Sites that deliberately expect the installer to fail, already capture its output, or run as bare statements under `set -e` were left as they are and are listed in the commit messages.
- One new assertion in cases/18 proves the loud path: `fixture_install` with a bogus flag exits 1 and prints the marker. Floor bumped accordingly.
- Two bugs caught while converting, both fixed before commit: a callee `local t` shadowing the caller's `t` under bash dynamic scoping, and `rc=$?` read inside `if ! (...)`, which reports the negation rather than the command.

## Measurements

| Check | Result |
|---|---|
| `bash tests/run.sh` | 620 passed, 0 failed (main: 619) |
| shellcheck on tests/ | 0 findings before and after |
| Manual loud path | `FIXTURE INSTALL FAILED (exit 1): install.sh --no-such-flag in ...`, exit 1 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
